### PR TITLE
Feat/546 547 endpoint user delete resource

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/file/application/adapter/controller/UserResourceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/application/adapter/controller/UserResourceController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import java.security.Principal;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -61,5 +62,17 @@ public class UserResourceController {
             file.getSize(),
             file.getBytes());
     return ResponseEntity.ok(UserPhotoUploadDTOMapper.fromDomain(userPhoto));
+  }
+
+  @DeleteMapping(path = "/{fileId}")
+  public ResponseEntity<String> deleteUserPhoto(
+      Principal principal, @Valid @PathVariable UUID fileId) {
+    log.debug(
+        "Received request to delete user picture [{}] of user [{}]", fileId, principal.getName());
+    User user = userUtil.getUser(principal);
+
+    userResourceService.deletePhoto(fileId, user);
+
+    return ResponseEntity.ok("Resource successfully deleted");
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/file/domain/port/input/UserResourceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/domain/port/input/UserResourceService.java
@@ -23,4 +23,6 @@ public interface UserResourceService {
       long size,
       byte[] content)
       throws IOException;
+
+  void deletePhoto(UUID fileId, User user);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/file/domain/service/UserResourceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/domain/service/UserResourceServiceImpl.java
@@ -11,6 +11,7 @@ import fr.avenirsesr.portfolio.file.domain.port.input.UserResourceService;
 import fr.avenirsesr.portfolio.file.domain.port.output.repository.UserPhotoRepository;
 import fr.avenirsesr.portfolio.file.domain.port.output.service.FileStorageService;
 import fr.avenirsesr.portfolio.file.infrastructure.configuration.FileStorageConstants;
+import fr.avenirsesr.portfolio.user.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.user.domain.model.*;
 import fr.avenirsesr.portfolio.user.domain.model.enums.EUserCategory;
 import java.io.IOException;
@@ -98,5 +99,29 @@ public class UserResourceServiceImpl implements UserResourceService {
     log.info("New user photo saved: {}", photo);
 
     return photo;
+  }
+
+  @Override
+  public void deletePhoto(UUID fileId, User user) {
+    var fileResource =
+        userPhotoRepository
+            .findById(fileId)
+            .orElseThrow(
+                () -> {
+                  log.error("No user photo with id {} found", fileId);
+                  return new FileNotFoundException();
+                });
+
+    if (!fileResource.getUser().equals(user)) {
+      throw new UserNotAuthorizedException();
+    }
+
+    try {
+      fileStorageService.delete(fileResource.getId());
+      userPhotoRepository.removeFromDatabase(fileResource);
+      log.info("User photo deleted: {}", fileResource);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/service/FileStorageServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/service/FileStorageServiceImpl.java
@@ -50,12 +50,12 @@ public class FileStorageServiceImpl implements FileStorageService {
 
     File dir = new File(uploadDir);
     if (!dir.exists()) {
-      throw new FileNotFoundException();
+      throw new IllegalStateException("File storage directory does not exist");
     }
 
-    // Search for the file with the given id (extension is unknown, so we check all)
     File[] matchingFiles = dir.listFiles((d, name) -> name.startsWith(id.toString() + "."));
     if (matchingFiles == null || matchingFiles.length == 0) {
+      log.error("No file found with id {} found", id);
       throw new FileNotFoundException();
     }
 

--- a/src/main/java/fr/avenirsesr/portfolio/shared/domain/port/output/repository/GenericRepositoryPort.java
+++ b/src/main/java/fr/avenirsesr/portfolio/shared/domain/port/output/repository/GenericRepositoryPort.java
@@ -13,4 +13,6 @@ public interface GenericRepositoryPort<D extends AvenirsBaseModel> {
   List<D> saveAll(List<D> collection);
 
   void flush();
+
+  void removeFromDatabase(D domain);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/repository/GenericJpaRepositoryAdapter.java
+++ b/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/repository/GenericJpaRepositoryAdapter.java
@@ -57,4 +57,9 @@ public abstract class GenericJpaRepositoryAdapter<
   public void flush() {
     jpaRepository.flush();
   }
+
+  @Override
+  public void removeFromDatabase(D domain) {
+    jpaRepository.delete(fromDomain.apply(domain));
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/seeder/SeederConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/seeder/SeederConfig.java
@@ -6,8 +6,8 @@ public class SeederConfig {
   public static final int USERS_NB_OF_STUDENT = (int) (0.8 * USERS_NB);
   public static final int USERS_NB_OF_TEACHER = (int) (0.15 * USERS_NB);
   public static final int USERS_NB_OF_BOTH = (int) (0.05 * USERS_NB);
-  public static final int MAX_PROFILE_PHOTO_PER_USER = 3;
-  public static final int MAX_COVER_PHOTO_PER_USER = 2;
+  public static final int MAX_PROFILE_PHOTO_PER_USER = 1;
+  public static final int MAX_COVER_PHOTO_PER_USER = 1;
 
   // Institutions
   private static final int INSTITUTIONS_NB = 5;

--- a/src/test/java/fr/avenirsesr/portfolio/file/application/adapter/controller/UserResourceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/file/application/adapter/controller/UserResourceControllerIT.java
@@ -1,6 +1,7 @@
 package fr.avenirsesr.portfolio.file.application.adapter.controller;
 
 import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -9,6 +10,7 @@ import fr.avenirsesr.portfolio.file.domain.model.EUserPhotoType;
 import fr.avenirsesr.portfolio.shared.infrastructure.adapter.seeder.SeederRunner;
 import fr.avenirsesr.portfolio.user.domain.model.enums.EUserCategory;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,6 +76,19 @@ class UserResourceControllerIT {
         .andExpect(
             jsonPath("$.fileSize")
                 .value("FakeImageContent".getBytes(StandardCharsets.UTF_8).length))
-        .andExpect(jsonPath("$.version").value(4));
+        .andExpect(jsonPath("$.version").value(2));
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenDeletingNonExistingPhoto() throws Exception {
+    UUID fileId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            delete("/me/storage/users/{fileId}", fileId)
+                .header("X-Signed-Context", studentPayload)
+                .header("X-Context-Kid", secretKey)
+                .header("X-Context-Signature", studentSignature))
+        .andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/file/domain/service/UserResourceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/file/domain/service/UserResourceServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 
+import fr.avenirsesr.portfolio.file.domain.exception.FileNotFoundException;
 import fr.avenirsesr.portfolio.file.domain.exception.FileSizeTooBigException;
 import fr.avenirsesr.portfolio.file.domain.exception.FileTypeNotSupportedException;
 import fr.avenirsesr.portfolio.file.domain.model.EUserPhotoType;
@@ -12,11 +13,13 @@ import fr.avenirsesr.portfolio.file.domain.model.shared.EFileType;
 import fr.avenirsesr.portfolio.file.domain.model.shared.FileResource;
 import fr.avenirsesr.portfolio.file.domain.port.output.repository.UserPhotoRepository;
 import fr.avenirsesr.portfolio.file.domain.port.output.service.FileStorageService;
+import fr.avenirsesr.portfolio.user.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -122,5 +125,95 @@ public class UserResourceServiceImplTest {
     org.junit.jupiter.api.Assertions.assertThrows(
         FileSizeTooBigException.class,
         () -> service.uploadPhoto(user, category, photoType, fileName, mimeType, size, content));
+  }
+
+  @Test
+  void deletePhoto_shouldDeletePhotoSuccessfully() throws IOException {
+    // Given
+    var user = student.getUser();
+    var photoId = UUID.randomUUID();
+    var photo =
+        UserPhoto.create(
+            photoId,
+            EFileType.PNG,
+            456,
+            1,
+            true,
+            "uri/to/photo.png",
+            user,
+            user,
+            EUserCategory.STUDENT,
+            EUserPhotoType.PROFILE);
+    when(userPhotoRepository.findById(photoId)).thenReturn(Optional.of(photo));
+
+    // When
+    service.deletePhoto(photoId, user);
+
+    // Then
+    verify(fileStorageService).delete(photo.getId());
+    verify(userPhotoRepository).removeFromDatabase(photo);
+  }
+
+  @Test
+  void deletePhoto_shouldThrowFileNotFoundException_whenPhotoDoesNotExist() {
+    // Given
+    var user = student.getUser();
+    var photoId = UUID.randomUUID();
+    when(userPhotoRepository.findById(photoId)).thenReturn(Optional.empty());
+
+    // Then
+    org.junit.jupiter.api.Assertions.assertThrows(
+        FileNotFoundException.class, () -> service.deletePhoto(photoId, user));
+  }
+
+  @Test
+  void deletePhoto_shouldThrowUserNotAuthorizedException_whenPhotoBelongsToAnotherUser() {
+    // Given
+    var user = student.getUser();
+    var otherUser = UserFixture.createStudent().toModel().toStudent().getUser();
+    var photoId = UUID.randomUUID();
+    var photo =
+        UserPhoto.create(
+            photoId,
+            EFileType.PNG,
+            456,
+            1,
+            true,
+            "uri/to/photo.png",
+            otherUser,
+            otherUser,
+            EUserCategory.STUDENT,
+            EUserPhotoType.PROFILE);
+    when(userPhotoRepository.findById(photoId)).thenReturn(Optional.of(photo));
+
+    // Then
+    org.junit.jupiter.api.Assertions.assertThrows(
+        UserNotAuthorizedException.class, () -> service.deletePhoto(photoId, user));
+  }
+
+  @Test
+  void deletePhoto_shouldWrapIOExceptionInRuntimeException() throws IOException {
+    // Given
+    var user = student.getUser();
+    var photoId = UUID.randomUUID();
+    var photo =
+        UserPhoto.create(
+            photoId,
+            EFileType.PNG,
+            456,
+            1,
+            true,
+            "uri/to/photo.png",
+            user,
+            user,
+            EUserCategory.STUDENT,
+            EUserPhotoType.PROFILE);
+    when(userPhotoRepository.findById(photoId)).thenReturn(Optional.of(photo));
+    doThrow(new IOException("IO error")).when(fileStorageService).delete(photo.getId());
+
+    // Then
+    org.junit.jupiter.api.Assertions.assertThrows(
+        RuntimeException.class, () -> service.deletePhoto(photoId, user));
+    verify(userPhotoRepository, never()).removeFromDatabase(photo);
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
new endpoint for deleting cover and profile user picture

_endpoint : `DELETE /me/storage/users/{fileId}`_

this endpoint is working for `STUDENT` & `TEACHER` category and `PROFILE` & `COVER` pictures
we check is the user connected is the user's photo

---

### Reference to an Issue, Feature, Task, User Story or another PR
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/546
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/547

---

### Target Branch
develop

---

### Known Limitations or Side Effects
deleting pictures that are generated by seeding is not working as the pictures are not uploaded on file system. only deleting pictures previously uploaded works


---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected

---
