### PR TITLE
fix(384): save enum in db with name value instead of index

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/programprogress/infrastructure/adapter/model/ProgramEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/programprogress/infrastructure/adapter/model/ProgramEntity.java
@@ -20,6 +20,7 @@ public class ProgramEntity extends AvenirsBaseEntity {
   private boolean isAPC;
 
   @Column(name = "duration_unit", nullable = true)
+  @Enumerated(EnumType.STRING)
   private EDurationUnit durationUnit;
 
   @Column(name = "duration_count", nullable = true)

--- a/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/model/TranslationEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/model/TranslationEntity.java
@@ -2,6 +2,8 @@ package fr.avenirsesr.portfolio.shared.infrastructure.adapter.model;
 
 import fr.avenirsesr.portfolio.shared.domain.model.enums.ELanguage;
 import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,5 +13,6 @@ import lombok.Setter;
 @MappedSuperclass
 public abstract class TranslationEntity extends AvenirsBaseEntity {
   @Column(name = "language", nullable = false)
+  @Enumerated(EnumType.STRING)
   protected ELanguage language;
 }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/model/TraceEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/model/TraceEntity.java
@@ -7,6 +7,8 @@ import fr.avenirsesr.portfolio.shared.infrastructure.adapter.model.AvenirsBaseEn
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.UserEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
@@ -34,6 +36,7 @@ public class TraceEntity extends AvenirsBaseEntity {
   private String title;
 
   @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
   private ELanguage language;
 
   @ManyToMany


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied

enums values vas saved by their indexe instead of their name in the database, for translations and program durability unit

---

### Reference to an Issue, Feature, Task, User Story or another PR
> closes [#384](https://github.com/avenirs-esr/AVENIRS-Project/issues/384)

---

### Target Branch
> develop
