### PR TITLE
feat(trace): introduce unassociate trace endpoint

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceController.java
@@ -145,6 +145,25 @@ public class TraceController {
     return ResponseEntity.ok("Trace successfully associated.");
   }
 
+  @PostMapping("/unassociate/{traceId}")
+  public ResponseEntity<String> unassociate(
+      Principal principal,
+      @PathVariable UUID traceId,
+      @RequestBody AssociateTraceDTO associateTraceDTO) {
+    log.info("User [{}] request to unassociate trace [{}]", principal.getName(), traceId);
+
+    User user = userUtil.getUser(principal);
+
+    traceService.unassociateTrace(
+        user,
+        traceId,
+        associateTraceDTO.amsIds(),
+        associateTraceDTO.skillLevelIds(),
+        associateTraceDTO.additionalSkillProgressIds());
+
+    return ResponseEntity.ok("Trace successfully unassociated.");
+  }
+
   @GetMapping("/search-association/{associationType}")
   public ResponseEntity<PagedResponse<TraceAssociationSearchResult>> getAssociatedTraces(
       Principal principal,

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/model/Trace.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/model/Trace.java
@@ -139,4 +139,22 @@ public class Trace extends DeletableAvenirsBaseModel {
         Stream.concat(additionalSkillProgresses.stream(), Stream.of(additionalSkillProgress))
             .toList());
   }
+
+  public void remove(AdditionalSkillProgress additionalSkillProgress) {
+    var newAdditionalSkillProgresses = new ArrayList<>(additionalSkillProgresses);
+    newAdditionalSkillProgresses.remove(additionalSkillProgress);
+    setAdditionalSkillProgresses(newAdditionalSkillProgresses);
+  }
+
+  public void remove(SkillLevelProgress skillLevelProgress) {
+    var newSkillLevel = new ArrayList<>(skillLevels);
+    newSkillLevel.remove(skillLevelProgress);
+    setSkillLevels(newSkillLevel);
+  }
+
+  public void remove(AMS ams) {
+    var newAmses = new ArrayList<>(amses);
+    newAmses.remove(ams);
+    setAmses(newAmses);
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/input/TraceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/input/TraceService.java
@@ -57,4 +57,11 @@ public interface TraceService {
       List<UUID> amsIds,
       List<UUID> skillLevelIds,
       List<UUID> additionalSkillProgressIds);
+
+  void unassociateTrace(
+      User user,
+      UUID traceId,
+      List<UUID> amsIds,
+      List<UUID> skillLevelIds,
+      List<UUID> additionalSkillProgressIds);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
@@ -36,10 +36,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -273,7 +270,7 @@ public class TraceServiceImpl implements TraceService {
 
     traceRepository.save(trace);
     log.info(
-        "Trace {} successfully associated with amses : {} - skill level progress {} - additonal"
+        "Trace {} successfully associated with amses : {} - skill level progress {} - additional"
             + " skill progress {}",
         trace,
         amsIds,
@@ -358,6 +355,99 @@ public class TraceServiceImpl implements TraceService {
                   .findAny()
                   .orElseThrow(UserNotAuthorizedException::new);
           trace.add(additionalSkillProgress);
+        });
+  }
+
+  @Override
+  public void unassociateTrace(
+      User user,
+      UUID traceId,
+      List<UUID> amsIds,
+      List<UUID> skillLevelIds,
+      List<UUID> additionalSkillProgressIds) {
+    var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
+    checkIfUserIsAuthorizedOnTrace(user, trace);
+
+    var student = studentService.getStudentById(user.getId());
+    unassociateAdditionalSkillProgress(student, trace, additionalSkillProgressIds);
+    unassociateAms(student, trace, amsIds);
+    unassociateSkillLevel(student, trace, skillLevelIds);
+
+    traceRepository.save(trace);
+    log.info(
+        "Trace {} successfully unassociated with amses : {} - skill level progress {} - additional"
+            + " skill progress {}",
+        trace,
+        amsIds,
+        skillLevelIds,
+        additionalSkillProgressIds);
+  }
+
+  private void unassociateAdditionalSkillProgress(
+      Student student, Trace trace, List<UUID> additionalSkillProgressIds) {
+    if (!new HashSet<>(
+            trace.getAdditionalSkillProgresses().stream()
+                .map(AdditionalSkillProgress::getId)
+                .toList())
+        .containsAll(additionalSkillProgressIds)) {
+      log.error(
+          "{} tried to unassociate trace with an additional skill that is not associated. ids : "
+              + " {}",
+          student,
+          additionalSkillProgressIds);
+      throw new UserNotAuthorizedException();
+    }
+    var studentAdditionalSkillProgress =
+        additionalSkillProgressRepository.findAllByStudent(student);
+    additionalSkillProgressIds.forEach(
+        id -> {
+          var progress =
+              studentAdditionalSkillProgress.stream()
+                  .filter(s -> id.equals(s.getId()))
+                  .findAny()
+                  .orElseThrow(UserNotAuthorizedException::new);
+          trace.remove(progress);
+        });
+  }
+
+  private void unassociateSkillLevel(Student student, Trace trace, List<UUID> skillLevelIds) {
+    if (!new HashSet<>(trace.getSkillLevels().stream().map(SkillLevelProgress::getId).toList())
+        .containsAll(skillLevelIds)) {
+      log.error(
+          "{} tried to unassociate trace with a skill level that is not associated. ids :  {}",
+          student,
+          skillLevelIds);
+      throw new UserNotAuthorizedException();
+    }
+    var studentSkillLevelProgress = skillLevelProgressRepository.findAllByStudent(student);
+    skillLevelIds.forEach(
+        id -> {
+          var progress =
+              studentSkillLevelProgress.stream()
+                  .filter(s -> id.equals(s.getId()))
+                  .findAny()
+                  .orElseThrow(UserNotAuthorizedException::new);
+          trace.remove(progress);
+        });
+  }
+
+  private void unassociateAms(Student student, Trace trace, List<UUID> amsIds) {
+    if (!new HashSet<>(trace.getAmses().stream().map(AMS::getId).toList()).containsAll(amsIds)) {
+      log.error(
+          "{} tried to unassociate trace with an ams that is not associated. ids :  {}",
+          student,
+          amsIds);
+      throw new UserNotAuthorizedException();
+    }
+    var studentAmses = amsRepository.findAllByStudent(student);
+    amsIds.forEach(
+        id -> {
+          var ams =
+              studentAmses.stream()
+                  .filter(s -> id.equals(s.getId()))
+                  .findAny()
+                  .orElseThrow(UserNotAuthorizedException::new);
+          trace.remove(ams);
         });
   }
 

--- a/src/test/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImplTest.java
@@ -56,13 +56,14 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@ActiveProfiles("test")
 public class TraceServiceImplTest {
   @Mock private TraceRepository traceRepository;
   @Mock private StudentRepository studentRepository;
@@ -626,5 +627,140 @@ public class TraceServiceImplTest {
         () ->
             traceService.associateTrace(
                 student.getUser(), trace.getId(), List.of(), List.of(fakeSkillLevelId), List.of()));
+  }
+
+  @Test
+  void givenValidTraceAndIds_shouldUnassociateAllAndSave() {
+    BddLogger.given(
+        "a trace belonging to the student with AMS, SkillLevels and AdditionalSkills associated");
+    Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+
+    AMS ams = AMSFixture.create().toModel();
+    SkillLevelProgress skillLevel =
+        SkillLevelProgressFixture.create(student, SkillLevelFixture.create().toModel()).toModel();
+    AdditionalSkillProgress additional = AdditionalSkillProgressFixture.create().toModel();
+
+    trace.add(ams);
+    trace.add(skillLevel);
+    trace.add(additional);
+
+    when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
+    when(amsRepository.findAllByStudent(any(Student.class))).thenReturn(List.of(ams));
+    when(skillLevelProgressRepository.findAllByStudent(any(Student.class)))
+        .thenReturn(List.of(skillLevel));
+    when(additionalSkillProgressRepository.findAllByStudent(any(Student.class)))
+        .thenReturn(List.of(additional));
+    when(studentService.getStudentById(any(UUID.class))).thenReturn(student);
+
+    BddLogger.when("unassociating AMS, SkillLevels and AdditionalSkills");
+    traceService.unassociateTrace(
+        student.getUser(),
+        trace.getId(),
+        List.of(ams.getId()),
+        List.of(skillLevel.getId()),
+        List.of(additional.getId()));
+
+    BddLogger.then("trace should be unassociated and saved");
+    verify(traceRepository).save(trace);
+    assertFalse(trace.getAmses().contains(ams));
+    assertFalse(trace.getSkillLevels().contains(skillLevel));
+    assertFalse(trace.getAdditionalSkillProgresses().contains(additional));
+  }
+
+  @Test
+  void givenNonExistentTrace_shouldThrowTraceNotFoundException_whenUnassociating() {
+    BddLogger.given("a non-existent trace for unassociation");
+    UUID traceId = UUID.randomUUID();
+    when(traceRepository.findById(traceId)).thenReturn(Optional.empty());
+
+    BddLogger.when("unassociating a trace that does not exist");
+    TraceNotFoundException ex =
+        assertThrows(
+            TraceNotFoundException.class,
+            () ->
+                traceService.unassociateTrace(
+                    student.getUser(), traceId, List.of(), List.of(), List.of()));
+
+    BddLogger.then("TRACE_NOT_FOUND should be thrown");
+    assertEquals(EErrorCode.TRACE_NOT_FOUND, ex.getErrorCode());
+  }
+
+  @Test
+  void givenTraceOfAnotherUser_shouldThrowUserNotAuthorizedException_whenUnassociating() {
+    BddLogger.given("a trace belonging to another user");
+    User otherUser = UserFixture.create().toModel();
+    Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+    when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
+
+    BddLogger.when("unassociating with another user");
+    UserNotAuthorizedException ex =
+        assertThrows(
+            UserNotAuthorizedException.class,
+            () ->
+                traceService.unassociateTrace(
+                    otherUser, trace.getId(), List.of(), List.of(), List.of()));
+
+    BddLogger.then("USER_NOT_AUTHORIZED should be thrown");
+    assertEquals(EErrorCode.USER_NOT_AUTHORIZED, ex.getErrorCode());
+  }
+
+  @Test
+  void givenTraceWithoutMatchingAms_shouldThrowUserNotAuthorizedException() {
+    BddLogger.given("a trace that does not have the given AMS associated");
+    Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+    when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
+    when(studentService.getStudentById(any(UUID.class))).thenReturn(student);
+
+    UUID fakeAmsId = UUID.randomUUID();
+    when(amsRepository.findAllByStudent(any(Student.class)))
+        .thenReturn(List.of(AMSFixture.create().toModel()));
+
+    BddLogger.when("unassociating a non-associated AMS");
+    assertThrows(
+        UserNotAuthorizedException.class,
+        () ->
+            traceService.unassociateTrace(
+                student.getUser(), trace.getId(), List.of(fakeAmsId), List.of(), List.of()));
+  }
+
+  @Test
+  void givenTraceWithoutMatchingSkillLevel_shouldThrowUserNotAuthorizedException() {
+    BddLogger.given("a trace that does not have the given SkillLevel associated");
+    Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+    when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
+    when(studentService.getStudentById(any(UUID.class))).thenReturn(student);
+
+    UUID fakeSkillLevelId = UUID.randomUUID();
+    when(skillLevelProgressRepository.findAllByStudent(any(Student.class)))
+        .thenReturn(
+            List.of(
+                SkillLevelProgressFixture.create(student, SkillLevelFixture.create().toModel())
+                    .toModel()));
+
+    BddLogger.when("unassociating a non-associated SkillLevel");
+    assertThrows(
+        UserNotAuthorizedException.class,
+        () ->
+            traceService.unassociateTrace(
+                student.getUser(), trace.getId(), List.of(), List.of(fakeSkillLevelId), List.of()));
+  }
+
+  @Test
+  void givenTraceWithoutMatchingAdditionalSkill_shouldThrowUserNotAuthorizedException() {
+    BddLogger.given("a trace that does not have the given AdditionalSkill associated");
+    Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+    when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
+    when(studentService.getStudentById(any(UUID.class))).thenReturn(student);
+
+    UUID fakeAdditionalId = UUID.randomUUID();
+    when(additionalSkillProgressRepository.findAllByStudent(any(Student.class)))
+        .thenReturn(List.of(AdditionalSkillProgressFixture.create().toModel()));
+
+    BddLogger.when("unassociating a non-associated AdditionalSkill");
+    assertThrows(
+        UserNotAuthorizedException.class,
+        () ->
+            traceService.unassociateTrace(
+                student.getUser(), trace.getId(), List.of(), List.of(), List.of(fakeAdditionalId)));
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
introduce new endpoint POST `/me/traces/unasociated/{traceId}`

this endpoint is similar to the associated endpoint, we can pass multiple `AMS`, `SkillLevelProgress` or `AdditionalSkillProgress` that we want to unassociate

---

### Reference to an Issue, Feature, Task, User Story or another PR

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/712

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
