### PR TITLE
Refactor/introduce mapper

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/api/domain/model/Student.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/domain/model/Student.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class Student {
-  @Setter(AccessLevel.NONE)
   private final User user;
 
   private String bio;
@@ -23,13 +22,18 @@ public class Student {
     return new Student(user);
   }
 
-  public static Student toDomain(
-      User user, String bio, byte[] profilePicture, byte[] coverPicture) {
+  public static Student of(User user, String bio, byte[] profilePicture, byte[] coverPicture) {
     var student = new Student(user);
     student.setBio(bio);
     student.setProfilePicture(profilePicture);
     student.setCoverPicture(coverPicture);
+
     return student;
+  }
+
+  public static Student toDomain(
+      User user, String bio, byte[] profilePicture, byte[] coverPicture) {
+    return of(user,bio,profilePicture,coverPicture);
   }
 
   public UUID getId() {

--- a/src/main/java/fr/avenirsesr/portfolio/api/domain/model/Teacher.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/domain/model/Teacher.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class Teacher {
-  @Setter(AccessLevel.NONE)
   private final User user;
 
   private String bio;
@@ -23,13 +22,18 @@ public class Teacher {
     return new Teacher(user);
   }
 
-  public static Teacher toDomain(
-      User user, String bio, byte[] profilePicture, byte[] coverPicture) {
+  public static Teacher of(User user, String bio, byte[] profilePicture, byte[] coverPicture) {
     var teacher = new Teacher(user);
     teacher.setBio(bio);
     teacher.setProfilePicture(profilePicture);
     teacher.setCoverPicture(coverPicture);
+
     return teacher;
+  }
+
+  public static Teacher toDomain(
+      User user, String bio, byte[] profilePicture, byte[] coverPicture) {
+    return of(user,bio,profilePicture,coverPicture);
   }
 
   public UUID getId() {

--- a/src/main/java/fr/avenirsesr/portfolio/api/domain/model/User.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/domain/model/User.java
@@ -8,14 +8,34 @@ import lombok.Setter;
 @Getter
 @Setter
 public class User {
-  @Setter(AccessLevel.NONE)
   private final UUID id;
-
   private String firstName;
   private String lastName;
   private String email;
-  private Student student;
-  private Teacher teacher;
+  private boolean isStudent;
+  private boolean isTeacher;
+
+  // -- Student --
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.PRIVATE)
+  private String studentBio;
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.PRIVATE)
+  private byte[] studentProfilePicture;
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.PRIVATE)
+  private byte[] studentCoverPicture;
+
+  // -- Teacher --
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.PRIVATE)
+  private String teacherBio;
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.PRIVATE)
+  private byte[] teacherProfilePicture;
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.PRIVATE)
+  private byte[] teacherCoverPicture;
 
   private User(UUID id) {
     this.id = id;
@@ -29,14 +49,32 @@ public class User {
     return user;
   }
 
+  public Student toStudent() {
+    return Student.of(this, studentBio, studentProfilePicture, studentCoverPicture);
+  }
+
+  public Teacher toTeacher() {
+    return Teacher.of(this, teacherBio, teacherProfilePicture, teacherCoverPicture);
+  }
+
   public static User toDomain(
-      UUID id, String firstName, String lastName, String email, Student student, Teacher teacher) {
+      UUID id,
+      String firstName,
+      String lastName,
+      String email,
+      String studentBio, byte[] studentProfilePicture, byte[] studentCoverPicture,
+      String teacherBio, byte[]teacherProfilePicture, byte[] teacherCoverPicture
+  ) {
     var user = new User(id);
     user.setFirstName(firstName);
     user.setLastName(lastName);
     user.setEmail(email);
-    user.setStudent(student);
-    user.setTeacher(teacher);
+    user.setStudentBio(studentBio);
+    user.setStudentProfilePicture(studentProfilePicture);
+    user.setStudentCoverPicture(studentCoverPicture);
+    user.setTeacherBio(teacherBio);
+    user.setTeacherProfilePicture(teacherProfilePicture);
+    user.setTeacherCoverPicture(teacherCoverPicture);
 
     return user;
   }

--- a/src/main/java/fr/avenirsesr/portfolio/api/domain/port/output/repository/GenericRepositoryPort.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/domain/port/output/repository/GenericRepositoryPort.java
@@ -1,8 +1,12 @@
 package fr.avenirsesr.portfolio.api.domain.port.output.repository;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface GenericRepositoryPort<D> {
+  Optional<D> findById(UUID id);
+
   void save(D domain);
 
   void saveAll(List<D> collection);

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/AMSMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/AMSMapper.java
@@ -1,0 +1,20 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.AMS;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.AMSEntity;
+
+public interface AMSMapper {
+  static AMSEntity fromDomain(AMS ams) {
+    return new AMSEntity(
+        ams.getId(),
+        UserMapper.fromDomain(ams.getUser()),
+        ams.getSkillLevels().stream().map(SkillLevelMapper::fromDomain).toList());
+  }
+
+  static AMS toDomain(AMSEntity entity) {
+    return AMS.toDomain(
+        entity.getId(),
+        UserMapper.toDomain(entity.getUser()),
+        entity.getSkillLevels().stream().map(SkillLevelMapper::toDomain).toList());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/ExternalUserMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/ExternalUserMapper.java
@@ -1,0 +1,28 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.ExternalUser;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.ExternalUserEntity;
+
+public interface ExternalUserMapper {
+  static ExternalUserEntity fromDomain(ExternalUser externalUser) {
+    return new ExternalUserEntity(
+        externalUser.getExternalId(),
+        externalUser.getSource(),
+        UserMapper.fromDomain(externalUser.getUser()),
+        externalUser.getCategory(),
+        externalUser.getEmail(),
+        externalUser.getFirstName(),
+        externalUser.getLastName());
+  }
+
+  static ExternalUser toDomain(ExternalUserEntity externalUserEntity) {
+    return ExternalUser.create(
+        UserMapper.toDomain(externalUserEntity.getUser()),
+        externalUserEntity.getExternalId(),
+        externalUserEntity.getSource(),
+        externalUserEntity.getCategory(),
+        externalUserEntity.getEmail(),
+        externalUserEntity.getFirstName(),
+        externalUserEntity.getLastName());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/InstitutionMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/InstitutionMapper.java
@@ -1,0 +1,18 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.Institution;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.InstitutionEntity;
+
+public interface InstitutionMapper {
+  static InstitutionEntity fromDomain(Institution institution) {
+    return new InstitutionEntity(
+        institution.getId(), institution.getName(), institution.getEnabledFields());
+  }
+
+  static Institution toDomain(InstitutionEntity institutionEntity) {
+    return Institution.toDomain(
+        institutionEntity.getId(),
+        institutionEntity.getName(),
+        institutionEntity.getEnabledFields());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/ProgramMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/ProgramMapper.java
@@ -1,0 +1,18 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.Program;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.ProgramEntity;
+
+public interface ProgramMapper {
+  static ProgramEntity fromDomain(Program program) {
+    return new ProgramEntity(
+        program.getId(), program.getName(), InstitutionMapper.fromDomain(program.getInstitution()));
+  }
+
+  static Program toDomain(ProgramEntity programEntity) {
+    return Program.toDomain(
+        programEntity.getId(),
+        InstitutionMapper.toDomain(programEntity.getInstitution()),
+        programEntity.getName());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/ProgramProgressMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/ProgramProgressMapper.java
@@ -1,0 +1,28 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.ProgramProgress;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.ProgramProgressEntity;
+import java.util.stream.Collectors;
+
+public interface ProgramProgressMapper {
+  static ProgramProgressEntity fromDomain(ProgramProgress programProgress) {
+    return new ProgramProgressEntity(
+        programProgress.getId(),
+        ProgramMapper.fromDomain(programProgress.getProgram()),
+        UserMapper.fromDomain(programProgress.getStudent().getUser()),
+        programProgress.getSkills().stream()
+            .map(SkillMapper::fromDomain)
+            .collect(Collectors.toSet()));
+  }
+
+  static ProgramProgress toDomain(ProgramProgressEntity programProgressEntity) {
+    return ProgramProgress.toDomain(
+        programProgressEntity.getId(),
+        ProgramMapper.toDomain(programProgressEntity.getProgram()),
+        StudentMapper.toDomain(
+            programProgressEntity.getStudent().getStudent(), programProgressEntity.getStudent()),
+        programProgressEntity.getSkills().stream()
+            .map(SkillMapper::toDomain)
+            .collect(Collectors.toSet()));
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/SkillLevelMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/SkillLevelMapper.java
@@ -1,0 +1,24 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.SkillLevel;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.SkillLevelEntity;
+
+public interface SkillLevelMapper {
+  static SkillLevelEntity fromDomain(SkillLevel skillLevel) {
+    return new SkillLevelEntity(
+        skillLevel.getId(),
+        skillLevel.getName(),
+        skillLevel.getStatus(),
+        skillLevel.getTracks().stream().map(TrackMapper::fromDomain).toList(),
+        skillLevel.getAmses().stream().map(AMSMapper::fromDomain).toList());
+  }
+
+  static SkillLevel toDomain(SkillLevelEntity skillLevelEntity) {
+    return SkillLevel.toDomain(
+        skillLevelEntity.getId(),
+        skillLevelEntity.getName(),
+        skillLevelEntity.getStatus(),
+        skillLevelEntity.getTracks().stream().map(TrackMapper::toDomain).toList(),
+        skillLevelEntity.getAmses().stream().map(AMSMapper::toDomain).toList());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/SkillMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/SkillMapper.java
@@ -1,0 +1,25 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.Skill;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.SkillEntity;
+import java.util.stream.Collectors;
+
+public interface SkillMapper {
+  static SkillEntity fromDomain(Skill skill) {
+    return new SkillEntity(
+        skill.getId(),
+        skill.getName(),
+        skill.getSkillLevels().stream()
+            .map(SkillLevelMapper::fromDomain)
+            .collect(Collectors.toSet()));
+  }
+
+  static Skill toDomain(SkillEntity skillEntity) {
+    return Skill.toDomain(
+        skillEntity.getId(),
+        skillEntity.getName(),
+        skillEntity.getSkillLevels().stream()
+            .map(SkillLevelMapper::toDomain)
+            .collect(Collectors.toSet()));
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/StudentMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/StudentMapper.java
@@ -1,0 +1,20 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.Student;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.StudentEntity;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.UserEntity;
+
+public interface StudentMapper {
+  static StudentEntity fromDomain(Student student) {
+    return new StudentEntity(
+        student.getBio(), student.getProfilePicture(), student.getCoverPicture());
+  }
+
+  static Student toDomain(StudentEntity studentEntity, UserEntity userEntity) {
+    return Student.toDomain(
+        UserMapper.toDomain(userEntity),
+        studentEntity.getBio(),
+        studentEntity.getProfilePicture(),
+        studentEntity.getCoverPicture());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/TeacherMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/TeacherMapper.java
@@ -1,0 +1,20 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.Teacher;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.TeacherEntity;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.UserEntity;
+
+public interface TeacherMapper {
+  static TeacherEntity fromDomain(Teacher teacher) {
+    return new TeacherEntity(
+        teacher.getBio(), teacher.getProfilePicture(), teacher.getCoverPicture());
+  }
+
+  static Teacher toDomain(TeacherEntity teacherEntity, UserEntity userEntity) {
+    return Teacher.toDomain(
+        UserMapper.toDomain(userEntity),
+        teacherEntity.getBio(),
+        teacherEntity.getProfilePicture(),
+        teacherEntity.getCoverPicture());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/TrackMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/TrackMapper.java
@@ -1,0 +1,22 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.Track;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.TrackEntity;
+
+public interface TrackMapper {
+  static TrackEntity fromDomain(Track track) {
+    return new TrackEntity(
+        track.getId(),
+        UserMapper.fromDomain(track.getUser()),
+        track.getSkillLevels().stream().map(SkillLevelMapper::fromDomain).toList(),
+        track.getAmses().stream().map(AMSMapper::fromDomain).toList());
+  }
+
+  static Track toDomain(TrackEntity trackEntity) {
+    return Track.toDomain(
+        trackEntity.getId(),
+        UserMapper.toDomain(trackEntity.getUser()),
+        trackEntity.getSkillLevels().stream().map(SkillLevelMapper::toDomain).toList(),
+        trackEntity.getAmses().stream().map(AMSMapper::toDomain).toList());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/UserMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/mapper/UserMapper.java
@@ -1,0 +1,30 @@
+package fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper;
+
+import fr.avenirsesr.portfolio.api.domain.model.User;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.UserEntity;
+
+public interface UserMapper {
+  static UserEntity fromDomain(User user) {
+    return new UserEntity(
+        user.getId(),
+        user.getFirstName(),
+        user.getLastName(),
+        user.getEmail(),
+        StudentMapper.fromDomain(user.toStudent()),
+        TeacherMapper.fromDomain(user.toTeacher()));
+  }
+
+  static User toDomain(UserEntity userEntity) {
+    return User.toDomain(
+        userEntity.getId(),
+        userEntity.getFirstName(),
+        userEntity.getLastName(),
+        userEntity.getEmail(),
+        userEntity.getStudent().getBio(),
+        userEntity.getStudent().getProfilePicture(),
+        userEntity.getStudent().getCoverPicture(),
+        userEntity.getTeacher().getBio(),
+        userEntity.getTeacher().getProfilePicture(),
+        userEntity.getTeacher().getCoverPicture());
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/AMSEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/AMSEntity.java
@@ -34,4 +34,12 @@ public class AMSEntity {
         UserEntity.fromDomain(ams.getUser()),
         ams.getSkillLevels().stream().map(SkillLevelEntity::fromDomain).toList());
   }
+
+  public static AMS toDomain(AMSEntity entity) {
+    return AMS.toDomain(
+            entity.getId(),
+            UserEntity.toDomain(entity.getUser()),
+            entity.getSkillLevels().stream().map(SkillLevelEntity::toDomain).toList()
+    );
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/AMSEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/AMSEntity.java
@@ -1,6 +1,5 @@
 package fr.avenirsesr.portfolio.api.infrastructure.adapter.model;
 
-import fr.avenirsesr.portfolio.api.domain.model.AMS;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
@@ -8,7 +7,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.List;
 import java.util.UUID;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +15,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "ams")
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Getter
 @Setter
 public class AMSEntity {
@@ -27,19 +25,4 @@ public class AMSEntity {
   private UserEntity user;
 
   @ManyToMany private List<SkillLevelEntity> skillLevels;
-
-  public static AMSEntity fromDomain(AMS ams) {
-    return new AMSEntity(
-        ams.getId(),
-        UserEntity.fromDomain(ams.getUser()),
-        ams.getSkillLevels().stream().map(SkillLevelEntity::fromDomain).toList());
-  }
-
-  public static AMS toDomain(AMSEntity entity) {
-    return AMS.toDomain(
-            entity.getId(),
-            UserEntity.toDomain(entity.getUser()),
-            entity.getSkillLevels().stream().map(SkillLevelEntity::toDomain).toList()
-    );
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ExternalUserEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ExternalUserEntity.java
@@ -75,27 +75,4 @@ public class ExternalUserEntity {
     this.firstName = firstName;
     this.lastName = lastName;
   }
-
-  public static ExternalUserEntity fromDomain(ExternalUser externalUser) {
-    return new ExternalUserEntity(
-        externalUser.getExternalId(),
-        externalUser.getSource(),
-        UserEntity.fromDomain(externalUser.getUser()),
-        externalUser.getCategory(),
-        externalUser.getEmail(),
-        externalUser.getFirstName(),
-        externalUser.getLastName());
-  }
-
-  public static ExternalUser toDomain(ExternalUserEntity externalUserEntity) {
-    return ExternalUser.create(
-            UserEntity.toDomain(externalUserEntity.getUser()),
-            externalUserEntity.getExternalId(),
-            externalUserEntity.getSource(),
-            externalUserEntity.getCategory(),
-            externalUserEntity.getEmail(),
-            externalUserEntity.getFirstName(),
-            externalUserEntity.getLastName()
-    );
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ExternalUserEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ExternalUserEntity.java
@@ -86,4 +86,16 @@ public class ExternalUserEntity {
         externalUser.getFirstName(),
         externalUser.getLastName());
   }
+
+  public static ExternalUser toDomain(ExternalUserEntity externalUserEntity) {
+    return ExternalUser.create(
+            UserEntity.toDomain(externalUserEntity.getUser()),
+            externalUserEntity.getExternalId(),
+            externalUserEntity.getSource(),
+            externalUserEntity.getCategory(),
+            externalUserEntity.getEmail(),
+            externalUserEntity.getFirstName(),
+            externalUserEntity.getLastName()
+    );
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/InstitutionEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/InstitutionEntity.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "institution")
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Getter
 @Setter
 public class InstitutionEntity {
@@ -54,17 +54,5 @@ public class InstitutionEntity {
 
   public void setEnabledFields(Set<ENavigationField> enabledFields) {
     this.enabledFieldsRaw = enabledFields.stream().map(Enum::name).collect(Collectors.joining(","));
-  }
-
-  public static InstitutionEntity fromDomain(Institution institution) {
-    return new InstitutionEntity(
-        institution.getId(), institution.getName(), institution.getEnabledFields());
-  }
-
-  public static Institution toDomain(InstitutionEntity institutionEntity) {
-    return Institution.toDomain(
-        institutionEntity.getId(),
-        institutionEntity.getName(),
-        institutionEntity.getEnabledFields());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/InstitutionEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/InstitutionEntity.java
@@ -60,4 +60,11 @@ public class InstitutionEntity {
     return new InstitutionEntity(
         institution.getId(), institution.getName(), institution.getEnabledFields());
   }
+
+  public static Institution toDomain(InstitutionEntity institutionEntity) {
+    return Institution.toDomain(
+        institutionEntity.getId(),
+        institutionEntity.getName(),
+        institutionEntity.getEnabledFields());
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ProgramEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ProgramEntity.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "program")
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -27,16 +27,4 @@ public class ProgramEntity {
 
   @ManyToOne(optional = false)
   private InstitutionEntity institution;
-
-  public static ProgramEntity fromDomain(Program program) {
-    return new ProgramEntity(
-        program.getId(), program.getName(), InstitutionEntity.fromDomain(program.getInstitution()));
-  }
-
-  public static Program toDomain(ProgramEntity programEntity) {
-    return Program.toDomain(
-        programEntity.getId(),
-        InstitutionEntity.toDomain(programEntity.getInstitution()),
-        programEntity.getName());
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ProgramEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ProgramEntity.java
@@ -32,4 +32,11 @@ public class ProgramEntity {
     return new ProgramEntity(
         program.getId(), program.getName(), InstitutionEntity.fromDomain(program.getInstitution()));
   }
+
+  public static Program toDomain(ProgramEntity programEntity) {
+    return Program.toDomain(
+        programEntity.getId(),
+        InstitutionEntity.toDomain(programEntity.getInstitution()),
+        programEntity.getName());
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ProgramProgressEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ProgramProgressEntity.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "program_progress")
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -39,23 +39,4 @@ public class ProgramProgressEntity {
       inverseJoinColumns = @JoinColumn(name = "skill_id"))
   private Set<SkillEntity> skills;
 
-  public static ProgramProgressEntity fromDomain(ProgramProgress programProgress) {
-    return new ProgramProgressEntity(
-        programProgress.getId(),
-        ProgramEntity.fromDomain(programProgress.getProgram()),
-        UserEntity.fromDomain(programProgress.getStudent().getUser()),
-        programProgress.getSkills().stream()
-            .map(SkillEntity::fromDomain)
-            .collect(Collectors.toSet()));
-  }
-
-  public static ProgramProgress toDomain(ProgramProgressEntity programProgressEntity) {
-    return ProgramProgress.toDomain(
-            programProgressEntity.getId(),
-            ProgramEntity.toDomain(programProgressEntity.getProgram()),
-            StudentEntity.toDomain(programProgressEntity.getStudent().getStudent(), programProgressEntity.getStudent()),
-            programProgressEntity.getSkills().stream()
-                    .map(SkillEntity::toDomain)
-                    .collect(Collectors.toSet()));
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ProgramProgressEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/ProgramProgressEntity.java
@@ -48,4 +48,14 @@ public class ProgramProgressEntity {
             .map(SkillEntity::fromDomain)
             .collect(Collectors.toSet()));
   }
+
+  public static ProgramProgress toDomain(ProgramProgressEntity programProgressEntity) {
+    return ProgramProgress.toDomain(
+            programProgressEntity.getId(),
+            ProgramEntity.toDomain(programProgressEntity.getProgram()),
+            StudentEntity.toDomain(programProgressEntity.getStudent().getStudent(), programProgressEntity.getStudent()),
+            programProgressEntity.getSkills().stream()
+                    .map(SkillEntity::toDomain)
+                    .collect(Collectors.toSet()));
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/SkillEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/SkillEntity.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "skill")
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -36,21 +36,5 @@ public class SkillEntity {
       inverseJoinColumns = @JoinColumn(name = "skill_level_id"))
   private Set<SkillLevelEntity> skillLevels;
 
-  public static SkillEntity fromDomain(Skill skill) {
-    return new SkillEntity(
-        skill.getId(),
-        skill.getName(),
-        skill.getSkillLevels().stream()
-            .map(SkillLevelEntity::fromDomain)
-            .collect(Collectors.toSet()));
-  }
 
-  public static Skill toDomain(SkillEntity skillEntity) {
-    return Skill.toDomain(
-            skillEntity.getId(),
-            skillEntity.getName(),
-            skillEntity.getSkillLevels().stream()
-                    .map(SkillLevelEntity::toDomain)
-                    .collect(Collectors.toSet()));
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/SkillEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/SkillEntity.java
@@ -44,4 +44,13 @@ public class SkillEntity {
             .map(SkillLevelEntity::fromDomain)
             .collect(Collectors.toSet()));
   }
+
+  public static Skill toDomain(SkillEntity skillEntity) {
+    return Skill.toDomain(
+            skillEntity.getId(),
+            skillEntity.getName(),
+            skillEntity.getSkillLevels().stream()
+                    .map(SkillLevelEntity::toDomain)
+                    .collect(Collectors.toSet()));
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/SkillLevelEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/SkillLevelEntity.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "skill_level")
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -37,21 +37,4 @@ public class SkillLevelEntity {
 
   @ManyToMany private List<AMSEntity> amses;
 
-  public static SkillLevelEntity fromDomain(SkillLevel skillLevel) {
-    return new SkillLevelEntity(
-        skillLevel.getId(),
-        skillLevel.getName(),
-        skillLevel.getStatus(),
-        skillLevel.getTracks().stream().map(TrackEntity::fromDomain).toList(),
-        skillLevel.getAmses().stream().map(AMSEntity::fromDomain).toList());
-  }
-
-  public static SkillLevel toDomain(SkillLevelEntity skillLevelEntity) {
-    return SkillLevel.toDomain(
-            skillLevelEntity.getId(),
-            skillLevelEntity.getName(),
-            skillLevelEntity.getStatus(),
-            skillLevelEntity.getTracks().stream().map(TrackEntity::toDomain).toList(),
-            skillLevelEntity.getAmses().stream().map(AMSEntity::toDomain).toList());
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/SkillLevelEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/SkillLevelEntity.java
@@ -45,4 +45,13 @@ public class SkillLevelEntity {
         skillLevel.getTracks().stream().map(TrackEntity::fromDomain).toList(),
         skillLevel.getAmses().stream().map(AMSEntity::fromDomain).toList());
   }
+
+  public static SkillLevel toDomain(SkillLevelEntity skillLevelEntity) {
+    return SkillLevel.toDomain(
+            skillLevelEntity.getId(),
+            skillLevelEntity.getName(),
+            skillLevelEntity.getStatus(),
+            skillLevelEntity.getTracks().stream().map(TrackEntity::toDomain).toList(),
+            skillLevelEntity.getAmses().stream().map(AMSEntity::toDomain).toList());
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/StudentEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/StudentEntity.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Embeddable
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -20,17 +20,4 @@ public class StudentEntity {
   @Column @Lob private byte[] profilePicture;
   @Column @Lob private byte[] coverPicture;
 
-  public static StudentEntity fromDomain(Student student) {
-    return new StudentEntity(
-        student.getBio(), student.getProfilePicture(), student.getCoverPicture());
-  }
-
-  public static Student toDomain(StudentEntity studentEntity, UserEntity userEntity) {
-    return Student.toDomain(
-            UserEntity.toDomain(userEntity),
-            studentEntity.getBio(),
-            studentEntity.getProfilePicture(),
-            studentEntity.getCoverPicture()
-    );
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/StudentEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/StudentEntity.java
@@ -24,4 +24,13 @@ public class StudentEntity {
     return new StudentEntity(
         student.getBio(), student.getProfilePicture(), student.getCoverPicture());
   }
+
+  public static Student toDomain(StudentEntity studentEntity, UserEntity userEntity) {
+    return Student.toDomain(
+            UserEntity.toDomain(userEntity),
+            studentEntity.getBio(),
+            studentEntity.getProfilePicture(),
+            studentEntity.getCoverPicture()
+    );
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/TeacherEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/TeacherEntity.java
@@ -24,4 +24,13 @@ public class TeacherEntity {
     return new TeacherEntity(
         teacher.getBio(), teacher.getProfilePicture(), teacher.getCoverPicture());
   }
+
+  public static Teacher toDomain(TeacherEntity teacherEntity, UserEntity userEntity) {
+    return Teacher.toDomain(
+            UserEntity.toDomain(userEntity),
+            teacherEntity.getBio(),
+            teacherEntity.getProfilePicture(),
+            teacherEntity.getCoverPicture()
+    );
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/TeacherEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/TeacherEntity.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Embeddable
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -20,17 +20,4 @@ public class TeacherEntity {
   @Column @Lob private byte[] profilePicture;
   @Column @Lob private byte[] coverPicture;
 
-  public static TeacherEntity fromDomain(Teacher teacher) {
-    return new TeacherEntity(
-        teacher.getBio(), teacher.getProfilePicture(), teacher.getCoverPicture());
-  }
-
-  public static Teacher toDomain(TeacherEntity teacherEntity, UserEntity userEntity) {
-    return Teacher.toDomain(
-            UserEntity.toDomain(userEntity),
-            teacherEntity.getBio(),
-            teacherEntity.getProfilePicture(),
-            teacherEntity.getCoverPicture()
-    );
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/TrackEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/TrackEntity.java
@@ -37,4 +37,12 @@ public class TrackEntity {
         track.getSkillLevels().stream().map(SkillLevelEntity::fromDomain).toList(),
         track.getAmses().stream().map(AMSEntity::fromDomain).toList());
   }
+
+  public static Track toDomain(TrackEntity trackEntity) {
+    return Track.toDomain(
+            trackEntity.getId(),
+            UserEntity.toDomain(trackEntity.getUser()),
+            trackEntity.getSkillLevels().stream().map(SkillLevelEntity::toDomain).toList(),
+            trackEntity.getAmses().stream().map(AMSEntity::toDomain).toList());
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/TrackEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/TrackEntity.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "track")
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -30,19 +30,4 @@ public class TrackEntity {
 
   @ManyToMany private List<AMSEntity> amses;
 
-  public static TrackEntity fromDomain(Track track) {
-    return new TrackEntity(
-        track.getId(),
-        UserEntity.fromDomain(track.getUser()),
-        track.getSkillLevels().stream().map(SkillLevelEntity::fromDomain).toList(),
-        track.getAmses().stream().map(AMSEntity::fromDomain).toList());
-  }
-
-  public static Track toDomain(TrackEntity trackEntity) {
-    return Track.toDomain(
-            trackEntity.getId(),
-            UserEntity.toDomain(trackEntity.getUser()),
-            trackEntity.getSkillLevels().stream().map(SkillLevelEntity::toDomain).toList(),
-            trackEntity.getAmses().stream().map(AMSEntity::toDomain).toList());
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/UserEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/UserEntity.java
@@ -58,4 +58,15 @@ public class UserEntity {
         user.getStudent() != null ? StudentEntity.fromDomain(user.getStudent()) : null,
         user.getTeacher() != null ? TeacherEntity.fromDomain(user.getTeacher()) : null);
   }
+
+  public static User toDomain(UserEntity userEntity) {
+    return User.toDomain(
+            userEntity.getId(),
+            userEntity.getFirstName(),
+            userEntity.getLastName(),
+            userEntity.getEmail(),
+            userEntity.getStudent() != null ? StudentEntity.toDomain(userEntity.getStudent(), userEntity) : null,
+            userEntity.getTeacher() != null ? TeacherEntity.toDomain(userEntity.getTeacher(), userEntity) : null
+    );
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/UserEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/UserEntity.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "users")
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -49,27 +49,4 @@ public class UserEntity {
   })
   private TeacherEntity teacher;
 
-  public static UserEntity fromDomain(User user) {
-    return new UserEntity(
-        user.getId(),
-        user.getFirstName(),
-        user.getLastName(),
-        user.getEmail(),
-        StudentEntity.fromDomain(user.toStudent()),
-        TeacherEntity.fromDomain(user.toTeacher()));
-  }
-
-  public static User toDomain(UserEntity userEntity) {
-    return User.toDomain(
-        userEntity.getId(),
-        userEntity.getFirstName(),
-        userEntity.getLastName(),
-        userEntity.getEmail(),
-        userEntity.getStudent().getBio(),
-        userEntity.getStudent().getProfilePicture(),
-        userEntity.getStudent().getCoverPicture(),
-        userEntity.getTeacher().getBio(),
-        userEntity.getTeacher().getProfilePicture(),
-        userEntity.getTeacher().getCoverPicture());
-  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/UserEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/model/UserEntity.java
@@ -55,18 +55,21 @@ public class UserEntity {
         user.getFirstName(),
         user.getLastName(),
         user.getEmail(),
-        user.getStudent() != null ? StudentEntity.fromDomain(user.getStudent()) : null,
-        user.getTeacher() != null ? TeacherEntity.fromDomain(user.getTeacher()) : null);
+        StudentEntity.fromDomain(user.toStudent()),
+        TeacherEntity.fromDomain(user.toTeacher()));
   }
 
   public static User toDomain(UserEntity userEntity) {
     return User.toDomain(
-            userEntity.getId(),
-            userEntity.getFirstName(),
-            userEntity.getLastName(),
-            userEntity.getEmail(),
-            userEntity.getStudent() != null ? StudentEntity.toDomain(userEntity.getStudent(), userEntity) : null,
-            userEntity.getTeacher() != null ? TeacherEntity.toDomain(userEntity.getTeacher(), userEntity) : null
-    );
+        userEntity.getId(),
+        userEntity.getFirstName(),
+        userEntity.getLastName(),
+        userEntity.getEmail(),
+        userEntity.getStudent().getBio(),
+        userEntity.getStudent().getProfilePicture(),
+        userEntity.getStudent().getCoverPicture(),
+        userEntity.getTeacher().getBio(),
+        userEntity.getTeacher().getProfilePicture(),
+        userEntity.getTeacher().getCoverPicture());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/AMSDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/AMSDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.AMS;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.AMSRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.AMSMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.AMSEntity;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,6 @@ public class AMSDatabaseRepository extends GenericJpaRepositoryAdapter<AMS, AMSE
     implements AMSRepository {
 
   public AMSDatabaseRepository(AMSJpaRepository repository) {
-    super(repository, AMSEntity::fromDomain, AMSEntity::toDomain);
+    super(repository, AMSMapper::fromDomain, AMSMapper::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/AMSDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/AMSDatabaseRepository.java
@@ -10,6 +10,6 @@ public class AMSDatabaseRepository extends GenericJpaRepositoryAdapter<AMS, AMSE
     implements AMSRepository {
 
   public AMSDatabaseRepository(AMSJpaRepository repository) {
-    super(repository, AMSEntity::fromDomain);
+    super(repository, AMSEntity::fromDomain, AMSEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ExternalUserDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ExternalUserDatabaseRepository.java
@@ -11,6 +11,6 @@ public class ExternalUserDatabaseRepository
     implements ExternalUserRepository {
 
   public ExternalUserDatabaseRepository(ExternalUserJpaRepository jpaRepository) {
-    super(jpaRepository, ExternalUserEntity::fromDomain);
+    super(jpaRepository, ExternalUserEntity::fromDomain, ExternalUserEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ExternalUserDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ExternalUserDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.ExternalUser;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.ExternalUserRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.ExternalUserMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.ExternalUserEntity;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +12,6 @@ public class ExternalUserDatabaseRepository
     implements ExternalUserRepository {
 
   public ExternalUserDatabaseRepository(ExternalUserJpaRepository jpaRepository) {
-    super(jpaRepository, ExternalUserEntity::fromDomain, ExternalUserEntity::toDomain);
+    super(jpaRepository, ExternalUserMapper::fromDomain, ExternalUserMapper::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/GenericJpaRepositoryAdapter.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/GenericJpaRepositoryAdapter.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.GenericRepositoryPort;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,11 +10,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public abstract class GenericJpaRepositoryAdapter<D, E> implements GenericRepositoryPort<D> {
   private final JpaRepository<E, UUID> jpaRepository;
   private final Function<D, E> fromDomain;
+  private final Function<E, D> toDomain;
 
   protected GenericJpaRepositoryAdapter(
-      JpaRepository<E, UUID> jpaRepository, Function<D, E> fromDomain) {
+      JpaRepository<E, UUID> jpaRepository, Function<D, E> fromDomain, Function<E, D> toDomain) {
     this.jpaRepository = jpaRepository;
     this.fromDomain = fromDomain;
+    this.toDomain = toDomain;
   }
 
   @Override
@@ -24,5 +27,10 @@ public abstract class GenericJpaRepositoryAdapter<D, E> implements GenericReposi
   @Override
   public void saveAll(List<D> domains) {
     jpaRepository.saveAll(domains.stream().map(fromDomain).toList());
+  }
+
+  @Override
+  public Optional<D> findById(UUID id) {
+    return Optional.ofNullable(toDomain.apply(jpaRepository.findById(id).orElse(null)));
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/InstitutionDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/InstitutionDatabaseRepository.java
@@ -10,6 +10,6 @@ public class InstitutionDatabaseRepository
     extends GenericJpaRepositoryAdapter<Institution, InstitutionEntity>
     implements InstitutionRepository {
   public InstitutionDatabaseRepository(InstitutionJpaRepository jpaRepository) {
-    super(jpaRepository, InstitutionEntity::fromDomain);
+    super(jpaRepository, InstitutionEntity::fromDomain, InstitutionEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/InstitutionDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/InstitutionDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.Institution;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.InstitutionRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.InstitutionMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.InstitutionEntity;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,6 @@ public class InstitutionDatabaseRepository
     extends GenericJpaRepositoryAdapter<Institution, InstitutionEntity>
     implements InstitutionRepository {
   public InstitutionDatabaseRepository(InstitutionJpaRepository jpaRepository) {
-    super(jpaRepository, InstitutionEntity::fromDomain, InstitutionEntity::toDomain);
+    super(jpaRepository, InstitutionMapper::fromDomain, InstitutionMapper::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ProgramDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ProgramDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.Program;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.ProgramRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.ProgramMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.ProgramEntity;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Component;
 public class ProgramDatabaseRepository extends GenericJpaRepositoryAdapter<Program, ProgramEntity>
     implements ProgramRepository {
   public ProgramDatabaseRepository(ProgramJpaRepository jpaRepository) {
-    super(jpaRepository, ProgramEntity::fromDomain, ProgramEntity::toDomain);
+    super(jpaRepository, ProgramMapper::fromDomain, ProgramMapper::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ProgramDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ProgramDatabaseRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Component;
 public class ProgramDatabaseRepository extends GenericJpaRepositoryAdapter<Program, ProgramEntity>
     implements ProgramRepository {
   public ProgramDatabaseRepository(ProgramJpaRepository jpaRepository) {
-    super(jpaRepository, ProgramEntity::fromDomain);
+    super(jpaRepository, ProgramEntity::fromDomain, ProgramEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ProgramProgressDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ProgramProgressDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.ProgramProgress;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.ProgramProgressRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.ProgramProgressMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.ProgramProgressEntity;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,6 @@ public class ProgramProgressDatabaseRepository
     extends GenericJpaRepositoryAdapter<ProgramProgress, ProgramProgressEntity>
     implements ProgramProgressRepository {
   public ProgramProgressDatabaseRepository(ProgramProgressJpaRepository jpaRepository) {
-    super(jpaRepository, ProgramProgressEntity::fromDomain, ProgramProgressEntity::toDomain);
+    super(jpaRepository, ProgramProgressMapper::fromDomain, ProgramProgressMapper::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ProgramProgressDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/ProgramProgressDatabaseRepository.java
@@ -10,6 +10,6 @@ public class ProgramProgressDatabaseRepository
     extends GenericJpaRepositoryAdapter<ProgramProgress, ProgramProgressEntity>
     implements ProgramProgressRepository {
   public ProgramProgressDatabaseRepository(ProgramProgressJpaRepository jpaRepository) {
-    super(jpaRepository, ProgramProgressEntity::fromDomain);
+    super(jpaRepository, ProgramProgressEntity::fromDomain, ProgramProgressEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/SkillDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/SkillDatabaseRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Component;
 public class SkillDatabaseRepository extends GenericJpaRepositoryAdapter<Skill, SkillEntity>
     implements SkillRepository {
   public SkillDatabaseRepository(SkillJpaRepository jpaRepository) {
-    super(jpaRepository, SkillEntity::fromDomain);
+    super(jpaRepository, SkillEntity::fromDomain, SkillEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/SkillDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/SkillDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.Skill;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.SkillRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.SkillMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.SkillEntity;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Component;
 public class SkillDatabaseRepository extends GenericJpaRepositoryAdapter<Skill, SkillEntity>
     implements SkillRepository {
   public SkillDatabaseRepository(SkillJpaRepository jpaRepository) {
-    super(jpaRepository, SkillEntity::fromDomain, SkillEntity::toDomain);
+    super(jpaRepository, SkillMapper::fromDomain, SkillMapper::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/SkillLevelDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/SkillLevelDatabaseRepository.java
@@ -10,6 +10,6 @@ public class SkillLevelDatabaseRepository
     extends GenericJpaRepositoryAdapter<SkillLevel, SkillLevelEntity>
     implements SkillLevelRepository {
   public SkillLevelDatabaseRepository(SkillLevelJpaRepository jpaRepository) {
-    super(jpaRepository, SkillLevelEntity::fromDomain);
+    super(jpaRepository, SkillLevelEntity::fromDomain, SkillLevelEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/SkillLevelDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/SkillLevelDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.SkillLevel;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.SkillLevelRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.SkillLevelMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.SkillLevelEntity;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,6 @@ public class SkillLevelDatabaseRepository
     extends GenericJpaRepositoryAdapter<SkillLevel, SkillLevelEntity>
     implements SkillLevelRepository {
   public SkillLevelDatabaseRepository(SkillLevelJpaRepository jpaRepository) {
-    super(jpaRepository, SkillLevelEntity::fromDomain, SkillLevelEntity::toDomain);
+    super(jpaRepository, SkillLevelMapper::fromDomain, SkillLevelMapper::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/TrackDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/TrackDatabaseRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Component;
 public class TrackDatabaseRepository extends GenericJpaRepositoryAdapter<Track, TrackEntity>
     implements TrackRepository {
   public TrackDatabaseRepository(TrackJpaRepository jpaRepository) {
-    super(jpaRepository, TrackEntity::fromDomain);
+    super(jpaRepository, TrackEntity::fromDomain, TrackEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/TrackDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/TrackDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.Track;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.TrackRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.TrackMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.TrackEntity;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Component;
 public class TrackDatabaseRepository extends GenericJpaRepositoryAdapter<Track, TrackEntity>
     implements TrackRepository {
   public TrackDatabaseRepository(TrackJpaRepository jpaRepository) {
-    super(jpaRepository, TrackEntity::fromDomain, TrackEntity::toDomain);
+    super(jpaRepository, TrackMapper::fromDomain, TrackMapper::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/UserDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/UserDatabaseRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Component;
 public class UserDatabaseRepository extends GenericJpaRepositoryAdapter<User, UserEntity>
     implements UserRepository {
   public UserDatabaseRepository(UserJpaRepository jpaRepository) {
-    super(jpaRepository, UserEntity::fromDomain);
+    super(jpaRepository, UserEntity::fromDomain, UserEntity::toDomain);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/UserDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/api/infrastructure/adapter/repository/UserDatabaseRepository.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.api.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.api.domain.model.User;
 import fr.avenirsesr.portfolio.api.domain.port.output.repository.UserRepository;
+import fr.avenirsesr.portfolio.api.infrastructure.adapter.mapper.UserMapper;
 import fr.avenirsesr.portfolio.api.infrastructure.adapter.model.UserEntity;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Component;
 public class UserDatabaseRepository extends GenericJpaRepositoryAdapter<User, UserEntity>
     implements UserRepository {
   public UserDatabaseRepository(UserJpaRepository jpaRepository) {
-    super(jpaRepository, UserEntity::fromDomain, UserEntity::toDomain);
+    super(jpaRepository, UserMapper::fromDomain, UserMapper::toDomain);
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Cette PR propose une amélioration de la couche domaine du modèle en supprimant la dépendance circulaire entre `Student` / `Teacher` & `User` 

_Deux champs `User.isStudent` & `User.isTeacher` ont fait leur apparition ce sera certainement à terme des timestamps du type `isActiveStudentUntil`, gardons pour le moment un fonctionnement simple et travaillons directement avec des `boolean`_

- Cette PR introduit aussi l’ensemble des Mappers `Entity / Domain`


- Cette PR ajoute `findById` dans le `GenericRepository`
---

### Target Branch
main

---
