### PR TITLE
feat: introduce entity grapher to improve fetching data

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/additionalskill/infrastructure/adapter/mapper/AdditionalSkillMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/additionalskill/infrastructure/adapter/mapper/AdditionalSkillMapper.java
@@ -2,10 +2,14 @@ package fr.avenirsesr.portfolio.additionalskill.infrastructure.adapter.mapper;
 
 import fr.avenirsesr.portfolio.additionalskill.domain.model.AdditionalSkill;
 import fr.avenirsesr.portfolio.additionalskill.infrastructure.adapter.model.AdditionalSkillEntity;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 
-public interface AdditionalSkillMapper {
+public class AdditionalSkillMapper implements Mapper<AdditionalSkillEntity, AdditionalSkill> {
 
-  static AdditionalSkill toDomain(AdditionalSkillEntity entity) {
+  public static final AdditionalSkillMapper INSTANCE = new AdditionalSkillMapper();
+
+  @Override
+  public AdditionalSkill toDomain(AdditionalSkillEntity entity) {
     return AdditionalSkill.toDomain(
         entity.getId(),
         entity.getExternalSkillId(),
@@ -16,7 +20,8 @@ public interface AdditionalSkillMapper {
         entity.getUpdatedAt());
   }
 
-  static AdditionalSkillEntity fromDomain(AdditionalSkill domain) {
+  @Override
+  public AdditionalSkillEntity fromDomain(AdditionalSkill domain) {
     return AdditionalSkillEntity.of(
         domain.getId(),
         domain.getExternalSkillId(),

--- a/src/main/java/fr/avenirsesr/portfolio/additionalskill/infrastructure/adapter/repository/AdditionalSkillDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/additionalskill/infrastructure/adapter/repository/AdditionalSkillDatabaseRepository.java
@@ -18,10 +18,7 @@ public class AdditionalSkillDatabaseRepository
 
   public AdditionalSkillDatabaseRepository(AdditionalSkillJpaRepository jpaRepository) {
     super(
-        jpaRepository,
-        jpaRepository,
-        AdditionalSkillMapper::fromDomain,
-        AdditionalSkillMapper::toDomain);
+        jpaRepository, jpaRepository, AdditionalSkillEntity.class, AdditionalSkillMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 
@@ -29,7 +26,7 @@ public class AdditionalSkillDatabaseRepository
   public Optional<AdditionalSkill> findByExternalSkillId(UUID externalSkillId) {
     return jpaRepository
         .findByExternalSkillId(externalSkillId)
-        .map(AdditionalSkillMapper::toDomain);
+        .map(AdditionalSkillMapper.INSTANCE::toDomain);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/additionalskill/infrastructure/adapter/seeder/AdditionalSkillSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/additionalskill/infrastructure/adapter/seeder/AdditionalSkillSeeder.java
@@ -39,7 +39,7 @@ public class AdditionalSkillSeeder {
                 externalSkill ->
                     additionalSkillSyncService
                         .getOrCreateFromExternalSkill(externalSkill.id())
-                        .map(AdditionalSkillMapper::fromDomain)
+                        .map(AdditionalSkillMapper.INSTANCE::fromDomain)
                         .orElse(null))
             .filter(entity -> entity != null)
             .toList();

--- a/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/mapper/AMSMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/mapper/AMSMapper.java
@@ -3,25 +3,49 @@ package fr.avenirsesr.portfolio.ams.infrastructure.adapter.mapper;
 import fr.avenirsesr.portfolio.ams.domain.model.AMS;
 import fr.avenirsesr.portfolio.ams.infrastructure.adapter.model.AMSEntity;
 import fr.avenirsesr.portfolio.ams.infrastructure.adapter.model.AMSTranslationEntity;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.common.language.infrastructure.adapter.utils.TranslationUtil;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
 
-public interface AMSMapper {
-  static AMSEntity fromDomain(AMS ams) {
+public class AMSMapper implements Mapper<AMSEntity, AMS> {
+  public static final AMSMapper INSTANCE = new AMSMapper();
+
+  @Override
+  public AMSEntity fromDomain(AMS ams) {
     return AMSEntity.of(
         ams.getId(),
-        StudentMapper.fromDomain(ams.getStudent()),
+        StudentMapper.INSTANCE.fromDomain(ams.getStudent()),
         ams.getStatus(),
         ams.getStartDate(),
         ams.getEndDate());
   }
 
-  static AMS toDomain(AMSEntity entity) {
+  @Override
+  public AMS toDomain(AMSEntity entity) {
     AMSTranslationEntity translationEntity =
         TranslationUtil.getTranslation(entity.getTranslations());
     return AMS.toDomain(
         entity.getId(),
-        StudentMapper.toDomain(entity.getStudent()),
+        StudentMapper.INSTANCE.toDomain(entity.getStudent()),
+        translationEntity.getTitle(),
+        entity.getStartDate(),
+        entity.getEndDate(),
+        entity.getStatus(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  @Override
+  public AMS toDomain(AMSEntity entity, EntityGrapher<?> graph) {
+    AMSTranslationEntity translationEntity =
+        TranslationUtil.getTranslation(entity.getTranslations());
+    var attributes = graph.attributes();
+    return AMS.toDomain(
+        entity.getId(),
+        attributes.contains("student")
+            ? StudentMapper.INSTANCE.toDomain(entity.getStudent(), graph.from("student"))
+            : null,
         translationEntity.getTitle(),
         entity.getStartDate(),
         entity.getEndDate(),

--- a/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/mapper/CohortMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/mapper/CohortMapper.java
@@ -2,30 +2,39 @@ package fr.avenirsesr.portfolio.ams.infrastructure.adapter.mapper;
 
 import fr.avenirsesr.portfolio.ams.domain.model.Cohort;
 import fr.avenirsesr.portfolio.ams.infrastructure.adapter.model.CohortEntity;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper.TrainingPathMapper;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
 import java.util.stream.Collectors;
 
-public interface CohortMapper {
-  static CohortEntity fromDomain(Cohort cohort) {
+public class CohortMapper implements Mapper<CohortEntity, Cohort> {
+  public static final CohortMapper INSTANCE = new CohortMapper();
+
+  @Override
+  public CohortEntity fromDomain(Cohort cohort) {
 
     return CohortEntity.of(
         cohort.getId(),
         cohort.getName(),
         cohort.getDescription(),
-        cohort.getUsers().stream().map(UserMapper::fromDomain).collect(Collectors.toSet()),
-        TrainingPathMapper.fromDomain(cohort.getTrainingPath()),
-        cohort.getAmsSet().stream().map(AMSMapper::fromDomain).collect(Collectors.toSet()));
+        cohort.getUsers().stream().map(UserMapper.INSTANCE::fromDomain).collect(Collectors.toSet()),
+        TrainingPathMapper.INSTANCE.fromDomain(cohort.getTrainingPath()),
+        cohort.getAmsSet().stream()
+            .map(AMSMapper.INSTANCE::fromDomain)
+            .collect(Collectors.toSet()));
   }
 
-  static Cohort toDomain(CohortEntity entity) {
+  @Override
+  public Cohort toDomain(CohortEntity entity) {
     return Cohort.toDomain(
         entity.getId(),
         entity.getName(),
         entity.getDescription(),
-        TrainingPathMapper.toDomain(entity.getTrainingPath()),
-        entity.getUsers().stream().map(UserMapper::toDomain).collect(Collectors.toSet()),
-        entity.getAmsEntities().stream().map(AMSMapper::toDomain).collect(Collectors.toSet()),
+        TrainingPathMapper.INSTANCE.toDomain(entity.getTrainingPath()),
+        entity.getUsers().stream().map(UserMapper.INSTANCE::toDomain).collect(Collectors.toSet()),
+        entity.getAmsEntities().stream()
+            .map(AMSMapper.INSTANCE::toDomain)
+            .collect(Collectors.toSet()),
         entity.getCreatedAt(),
         entity.getUpdatedAt());
   }

--- a/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/repository/AMSDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/repository/AMSDatabaseRepository.java
@@ -21,7 +21,7 @@ public class AMSDatabaseRepository extends GenericUserJpaRepositoryAdapter<AMS, 
     implements AMSRepository {
 
   public AMSDatabaseRepository(AMSJpaRepository repository) {
-    super(repository, repository, AMSMapper::fromDomain, AMSMapper::toDomain);
+    super(repository, repository, AMSEntity.class, AMSMapper.INSTANCE);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/repository/CohortDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/repository/CohortDatabaseRepository.java
@@ -13,7 +13,7 @@ public class CohortDatabaseRepository extends GenericJpaRepositoryAdapter<Cohort
   private final CohortJpaRepository jpaRepository;
 
   public CohortDatabaseRepository(CohortJpaRepository repository) {
-    super(repository, repository, CohortMapper::fromDomain, CohortMapper::toDomain);
+    super(repository, repository, CohortEntity.class, CohortMapper.INSTANCE);
     this.jpaRepository = repository;
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/seeder/AMSSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/seeder/AMSSeeder.java
@@ -133,7 +133,9 @@ public class AMSSeeder {
       var skillLevels = getRandomSkillLevels(savedSkillLevels);
       skillLevels.forEach(
           level ->
-              level.setAmses(Stream.concat(level.getAmses().stream(), Stream.of(ams)).toList()));
+              level.setAmses(
+                  Stream.concat(level.getAmses().stream(), Stream.of(ams))
+                      .collect(Collectors.toSet())));
       skillLevelProgressList.addAll(skillLevels);
 
       var traces = getRandomTraces(savedTraces);

--- a/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/seeder/CohortSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/seeder/CohortSeeder.java
@@ -68,7 +68,7 @@ public class CohortSeeder {
               .toEntity());
     }
 
-    cohortRepository.saveAll(cohorts.stream().map(CohortMapper::toDomain).toList());
+    cohortRepository.saveAll(cohorts.stream().map(CohortMapper.INSTANCE::toDomain).toList());
     log.info("✔ {} cohorts created", cohorts.size());
 
     return cohorts;

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/mapper/TraceAttachmentMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/mapper/TraceAttachmentMapper.java
@@ -1,36 +1,41 @@
 package fr.avenirsesr.portfolio.file.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.file.domain.model.TraceAttachment;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.model.TraceAttachmentEntity;
 import fr.avenirsesr.portfolio.trace.infrastructure.adapter.mapper.TraceMapper;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
 
-public interface TraceAttachmentMapper {
-  static TraceAttachmentEntity fromDomain(TraceAttachment traceAttachment) {
+public class TraceAttachmentMapper implements Mapper<TraceAttachmentEntity, TraceAttachment> {
+  public static final TraceAttachmentMapper INSTANCE = new TraceAttachmentMapper();
+
+  @Override
+  public TraceAttachmentEntity fromDomain(TraceAttachment traceAttachment) {
     return TraceAttachmentEntity.of(
         traceAttachment.getId(),
-        TraceMapper.fromDomain(traceAttachment.getTrace()),
+        TraceMapper.INSTANCE.fromDomain(traceAttachment.getTrace()),
         traceAttachment.getName(),
         traceAttachment.getFileType(),
         traceAttachment.getSize(),
         traceAttachment.getVersion(),
         traceAttachment.isActiveVersion(),
         traceAttachment.getUri(),
-        UserMapper.fromDomain(traceAttachment.getUploadedBy()),
+        UserMapper.INSTANCE.fromDomain(traceAttachment.getUploadedBy()),
         traceAttachment.getUploadedAt());
   }
 
-  static TraceAttachment toDomain(TraceAttachmentEntity entity) {
+  @Override
+  public TraceAttachment toDomain(TraceAttachmentEntity entity) {
     return TraceAttachment.toDomain(
         entity.getId(),
-        TraceMapper.toDomain(entity.getTrace()),
+        TraceMapper.INSTANCE.toDomain(entity.getTrace()),
         entity.getName(),
         entity.getFileType(),
         entity.getSize(),
         entity.getVersion(),
         entity.isActiveVersion(),
         entity.getUri(),
-        UserMapper.toDomain(entity.getUploadedBy()),
+        UserMapper.INSTANCE.toDomain(entity.getUploadedBy()),
         entity.getUploadedAt(),
         entity.getCreatedAt(),
         entity.getUpdatedAt());

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/mapper/UserPhotoMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/mapper/UserPhotoMapper.java
@@ -1,15 +1,19 @@
 package fr.avenirsesr.portfolio.file.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.file.domain.model.UserPhoto;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.model.UserPhotoEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
 
-public interface UserPhotoMapper {
-  static UserPhotoEntity fromDomain(UserPhoto userPhoto) {
+public class UserPhotoMapper implements Mapper<UserPhotoEntity, UserPhoto> {
+  public static UserPhotoMapper INSTANCE = new UserPhotoMapper();
+
+  @Override
+  public UserPhotoEntity fromDomain(UserPhoto userPhoto) {
     return UserPhotoEntity.of(
         userPhoto.getId(),
         userPhoto.getName(),
-        UserMapper.fromDomain(userPhoto.getUser()),
+        UserMapper.INSTANCE.fromDomain(userPhoto.getUser()),
         userPhoto.getUserCategory(),
         userPhoto.getUserPhotoType(),
         userPhoto.getFileType(),
@@ -17,11 +21,12 @@ public interface UserPhotoMapper {
         userPhoto.getVersion(),
         userPhoto.isActiveVersion(),
         userPhoto.getUri(),
-        UserMapper.fromDomain(userPhoto.getUploadedBy()),
+        UserMapper.INSTANCE.fromDomain(userPhoto.getUploadedBy()),
         userPhoto.getUploadedAt());
   }
 
-  static UserPhoto toDomain(UserPhotoEntity entity) {
+  @Override
+  public UserPhoto toDomain(UserPhotoEntity entity) {
     return UserPhoto.toDomain(
         entity.getId(),
         entity.getName(),
@@ -30,9 +35,9 @@ public interface UserPhotoMapper {
         entity.getVersion(),
         entity.isActiveVersion(),
         entity.getUri(),
-        UserMapper.toDomain(entity.getUploadedBy()),
+        UserMapper.INSTANCE.toDomain(entity.getUploadedBy()),
         entity.getUploadedAt(),
-        UserMapper.toDomain(entity.getUser()),
+        UserMapper.INSTANCE.toDomain(entity.getUser()),
         entity.getUserCategory(),
         entity.getUserPhotoType(),
         entity.getCreatedAt(),

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/repository/TraceAttachmentDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/repository/TraceAttachmentDatabaseRepository.java
@@ -16,10 +16,7 @@ public class TraceAttachmentDatabaseRepository
     implements TraceAttachmentRepository {
   public TraceAttachmentDatabaseRepository(TraceAttachmentJpaRepository jpaRepository) {
     super(
-        jpaRepository,
-        jpaRepository,
-        TraceAttachmentMapper::fromDomain,
-        TraceAttachmentMapper::toDomain);
+        jpaRepository, jpaRepository, TraceAttachmentEntity.class, TraceAttachmentMapper.INSTANCE);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/repository/UserPhotoDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/repository/UserPhotoDatabaseRepository.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Repository;
 public class UserPhotoDatabaseRepository
     extends GenericJpaRepositoryAdapter<UserPhoto, UserPhotoEntity> implements UserPhotoRepository {
   public UserPhotoDatabaseRepository(UserPhotoJpaRepository jpaRepository) {
-    super(jpaRepository, jpaRepository, UserPhotoMapper::fromDomain, UserPhotoMapper::toDomain);
+    super(jpaRepository, jpaRepository, UserPhotoEntity.class, UserPhotoMapper.INSTANCE);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class UserPhotoDatabaseRepository
             UserResourceSpecification.ofUser(user, userCategory, type)
                 .and(UserResourceSpecification.onlyActiveVersion()))
         .stream()
-        .map(UserPhotoMapper::toDomain)
+        .map(UserPhotoMapper.INSTANCE::toDomain)
         .findAny();
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/seeder/TraceAttachmentSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/seeder/TraceAttachmentSeeder.java
@@ -46,7 +46,7 @@ public class TraceAttachmentSeeder {
     }
 
     attachmentRepository.saveAll(
-        attachmentEntities.stream().map(TraceAttachmentMapper::toDomain).toList());
+        attachmentEntities.stream().map(TraceAttachmentMapper.INSTANCE::toDomain).toList());
     log.info("✔ {} traces attachments created", attachmentEntities.size());
     return attachmentEntities;
   }

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/seeder/UserPhotoSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/seeder/UserPhotoSeeder.java
@@ -87,7 +87,8 @@ public class UserPhotoSeeder {
       }
     }
 
-    userPhotoRepository.saveAll(userPhotoEntities.stream().map(UserPhotoMapper::toDomain).toList());
+    userPhotoRepository.saveAll(
+        userPhotoEntities.stream().map(UserPhotoMapper.INSTANCE::toDomain).toList());
     log.info("✔ {} user photos created", userPhotoEntities.size());
     return userPhotoEntities;
   }

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/specification/TraceAttachmentSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/specification/TraceAttachmentSpecification.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.domain.Specification;
 public interface TraceAttachmentSpecification {
   static Specification<TraceAttachmentEntity> ofTrace(Trace trace) {
     return (root, query, criteriaBuilder) ->
-        criteriaBuilder.equal(root.get("trace"), TraceMapper.fromDomain(trace));
+        criteriaBuilder.equal(root.get("trace"), TraceMapper.INSTANCE.fromDomain(trace));
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/specification/UserResourceSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/specification/UserResourceSpecification.java
@@ -12,7 +12,7 @@ public interface UserResourceSpecification {
       User user, EUserCategory userCategory, EUserPhotoType type) {
     return (root, query, criteriaBuilder) ->
         criteriaBuilder.and(
-            criteriaBuilder.equal(root.get("user"), UserMapper.fromDomain(user)),
+            criteriaBuilder.equal(root.get("user"), UserMapper.INSTANCE.fromDomain(user)),
             criteriaBuilder.equal(root.get("userCategory"), userCategory),
             criteriaBuilder.equal(root.get("userPhotoType"), type));
   }

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/InstitutionMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/InstitutionMapper.java
@@ -1,18 +1,24 @@
 package fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.common.language.infrastructure.adapter.utils.TranslationUtil;
 import fr.avenirsesr.portfolio.program.domain.model.Institution;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.InstitutionEntity;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.InstitutionTranslationEntity;
 
-public interface InstitutionMapper {
-  static InstitutionEntity fromDomain(Institution institution) {
+public class InstitutionMapper implements Mapper<InstitutionEntity, Institution> {
+  public static final InstitutionMapper INSTANCE = new InstitutionMapper();
+
+  @Override
+  public InstitutionEntity fromDomain(Institution institution) {
     return InstitutionEntity.of(institution.getId());
   }
 
-  static Institution toDomain(InstitutionEntity entity) {
+  @Override
+  public Institution toDomain(InstitutionEntity entity) {
     InstitutionTranslationEntity translationEntity =
         TranslationUtil.getTranslation(entity.getTranslations());
+
     return Institution.toDomain(
         entity.getId(), translationEntity.getName(), entity.getCreatedAt(), entity.getUpdatedAt());
   }

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/ProgramMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/ProgramMapper.java
@@ -1,26 +1,51 @@
 package fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.common.language.infrastructure.adapter.utils.TranslationUtil;
 import fr.avenirsesr.portfolio.program.domain.model.Program;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.ProgramEntity;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.ProgramTranslationEntity;
 
-public interface ProgramMapper {
-  static ProgramEntity fromDomain(Program program) {
+public class ProgramMapper implements Mapper<ProgramEntity, Program> {
+  public static ProgramMapper INSTANCE = new ProgramMapper();
+
+  @Override
+  public ProgramEntity fromDomain(Program program) {
     return ProgramEntity.of(
         program.getId(),
         program.isAPC(),
-        InstitutionMapper.fromDomain(program.getInstitution()),
+        InstitutionMapper.INSTANCE.fromDomain(program.getInstitution()),
         program.getDurationUnit().orElse(null),
         program.getDurationCount().orElse(null));
   }
 
-  static Program toDomain(ProgramEntity programEntity) {
+  @Override
+  public Program toDomain(ProgramEntity programEntity) {
     ProgramTranslationEntity translationEntity =
         TranslationUtil.getTranslation(programEntity.getTranslations());
     return Program.toDomain(
         programEntity.getId(),
-        InstitutionMapper.toDomain(programEntity.getInstitution()),
+        InstitutionMapper.INSTANCE.toDomain(programEntity.getInstitution()),
+        translationEntity.getName(),
+        programEntity.isAPC(),
+        programEntity.getDurationUnit(),
+        programEntity.getDurationCount(),
+        programEntity.getCreatedAt(),
+        programEntity.getUpdatedAt());
+  }
+
+  @Override
+  public Program toDomain(ProgramEntity programEntity, EntityGrapher<?> graph) {
+    var attributes = graph.attributes();
+    ProgramTranslationEntity translationEntity =
+        TranslationUtil.getTranslation(programEntity.getTranslations());
+
+    return Program.toDomain(
+        programEntity.getId(),
+        attributes.contains("institution")
+            ? InstitutionMapper.INSTANCE.toDomain(programEntity.getInstitution())
+            : null,
         translationEntity.getName(),
         programEntity.isAPC(),
         programEntity.getDurationUnit(),

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/SkillLevelMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/SkillLevelMapper.java
@@ -1,21 +1,23 @@
 package fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.common.language.infrastructure.adapter.utils.TranslationUtil;
 import fr.avenirsesr.portfolio.program.domain.model.SkillLevel;
-import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.SkillEntity;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.SkillLevelEntity;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.SkillLevelTranslationEntity;
 
-public interface SkillLevelMapper {
-  static SkillLevelEntity fromDomain(SkillLevel skillLevel) {
-    return SkillLevelEntity.of(skillLevel.getId(), SkillMapper.fromDomain(skillLevel.getSkill()));
+public class SkillLevelMapper implements Mapper<SkillLevelEntity, SkillLevel> {
+  public static final SkillLevelMapper INSTANCE = new SkillLevelMapper();
+
+  @Override
+  public SkillLevelEntity fromDomain(SkillLevel skillLevel) {
+    return SkillLevelEntity.of(
+        skillLevel.getId(), SkillMapper.INSTANCE.fromDomain(skillLevel.getSkill()));
   }
 
-  static SkillLevelEntity fromDomain(SkillLevel skillLevel, SkillEntity skillEntity) {
-    return SkillLevelEntity.of(skillLevel.getId(), skillEntity);
-  }
-
-  static SkillLevel toDomain(SkillLevelEntity skillLevelEntity) {
+  @Override
+  public SkillLevel toDomain(SkillLevelEntity skillLevelEntity) {
     SkillLevelTranslationEntity skillLevelTranslationEntity =
         TranslationUtil.getTranslation(skillLevelEntity.getTranslations());
 
@@ -23,7 +25,24 @@ public interface SkillLevelMapper {
         skillLevelEntity.getId(),
         skillLevelTranslationEntity.getName(),
         skillLevelTranslationEntity.getDescription(),
-        SkillMapper.toDomain(skillLevelEntity.getSkill()),
+        SkillMapper.INSTANCE.toDomain(skillLevelEntity.getSkill()),
+        skillLevelEntity.getCreatedAt(),
+        skillLevelEntity.getUpdatedAt());
+  }
+
+  @Override
+  public SkillLevel toDomain(SkillLevelEntity skillLevelEntity, EntityGrapher<?> graph) {
+    SkillLevelTranslationEntity skillLevelTranslationEntity =
+        TranslationUtil.getTranslation(skillLevelEntity.getTranslations());
+    var attributes = graph.attributes();
+
+    return SkillLevel.toDomain(
+        skillLevelEntity.getId(),
+        skillLevelTranslationEntity.getName(),
+        skillLevelTranslationEntity.getDescription(),
+        attributes.contains("skill")
+            ? SkillMapper.INSTANCE.toDomain(skillLevelEntity.getSkill())
+            : null,
         skillLevelEntity.getCreatedAt(),
         skillLevelEntity.getUpdatedAt());
   }

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/SkillMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/SkillMapper.java
@@ -1,16 +1,21 @@
 package fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.common.language.infrastructure.adapter.utils.TranslationUtil;
 import fr.avenirsesr.portfolio.program.domain.model.Skill;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.SkillEntity;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.SkillTranslationEntity;
 
-public interface SkillMapper {
-  static SkillEntity fromDomain(Skill skill) {
+public class SkillMapper implements Mapper<SkillEntity, Skill> {
+  public static SkillMapper INSTANCE = new SkillMapper();
+
+  @Override
+  public SkillEntity fromDomain(Skill skill) {
     return SkillEntity.of(skill.getId());
   }
 
-  static Skill toDomain(SkillEntity skillEntity) {
+  @Override
+  public Skill toDomain(SkillEntity skillEntity) {
     SkillTranslationEntity skillTranslationEntity =
         TranslationUtil.getTranslation(skillEntity.getTranslations());
 

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/TrainingPathMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/mapper/TrainingPathMapper.java
@@ -1,52 +1,65 @@
 package fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.program.domain.model.TrainingPath;
-import fr.avenirsesr.portfolio.program.infrastructure.adapter.dto.StudentTrainingPathSummaryDTO;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.TrainingPathEntity;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public interface TrainingPathMapper {
-  static TrainingPathEntity fromDomain(TrainingPath trainingPath) {
+public class TrainingPathMapper implements Mapper<TrainingPathEntity, TrainingPath> {
+  public static TrainingPathMapper INSTANCE = new TrainingPathMapper();
+
+  @Override
+  public TrainingPathEntity fromDomain(TrainingPath trainingPath) {
     var entity =
         new TrainingPathEntity(
-            trainingPath.getId(), ProgramMapper.fromDomain(trainingPath.getProgram()), Set.of());
+            trainingPath.getId(),
+            ProgramMapper.INSTANCE.fromDomain(trainingPath.getProgram()),
+            Set.of());
 
     entity.setSkillLevels(
         trainingPath.getSkillLevels().stream()
-            .map(
-                skillLevel ->
-                    SkillLevelMapper.fromDomain(
-                        skillLevel, SkillMapper.fromDomain(skillLevel.getSkill())))
+            .map(SkillLevelMapper.INSTANCE::fromDomain)
             .collect(Collectors.toSet()));
 
     return entity;
   }
 
-  static TrainingPath toDomain(TrainingPathEntity trainingPathEntity) {
+  @Override
+  public TrainingPath toDomain(TrainingPathEntity trainingPathEntity) {
     var trainingPath =
         TrainingPath.toDomain(
             trainingPathEntity.getId(),
-            ProgramMapper.toDomain(trainingPathEntity.getProgram()),
+            ProgramMapper.INSTANCE.toDomain(trainingPathEntity.getProgram()),
             Set.of(),
             trainingPathEntity.getCreatedAt(),
             trainingPathEntity.getUpdatedAt());
 
     trainingPath.setSkillLevels(
         trainingPathEntity.getSkillLevels().stream()
-            .map(SkillLevelMapper::toDomain)
+            .map(SkillLevelMapper.INSTANCE::toDomain)
             .collect(Collectors.toSet()));
 
     return trainingPath;
   }
 
-  static TrainingPath toDomainWithoutRecursion(
-      StudentTrainingPathSummaryDTO studentTrainingPathSummaryDTO) {
+  @Override
+  public TrainingPath toDomain(TrainingPathEntity trainingPathEntity, EntityGrapher<?> graph) {
+    var attributes = graph.attributes();
     return TrainingPath.toDomain(
-        studentTrainingPathSummaryDTO.id(),
-        ProgramMapper.toDomain(studentTrainingPathSummaryDTO.program()),
-        Set.of(),
-        studentTrainingPathSummaryDTO.program().getCreatedAt(),
-        studentTrainingPathSummaryDTO.program().getUpdatedAt());
+        trainingPathEntity.getId(),
+        attributes.contains("program")
+            ? ProgramMapper.INSTANCE.toDomain(
+                trainingPathEntity.getProgram(), graph.from("program"))
+            : null,
+        attributes.contains("skillLevels")
+            ? trainingPathEntity.getSkillLevels().stream()
+                .map(
+                    entity -> SkillLevelMapper.INSTANCE.toDomain(entity, graph.from("skillLevels")))
+                .collect(Collectors.toSet())
+            : Set.of(),
+        trainingPathEntity.getCreatedAt(),
+        trainingPathEntity.getUpdatedAt());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/InstitutionDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/InstitutionDatabaseRepository.java
@@ -14,7 +14,7 @@ public class InstitutionDatabaseRepository
   private final InstitutionJpaRepository jpaRepository;
 
   public InstitutionDatabaseRepository(InstitutionJpaRepository jpaRepository) {
-    super(jpaRepository, jpaRepository, InstitutionMapper::fromDomain, InstitutionMapper::toDomain);
+    super(jpaRepository, jpaRepository, InstitutionEntity.class, InstitutionMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/ProgramDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/ProgramDatabaseRepository.java
@@ -13,7 +13,7 @@ public class ProgramDatabaseRepository extends GenericJpaRepositoryAdapter<Progr
   private final ProgramJpaRepository jpaRepository;
 
   public ProgramDatabaseRepository(ProgramJpaRepository jpaRepository) {
-    super(jpaRepository, jpaRepository, ProgramMapper::fromDomain, ProgramMapper::toDomain);
+    super(jpaRepository, jpaRepository, ProgramEntity.class, ProgramMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/SkillDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/SkillDatabaseRepository.java
@@ -13,7 +13,7 @@ public class SkillDatabaseRepository extends GenericJpaRepositoryAdapter<Skill, 
   private final SkillJpaRepository jpaRepository;
 
   public SkillDatabaseRepository(SkillJpaRepository jpaRepository) {
-    super(jpaRepository, jpaRepository, SkillMapper::fromDomain, SkillMapper::toDomain);
+    super(jpaRepository, jpaRepository, SkillEntity.class, SkillMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/SkillLevelDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/SkillLevelDatabaseRepository.java
@@ -4,7 +4,6 @@ import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.repository.Gen
 import fr.avenirsesr.portfolio.program.domain.model.SkillLevel;
 import fr.avenirsesr.portfolio.program.domain.port.output.repository.SkillLevelRepository;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper.SkillLevelMapper;
-import fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper.SkillMapper;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.SkillLevelEntity;
 import org.springframework.stereotype.Component;
 
@@ -13,11 +12,6 @@ public class SkillLevelDatabaseRepository
     extends GenericJpaRepositoryAdapter<SkillLevel, SkillLevelEntity>
     implements SkillLevelRepository {
   public SkillLevelDatabaseRepository(SkillLevelJpaRepository jpaRepository) {
-    super(
-        jpaRepository,
-        jpaRepository,
-        skillLevel ->
-            SkillLevelMapper.fromDomain(skillLevel, SkillMapper.fromDomain(skillLevel.getSkill())),
-        SkillLevelMapper::toDomain);
+    super(jpaRepository, jpaRepository, SkillLevelEntity.class, SkillLevelMapper.INSTANCE);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/TrainingPathDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/program/infrastructure/adapter/repository/TrainingPathDatabaseRepository.java
@@ -14,8 +14,7 @@ public class TrainingPathDatabaseRepository
   private final TrainingPathJpaRepository jpaRepository;
 
   public TrainingPathDatabaseRepository(TrainingPathJpaRepository jpaRepository) {
-    super(
-        jpaRepository, jpaRepository, TrainingPathMapper::fromDomain, TrainingPathMapper::toDomain);
+    super(jpaRepository, jpaRepository, TrainingPathEntity.class, TrainingPathMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/mapper/SelfKnowledgeCategoryMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/mapper/SelfKnowledgeCategoryMapper.java
@@ -1,18 +1,23 @@
 package fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.common.language.infrastructure.adapter.utils.TranslationUtil;
 import fr.avenirsesr.portfolio.selfknowledge.domain.model.SelfKnowledgeCategory;
 import fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.model.SelfKnowledgeCategoryEntity;
 import fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.model.SelfKnowledgeCategoryTranslationEntity;
 
-public interface SelfKnowledgeCategoryMapper {
+public class SelfKnowledgeCategoryMapper
+    implements Mapper<SelfKnowledgeCategoryEntity, SelfKnowledgeCategory> {
+  public static SelfKnowledgeCategoryMapper INSTANCE = new SelfKnowledgeCategoryMapper();
 
-  static SelfKnowledgeCategoryEntity fromDomain(SelfKnowledgeCategory category) {
+  @Override
+  public SelfKnowledgeCategoryEntity fromDomain(SelfKnowledgeCategory category) {
     return SelfKnowledgeCategoryEntity.of(
         category.getId(), category.getType(), category.isMandatory());
   }
 
-  static SelfKnowledgeCategory toDomain(SelfKnowledgeCategoryEntity entity) {
+  @Override
+  public SelfKnowledgeCategory toDomain(SelfKnowledgeCategoryEntity entity) {
     SelfKnowledgeCategoryTranslationEntity translation =
         TranslationUtil.getTranslation(entity.getTranslations());
 

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/mapper/SelfKnowledgeElementMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/mapper/SelfKnowledgeElementMapper.java
@@ -1,29 +1,34 @@
 package fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.selfknowledge.domain.model.SelfKnowledgeElement;
 import fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.model.SelfKnowledgeElementEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
 
-public interface SelfKnowledgeElementMapper {
+public class SelfKnowledgeElementMapper
+    implements Mapper<SelfKnowledgeElementEntity, SelfKnowledgeElement> {
+  public static final SelfKnowledgeElementMapper INSTANCE = new SelfKnowledgeElementMapper();
 
-  static SelfKnowledgeElementEntity fromDomain(SelfKnowledgeElement element) {
+  @Override
+  public SelfKnowledgeElementEntity fromDomain(SelfKnowledgeElement element) {
     return SelfKnowledgeElementEntity.of(
         element.getId(),
-        StudentMapper.fromDomain(element.getStudent()),
+        StudentMapper.INSTANCE.fromDomain(element.getStudent()),
         element.getTitle(),
         element.getDescription(),
         element.getRating(),
-        SelfKnowledgeCategoryMapper.fromDomain(element.getSelfKnowledgeCategory()));
+        SelfKnowledgeCategoryMapper.INSTANCE.fromDomain(element.getSelfKnowledgeCategory()));
   }
 
-  static SelfKnowledgeElement toDomain(SelfKnowledgeElementEntity entity) {
+  @Override
+  public SelfKnowledgeElement toDomain(SelfKnowledgeElementEntity entity) {
     return SelfKnowledgeElement.toDomain(
         entity.getId(),
-        StudentMapper.toDomain(entity.getStudent()),
+        StudentMapper.INSTANCE.toDomain(entity.getStudent()),
         entity.getTitle(),
         entity.getDescription(),
         entity.getRating(),
-        SelfKnowledgeCategoryMapper.toDomain(entity.getSelfKnowledgeCategory()),
+        SelfKnowledgeCategoryMapper.INSTANCE.toDomain(entity.getSelfKnowledgeCategory()),
         entity.getCreatedAt(),
         entity.getUpdatedAt());
   }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/repository/SelfKnowledgeCategoryDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/repository/SelfKnowledgeCategoryDatabaseRepository.java
@@ -21,8 +21,8 @@ public class SelfKnowledgeCategoryDatabaseRepository
     super(
         jpaRepository,
         jpaRepository,
-        SelfKnowledgeCategoryMapper::fromDomain,
-        SelfKnowledgeCategoryMapper::toDomain);
+        SelfKnowledgeCategoryEntity.class,
+        SelfKnowledgeCategoryMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/repository/SelfKnowledgeElementDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/repository/SelfKnowledgeElementDatabaseRepository.java
@@ -28,8 +28,8 @@ public class SelfKnowledgeElementDatabaseRepository
     super(
         jpaRepository,
         jpaRepository,
-        SelfKnowledgeElementMapper::fromDomain,
-        SelfKnowledgeElementMapper::toDomain);
+        SelfKnowledgeElementEntity.class,
+        SelfKnowledgeElementMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 
@@ -47,6 +47,7 @@ public class SelfKnowledgeElementDatabaseRepository
   @Override
   public void deleteAllByStudentAndCategory(Student student, SelfKnowledgeCategory category) {
     jpaRepository.deleteByStudentAndSelfKnowledgeCategory(
-        StudentMapper.fromDomain(student), SelfKnowledgeCategoryMapper.fromDomain(category));
+        StudentMapper.INSTANCE.fromDomain(student),
+        SelfKnowledgeCategoryMapper.INSTANCE.fromDomain(category));
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/specification/SelfKnowledgeCategorySpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/specification/SelfKnowledgeCategorySpecification.java
@@ -14,7 +14,8 @@ public class SelfKnowledgeCategorySpecification {
     return (root, query, criteriaBuilder) -> {
       assert query != null;
       query.distinct(true);
-      return criteriaBuilder.equal(root.join("students"), StudentMapper.fromDomain(student));
+      return criteriaBuilder.equal(
+          root.join("students"), StudentMapper.INSTANCE.fromDomain(student));
     };
   }
 
@@ -31,7 +32,7 @@ public class SelfKnowledgeCategorySpecification {
           .where(
               criteriaBuilder.equal(subRoot.get("id"), root.get("id")),
               criteriaBuilder.equal(
-                  subStudents.get("id"), StudentMapper.fromDomain(student).getId()));
+                  subStudents.get("id"), StudentMapper.INSTANCE.fromDomain(student).getId()));
 
       return criteriaBuilder.not(criteriaBuilder.exists(sub));
     };

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/mapper/DeclaredExperienceMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/mapper/DeclaredExperienceMapper.java
@@ -1,16 +1,22 @@
 package fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructure.adapter.model.DeclaredExperienceEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
 
-public interface DeclaredExperienceMapper {
-  static DeclaredExperienceEntity fromDomain(DeclaredExperience declaredExperience) {
+public class DeclaredExperienceMapper
+    implements Mapper<DeclaredExperienceEntity, DeclaredExperience> {
+  public static final DeclaredExperienceMapper INSTANCE = new DeclaredExperienceMapper();
+
+  @Override
+  public DeclaredExperienceEntity fromDomain(DeclaredExperience declaredExperience) {
     return DeclaredExperienceEntity.of(
         declaredExperience.getId(),
         declaredExperience.getCreatedAt(),
         declaredExperience.getUpdatedAt(),
-        StudentMapper.fromDomain(declaredExperience.getStudent()),
+        StudentMapper.INSTANCE.fromDomain(declaredExperience.getStudent()),
         declaredExperience.getTitle(),
         declaredExperience.getExperienceType(),
         declaredExperience.getOrganization(),
@@ -24,12 +30,37 @@ public interface DeclaredExperienceMapper {
         declaredExperience.getEndDate());
   }
 
-  static DeclaredExperience toDomain(DeclaredExperienceEntity entity) {
+  @Override
+  public DeclaredExperience toDomain(DeclaredExperienceEntity entity) {
     return DeclaredExperience.toDomain(
         entity.getId(),
         entity.getCreatedAt(),
         entity.getUpdatedAt(),
-        StudentMapper.toDomain(entity.getStudent()),
+        StudentMapper.INSTANCE.toDomain(entity.getStudent()),
+        entity.getTitle(),
+        entity.getExperienceType(),
+        entity.getOrganization(),
+        entity.getActivitySector(),
+        entity.getLocation(),
+        entity.getDescription(),
+        entity.getSourceOfInformation(),
+        entity.getSummary(),
+        entity.getExternalLink(),
+        entity.getStartDate(),
+        entity.getEndDate());
+  }
+
+  @Override
+  public DeclaredExperience toDomain(DeclaredExperienceEntity entity, EntityGrapher<?> graph) {
+    var attributes = graph.attributes();
+
+    return DeclaredExperience.toDomain(
+        entity.getId(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt(),
+        attributes.contains("student")
+            ? StudentMapper.INSTANCE.toDomain(entity.getStudent())
+            : null,
         entity.getTitle(),
         entity.getExperienceType(),
         entity.getOrganization(),

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/repository/DeclaredExperienceDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/repository/DeclaredExperienceDatabaseRepository.java
@@ -9,6 +9,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructu
 import fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructure.adapter.specification.DeclaredExperienceSpecification;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.repository.GenericUserJpaRepositoryAdapter;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,14 +21,15 @@ public class DeclaredExperienceDatabaseRepository
     super(
         jpaRepository,
         jpaRepository,
-        DeclaredExperienceMapper::fromDomain,
-        DeclaredExperienceMapper::toDomain);
+        DeclaredExperienceEntity.class,
+        DeclaredExperienceMapper.INSTANCE);
   }
 
   @Override
   public PagedResult<DeclaredExperience> findAllByStudent(
       Student student, PageCriteria pageCriteria) {
     return findAll(
-        hasStudent(student).and(DeclaredExperienceSpecification.ordered()), pageCriteria);
+        hasStudent(student).and(DeclaredExperienceSpecification.ordered()),
+        PageRequest.of(pageCriteria.page(), pageCriteria.pageSize()));
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/infrastructure/adapter/mapper/DeclaredProgramMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/infrastructure/adapter/mapper/DeclaredProgramMapper.java
@@ -1,14 +1,19 @@
 package fr.avenirsesr.portfolio.student.progress.declared.program.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.student.progress.declared.program.domain.model.DeclaredProgram;
 import fr.avenirsesr.portfolio.student.progress.declared.program.infrastructure.adapter.model.DeclaredProgramEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
 
-public interface DeclaredProgramMapper {
-  static DeclaredProgramEntity fromDomain(DeclaredProgram declaredProgram) {
+public class DeclaredProgramMapper implements Mapper<DeclaredProgramEntity, DeclaredProgram> {
+  public static final DeclaredProgramMapper INSTANCE = new DeclaredProgramMapper();
+
+  @Override
+  public DeclaredProgramEntity fromDomain(DeclaredProgram declaredProgram) {
     return DeclaredProgramEntity.of(
         declaredProgram.getId(),
-        StudentMapper.fromDomain(declaredProgram.getStudent()),
+        StudentMapper.INSTANCE.fromDomain(declaredProgram.getStudent()),
         declaredProgram.getStatus(),
         declaredProgram.getTitle(),
         declaredProgram.getDescription(),
@@ -22,10 +27,33 @@ public interface DeclaredProgramMapper {
         declaredProgram.getUpdatedAt());
   }
 
-  static DeclaredProgram toDomain(DeclaredProgramEntity declaredProgram) {
+  @Override
+  public DeclaredProgram toDomain(DeclaredProgramEntity declaredProgram) {
     return DeclaredProgram.of(
         declaredProgram.getId(),
-        StudentMapper.toDomain(declaredProgram.getStudent()),
+        StudentMapper.INSTANCE.toDomain(declaredProgram.getStudent()),
+        declaredProgram.getStatus(),
+        declaredProgram.getTitle(),
+        declaredProgram.getDescription(),
+        declaredProgram.getOrganization(),
+        declaredProgram.getResult(),
+        declaredProgram.getSourceOfInformation(),
+        declaredProgram.getLink(),
+        declaredProgram.getStartDate(),
+        declaredProgram.getEndDate(),
+        declaredProgram.getCreatedAt(),
+        declaredProgram.getUpdatedAt());
+  }
+
+  @Override
+  public DeclaredProgram toDomain(DeclaredProgramEntity declaredProgram, EntityGrapher<?> graph) {
+    var attributes = graph.attributes();
+
+    return DeclaredProgram.of(
+        declaredProgram.getId(),
+        attributes.contains("student")
+            ? StudentMapper.INSTANCE.toDomain(declaredProgram.getStudent())
+            : null,
         declaredProgram.getStatus(),
         declaredProgram.getTitle(),
         declaredProgram.getDescription(),

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/infrastructure/adapter/repository/DeclaredProgramDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/infrastructure/adapter/repository/DeclaredProgramDatabaseRepository.java
@@ -8,6 +8,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.program.infrastructure.
 import fr.avenirsesr.portfolio.student.progress.declared.program.infrastructure.adapter.model.DeclaredProgramEntity;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.repository.GenericUserJpaRepositoryAdapter;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,14 +17,12 @@ public class DeclaredProgramDatabaseRepository
     implements DeclaredProgramRepository {
   public DeclaredProgramDatabaseRepository(DeclaredProgramJpaRepository jpaRepository) {
     super(
-        jpaRepository,
-        jpaRepository,
-        DeclaredProgramMapper::fromDomain,
-        DeclaredProgramMapper::toDomain);
+        jpaRepository, jpaRepository, DeclaredProgramEntity.class, DeclaredProgramMapper.INSTANCE);
   }
 
   @Override
   public PagedResult<DeclaredProgram> findAllByStudent(Student student, PageCriteria pageCriteria) {
-    return findAll(hasStudent(student), pageCriteria);
+    return findAll(
+        hasStudent(student), PageRequest.of(pageCriteria.page(), pageCriteria.pageSize()));
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/domain/model/StudentProgress.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/domain/model/StudentProgress.java
@@ -81,12 +81,12 @@ public class StudentProgress extends AvenirsBaseModel {
   }
 
   public List<SkillLevelProgress> getAllSkillLevels() {
-    return skillLevelProgresses;
+    return skillLevelProgresses.stream().distinct().collect(Collectors.toList());
   }
 
   public List<SkillLevelProgress> getCurrentSkillLevels() {
     Map<Skill, List<SkillLevelProgress>> startedSkillLevelsBySkill =
-        skillLevelProgresses.stream()
+        getAllSkillLevels().stream()
             .collect(
                 Collectors.groupingBy(
                     skillLevelProgress -> skillLevelProgress.getSkillLevel().getSkill(),

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/domain/service/StudentProgressServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/domain/service/StudentProgressServiceImpl.java
@@ -8,6 +8,7 @@ import fr.avenirsesr.portfolio.additionalskill.domain.model.enums.EAdditionalSki
 import fr.avenirsesr.portfolio.additionalskill.domain.model.enums.EAdditionalSkillType;
 import fr.avenirsesr.portfolio.additionalskill.domain.port.input.AdditionalSkillSyncService;
 import fr.avenirsesr.portfolio.additionalskill.infrastructure.adapter.client.ExternalSkillClient;
+import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
@@ -250,7 +251,9 @@ public class StudentProgressServiceImpl implements StudentProgressService {
 
     AdditionalSkillProgress additionalSkillProgress =
         additionalSkillProgressRepository
-            .findById(additionalSkillProgressId)
+            .findById(
+                additionalSkillProgressId,
+                FetchGraph.init().fetch("student").fetch("additionalSkill"))
             .orElseThrow(AdditionalSkillProgressNotFoundException::new);
 
     if (!additionalSkillProgress.getStudent().getId().equals(student.getId())) {

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/mapper/AdditionalSkillProgressMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/mapper/AdditionalSkillProgressMapper.java
@@ -1,25 +1,50 @@
 package fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.mapper;
 
 import fr.avenirsesr.portfolio.additionalskill.infrastructure.adapter.mapper.AdditionalSkillMapper;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.student.progress.imported.domain.model.AdditionalSkillProgress;
 import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.model.AdditionalSkillProgressEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
 
-public interface AdditionalSkillProgressMapper {
-  static AdditionalSkillProgressEntity fromDomain(AdditionalSkillProgress additionalSkillProgress) {
+public class AdditionalSkillProgressMapper
+    implements Mapper<AdditionalSkillProgressEntity, AdditionalSkillProgress> {
+  public static final AdditionalSkillProgressMapper INSTANCE = new AdditionalSkillProgressMapper();
+
+  @Override
+  public AdditionalSkillProgressEntity fromDomain(AdditionalSkillProgress additionalSkillProgress) {
     return AdditionalSkillProgressEntity.create(
         additionalSkillProgress.getId(),
-        StudentMapper.fromDomain(additionalSkillProgress.getStudent()),
-        AdditionalSkillMapper.fromDomain(additionalSkillProgress.getSkill()),
+        StudentMapper.INSTANCE.fromDomain(additionalSkillProgress.getStudent()),
+        AdditionalSkillMapper.INSTANCE.fromDomain(additionalSkillProgress.getSkill()),
         additionalSkillProgress.getLevel(),
         additionalSkillProgress.getDescription());
   }
 
-  static AdditionalSkillProgress toDomain(AdditionalSkillProgressEntity entity) {
+  @Override
+  public AdditionalSkillProgress toDomain(AdditionalSkillProgressEntity entity) {
     return AdditionalSkillProgress.toDomain(
         entity.getId(),
-        StudentMapper.toDomain(entity.getStudent()),
-        AdditionalSkillMapper.toDomain(entity.getAdditionalSkill()),
+        StudentMapper.INSTANCE.toDomain(entity.getStudent()),
+        AdditionalSkillMapper.INSTANCE.toDomain(entity.getAdditionalSkill()),
+        entity.getLevel(),
+        entity.getDescription(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  @Override
+  public AdditionalSkillProgress toDomain(
+      AdditionalSkillProgressEntity entity, EntityGrapher<?> graph) {
+    var attributes = graph.attributes();
+    return AdditionalSkillProgress.toDomain(
+        entity.getId(),
+        attributes.contains("student")
+            ? StudentMapper.INSTANCE.toDomain(entity.getStudent())
+            : null,
+        attributes.contains("additionalSkill")
+            ? AdditionalSkillMapper.INSTANCE.toDomain(entity.getAdditionalSkill())
+            : null,
         entity.getLevel(),
         entity.getDescription(),
         entity.getCreatedAt(),

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/mapper/SkillLevelProgressMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/mapper/SkillLevelProgressMapper.java
@@ -1,32 +1,66 @@
 package fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.mapper;
 
 import fr.avenirsesr.portfolio.ams.infrastructure.adapter.mapper.AMSMapper;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper.SkillLevelMapper;
 import fr.avenirsesr.portfolio.student.progress.imported.domain.model.SkillLevelProgress;
 import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.model.SkillLevelProgressEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
+import java.util.List;
+import java.util.stream.Collectors;
 
-public interface SkillLevelProgressMapper {
-  static SkillLevelProgressEntity fromDomain(SkillLevelProgress skillLevelProgress) {
+public class SkillLevelProgressMapper
+    implements Mapper<SkillLevelProgressEntity, SkillLevelProgress> {
+  public static final SkillLevelProgressMapper INSTANCE = new SkillLevelProgressMapper();
+
+  @Override
+  public SkillLevelProgressEntity fromDomain(SkillLevelProgress skillLevelProgress) {
     return SkillLevelProgressEntity.of(
         skillLevelProgress.getId(),
-        StudentMapper.fromDomain(skillLevelProgress.getStudent()),
-        SkillLevelMapper.fromDomain(skillLevelProgress.getSkillLevel()),
+        StudentMapper.INSTANCE.fromDomain(skillLevelProgress.getStudent()),
+        SkillLevelMapper.INSTANCE.fromDomain(skillLevelProgress.getSkillLevel()),
         skillLevelProgress.getStatus(),
         skillLevelProgress.getStartDate(),
         skillLevelProgress.getEndDate(),
-        skillLevelProgress.getAmses().stream().map(AMSMapper::fromDomain).toList());
+        skillLevelProgress.getAmses().stream()
+            .map(AMSMapper.INSTANCE::fromDomain)
+            .collect(Collectors.toSet()));
   }
 
-  static SkillLevelProgress toDomain(SkillLevelProgressEntity entity) {
+  @Override
+  public SkillLevelProgress toDomain(SkillLevelProgressEntity entity) {
     return SkillLevelProgress.toDomain(
         entity.getId(),
-        StudentMapper.toDomain(entity.getStudent()),
-        SkillLevelMapper.toDomain(entity.getSkillLevel()),
+        StudentMapper.INSTANCE.toDomain(entity.getStudent()),
+        SkillLevelMapper.INSTANCE.toDomain(entity.getSkillLevel()),
         entity.getStatus(),
         entity.getStartDate(),
         entity.getEndDate(),
-        entity.getAmses().stream().map(AMSMapper::toDomain).toList(),
+        entity.getAmses().stream().map(AMSMapper.INSTANCE::toDomain).toList(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  @Override
+  public SkillLevelProgress toDomain(SkillLevelProgressEntity entity, EntityGrapher<?> graph) {
+    var attributs = graph.attributes();
+    return SkillLevelProgress.toDomain(
+        entity.getId(),
+        attributs.contains("student")
+            ? StudentMapper.INSTANCE.toDomain(entity.getStudent(), graph.from("student"))
+            : null,
+        attributs.contains("skillLevel")
+            ? SkillLevelMapper.INSTANCE.toDomain(entity.getSkillLevel(), graph.from("skillLevel"))
+            : null,
+        entity.getStatus(),
+        entity.getStartDate(),
+        entity.getEndDate(),
+        attributs.contains("amses")
+            ? entity.getAmses().stream()
+                .map(e -> AMSMapper.INSTANCE.toDomain(e, graph.from("amses")))
+                .toList()
+            : List.of(),
         entity.getCreatedAt(),
         entity.getUpdatedAt());
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/mapper/StudentProgressMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/mapper/StudentProgressMapper.java
@@ -1,30 +1,66 @@
 package fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.mapper.TrainingPathMapper;
 import fr.avenirsesr.portfolio.student.progress.imported.domain.model.StudentProgress;
 import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.model.StudentProgressEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
+import java.util.List;
 
-public interface StudentProgressMapper {
-  static StudentProgressEntity fromDomain(StudentProgress studentProgress) {
+public class StudentProgressMapper implements Mapper<StudentProgressEntity, StudentProgress> {
+  public static final StudentProgressMapper INSTANCE = new StudentProgressMapper();
+
+  @Override
+  public StudentProgressEntity fromDomain(StudentProgress studentProgress) {
     return new StudentProgressEntity(
-        StudentMapper.fromDomain(studentProgress.getStudent()),
-        TrainingPathMapper.fromDomain(studentProgress.getTrainingPath()),
+        StudentMapper.INSTANCE.fromDomain(studentProgress.getStudent()),
+        TrainingPathMapper.INSTANCE.fromDomain(studentProgress.getTrainingPath()),
         studentProgress.getAllSkillLevels().stream()
-            .map(SkillLevelProgressMapper::fromDomain)
+            .map(SkillLevelProgressMapper.INSTANCE::fromDomain)
             .toList());
   }
 
-  static StudentProgress toDomain(StudentProgressEntity studentProgressEntity) {
+  @Override
+  public StudentProgress toDomain(StudentProgressEntity studentProgressEntity) {
     return StudentProgress.toDomain(
         studentProgressEntity.getId(),
-        StudentMapper.toDomain(studentProgressEntity.getStudent()),
-        TrainingPathMapper.toDomain(studentProgressEntity.getTrainingPath()),
+        StudentMapper.INSTANCE.toDomain(studentProgressEntity.getStudent()),
+        TrainingPathMapper.INSTANCE.toDomain(studentProgressEntity.getTrainingPath()),
         studentProgressEntity.getStartDate(),
         studentProgressEntity.getEndDate(),
         studentProgressEntity.getSkillLevels().stream()
-            .map(SkillLevelProgressMapper::toDomain)
+            .map(SkillLevelProgressMapper.INSTANCE::toDomain)
             .toList(),
+        studentProgressEntity.getCreatedAt(),
+        studentProgressEntity.getUpdatedAt());
+  }
+
+  @Override
+  public StudentProgress toDomain(
+      StudentProgressEntity studentProgressEntity, EntityGrapher<?> graph) {
+    var attributs = graph.attributes();
+
+    return StudentProgress.toDomain(
+        studentProgressEntity.getId(),
+        attributs.contains("student")
+            ? StudentMapper.INSTANCE.toDomain(
+                studentProgressEntity.getStudent(), graph.from("student"))
+            : null,
+        attributs.contains("trainingPath")
+            ? TrainingPathMapper.INSTANCE.toDomain(
+                studentProgressEntity.getTrainingPath(), graph.from("trainingPath"))
+            : null,
+        studentProgressEntity.getStartDate(),
+        studentProgressEntity.getEndDate(),
+        attributs.contains("skillLevels")
+            ? studentProgressEntity.getSkillLevels().stream()
+                .map(
+                    entity ->
+                        SkillLevelProgressMapper.INSTANCE.toDomain(
+                            entity, graph.from("skillLevels")))
+                .toList()
+            : List.of(),
         studentProgressEntity.getCreatedAt(),
         studentProgressEntity.getUpdatedAt());
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/model/SkillLevelProgressEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/model/SkillLevelProgressEntity.java
@@ -7,7 +7,7 @@ import fr.avenirsesr.portfolio.program.infrastructure.adapter.model.SkillLevelEn
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.StudentEntity;
 import jakarta.persistence.*;
 import java.time.LocalDate;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -43,7 +43,7 @@ public class SkillLevelProgressEntity extends PeriodEntity<LocalDate> {
       name = "ams_skill_level_progress",
       joinColumns = @JoinColumn(name = "skill_level_progress_id"),
       inverseJoinColumns = @JoinColumn(name = "ams_id"))
-  private List<AMSEntity> amses;
+  private Set<AMSEntity> amses;
 
   private SkillLevelProgressEntity(
       UUID id,
@@ -52,7 +52,7 @@ public class SkillLevelProgressEntity extends PeriodEntity<LocalDate> {
       ESkillLevelStatus status,
       LocalDate startDate,
       LocalDate endDate,
-      List<AMSEntity> amses) {
+      Set<AMSEntity> amses) {
     setId(id);
     this.student = student;
     this.skillLevel = skillLevelEntity;
@@ -69,7 +69,7 @@ public class SkillLevelProgressEntity extends PeriodEntity<LocalDate> {
       ESkillLevelStatus status,
       LocalDate startDate,
       LocalDate endDate,
-      List<AMSEntity> amses) {
+      Set<AMSEntity> amses) {
     return new SkillLevelProgressEntity(
         id, student, skillLevelEntity, status, startDate, endDate, amses);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/repository/AdditionalSkillProgressDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/repository/AdditionalSkillProgressDatabaseRepository.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.repository;
 
+import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.student.progress.imported.domain.model.AdditionalSkillProgress;
@@ -9,6 +10,8 @@ import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.
 import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.specification.AdditionalSkillProgressSpecification;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.repository.GenericUserJpaRepositoryAdapter;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
@@ -19,14 +22,15 @@ public class AdditionalSkillProgressDatabaseRepository
     extends GenericUserJpaRepositoryAdapter<AdditionalSkillProgress, AdditionalSkillProgressEntity>
     implements AdditionalSkillProgressRepository {
   private final AdditionalSkillProgressJpaRepository jpaRepository;
+  @PersistenceContext private EntityManager em;
 
   public AdditionalSkillProgressDatabaseRepository(
       AdditionalSkillProgressJpaRepository jpaRepository) {
     super(
         jpaRepository,
         jpaRepository,
-        AdditionalSkillProgressMapper::fromDomain,
-        AdditionalSkillProgressMapper::toDomain);
+        AdditionalSkillProgressEntity.class,
+        AdditionalSkillProgressMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 
@@ -47,7 +51,10 @@ public class AdditionalSkillProgressDatabaseRepository
   public PagedResult<AdditionalSkillProgress> findAllByStudent(
       Student student, PageCriteria pageCriteria) {
     var specification = hasStudent(student);
-    return findAllByStudent(specification, pageCriteria);
+    return findAll(
+        specification,
+        PageRequest.of(pageCriteria.page(), pageCriteria.pageSize()),
+        FetchGraph.init().fetch("student").fetch("additionalSkill"));
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/repository/SkillLevelProgressDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/repository/SkillLevelProgressDatabaseRepository.java
@@ -29,8 +29,8 @@ public class SkillLevelProgressDatabaseRepository
     super(
         jpaRepository,
         jpaRepository,
-        SkillLevelProgressMapper::fromDomain,
-        SkillLevelProgressMapper::toDomain);
+        SkillLevelProgressEntity.class,
+        SkillLevelProgressMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/repository/StudentProgressDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/repository/StudentProgressDatabaseRepository.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.repository;
 
+import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.student.progress.imported.domain.model.SkillLevelProgress;
 import fr.avenirsesr.portfolio.student.progress.imported.domain.model.StudentProgress;
 import fr.avenirsesr.portfolio.student.progress.imported.domain.port.output.repository.StudentProgressRepository;
@@ -8,26 +9,52 @@ import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.
 import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.specification.StudentProgressSpecification;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.repository.GenericUserJpaRepositoryAdapter;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 public class StudentProgressDatabaseRepository
     extends GenericUserJpaRepositoryAdapter<StudentProgress, StudentProgressEntity>
     implements StudentProgressRepository {
 
+  @PersistenceContext private EntityManager em;
+
   public StudentProgressDatabaseRepository(StudentProgressJpaRepository jpaRepository) {
     super(
-        jpaRepository,
-        jpaRepository,
-        StudentProgressMapper::fromDomain,
-        StudentProgressMapper::toDomain);
+        jpaRepository, jpaRepository, StudentProgressEntity.class, StudentProgressMapper.INSTANCE);
   }
 
   @Override
   public List<StudentProgress> findAllByStudent(Student student) {
-    return findAll(hasStudent(student));
+
+    var graph =
+        FetchGraph.init()
+            .fetch("student")
+            .add("trainingPath")
+            .add("program")
+            .fetch("translations")
+            .add("institution")
+            .fetch("translations")
+            .root()
+            .add("skillLevels")
+            .root()
+            .from("skillLevels")
+            .add("student")
+            .fetch("user")
+            .root()
+            .from("skillLevels")
+            .add("skillLevel")
+            .fetch("translations")
+            .add("skill")
+            .fetch("translations")
+            .root();
+
+    return findAll(hasStudent(student), graph);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/seeder/fake/FakeSkillLevelProgress.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/seeder/fake/FakeSkillLevelProgress.java
@@ -9,7 +9,7 @@ import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.StudentEntity;
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.List;
+import java.util.Set;
 
 public class FakeSkillLevelProgress {
   private static final DataGeneratorProvider<SharedDataGenerator> dataGenerator =
@@ -33,7 +33,7 @@ public class FakeSkillLevelProgress {
             ESkillLevelStatus.NOT_STARTED,
             futureStartDate,
             futureEndDate,
-            List.of()));
+            Set.of()));
   }
 
   public FakeSkillLevelProgress withStatus(ESkillLevelStatus status) {
@@ -59,7 +59,7 @@ public class FakeSkillLevelProgress {
     return this;
   }
 
-  public FakeSkillLevelProgress withAmses(List<AMSEntity> amses) {
+  public FakeSkillLevelProgress withAmses(Set<AMSEntity> amses) {
     this.skillLevelProgress.setAmses(amses);
     return this;
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/specification/AdditionalSkillProgressSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/specification/AdditionalSkillProgressSpecification.java
@@ -12,7 +12,8 @@ public class AdditionalSkillProgressSpecification {
     return (root, query, criteriaBuilder) ->
         criteriaBuilder.and(
             criteriaBuilder.equal(
-                root.get("additionalSkill"), AdditionalSkillMapper.fromDomain(additionalSkill)),
+                root.get("additionalSkill"),
+                AdditionalSkillMapper.INSTANCE.fromDomain(additionalSkill)),
             criteriaBuilder.equal(root.get("student").get("id"), studentId));
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/specification/SkillLevelProgressSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/specification/SkillLevelProgressSpecification.java
@@ -13,13 +13,13 @@ import org.springframework.data.jpa.domain.Specification;
 public class SkillLevelProgressSpecification {
   public static Specification<SkillLevelProgressEntity> linkedTo(AMS ams) {
     return (root, query, criteriaBuilder) ->
-        criteriaBuilder.isMember(AMSMapper.fromDomain(ams), root.get("amses"));
+        criteriaBuilder.isMember(AMSMapper.INSTANCE.fromDomain(ams), root.get("amses"));
   }
 
   public static Specification<SkillLevelProgressEntity> with(Student student, UUID skillId) {
     return (root, query, criteriaBuilder) -> {
       var studentPredicate =
-          criteriaBuilder.equal(root.get("student"), StudentMapper.fromDomain(student));
+          criteriaBuilder.equal(root.get("student"), StudentMapper.INSTANCE.fromDomain(student));
       Join<Object, Object> skillEntity = root.join("skillLevel").join("skill");
       var skillPredicate = criteriaBuilder.equal(skillEntity.get("id"), skillId);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/specification/StudentProgressSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/imported/infrastructure/adapter/specification/StudentProgressSpecification.java
@@ -20,7 +20,7 @@ public class StudentProgressSpecification {
   public static Specification<StudentProgressEntity> hasSkillLevelProgresses(
       List<SkillLevelProgress> skillLevelProgresses) {
     List<SkillLevelProgressEntity> skillLevelProgressEntities =
-        skillLevelProgresses.stream().map(SkillLevelProgressMapper::fromDomain).toList();
+        skillLevelProgresses.stream().map(SkillLevelProgressMapper.INSTANCE::fromDomain).toList();
     return (root, query, criteriaBuilder) -> {
       Join<StudentProgressEntity, SkillLevelProgressEntity> skillLevelProgressJoin =
           root.join("skillLevels");

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/output/repository/TraceRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/output/repository/TraceRepository.java
@@ -11,6 +11,7 @@ import fr.avenirsesr.portfolio.student.progress.imported.domain.model.SkillLevel
 import fr.avenirsesr.portfolio.trace.domain.filter.TraceFilter;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import java.util.List;
+import java.util.Map;
 
 public interface TraceRepository extends GenericDeletableRepositoryPort<Trace> {
   List<Trace> findLastsOf(User user, int limit);
@@ -27,6 +28,8 @@ public interface TraceRepository extends GenericDeletableRepositoryPort<Trace> {
   List<Trace> linkedWith(AMS ams);
 
   List<Trace> linkedWith(SkillLevelProgress skillLevelProgress);
+
+  Map<SkillLevelProgress, List<Trace>> linkedWith(List<SkillLevelProgress> skillLevelProgresses);
 
   List<Trace> linkedWith(AdditionalSkillProgress additionalSkillProgress);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/mapper/TraceMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/mapper/TraceMapper.java
@@ -1,6 +1,8 @@
 package fr.avenirsesr.portfolio.trace.infrastructure.adapter.mapper;
 
 import fr.avenirsesr.portfolio.ams.infrastructure.adapter.mapper.AMSMapper;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.mapper.AdditionalSkillProgressMapper;
 import fr.avenirsesr.portfolio.student.progress.imported.infrastructure.adapter.mapper.SkillLevelProgressMapper;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
@@ -8,18 +10,21 @@ import fr.avenirsesr.portfolio.trace.infrastructure.adapter.model.TraceEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
 import java.util.List;
 
-public interface TraceMapper {
-  static TraceEntity fromDomain(Trace trace) {
+public class TraceMapper implements Mapper<TraceEntity, Trace> {
+  public static final TraceMapper INSTANCE = new TraceMapper();
+
+  @Override
+  public TraceEntity fromDomain(Trace trace) {
     return TraceEntity.of(
         trace.getId(),
-        UserMapper.fromDomain(trace.getUser()),
+        UserMapper.INSTANCE.fromDomain(trace.getUser()),
         trace.getTitle(),
         trace.getLanguage(),
-        trace.getSkillLevels().stream().map(SkillLevelProgressMapper::fromDomain).toList(),
+        trace.getSkillLevels().stream().map(SkillLevelProgressMapper.INSTANCE::fromDomain).toList(),
         trace.getAdditionalSkillProgresses().stream()
-            .map(AdditionalSkillProgressMapper::fromDomain)
+            .map(AdditionalSkillProgressMapper.INSTANCE::fromDomain)
             .toList(),
-        trace.getAmses().stream().map(AMSMapper::fromDomain).toList(),
+        trace.getAmses().stream().map(AMSMapper.INSTANCE::fromDomain).toList(),
         trace.isGroup(),
         trace.getAiUseJustification().orElse(null),
         trace.getPersonalNote().orElse(null),
@@ -28,17 +33,18 @@ public interface TraceMapper {
         trace.getDeletedAt().orElse(null));
   }
 
-  static Trace toDomain(TraceEntity traceEntity) {
+  @Override
+  public Trace toDomain(TraceEntity traceEntity) {
     Trace trace =
         Trace.toDomain(
             traceEntity.getId(),
-            UserMapper.toDomain(traceEntity.getUser()),
+            UserMapper.INSTANCE.toDomain(traceEntity.getUser()),
             traceEntity.getTitle(),
             List.of(),
             traceEntity.getAdditionalSkillsProgresses().stream()
-                .map(AdditionalSkillProgressMapper::toDomain)
+                .map(AdditionalSkillProgressMapper.INSTANCE::toDomain)
                 .toList(),
-            traceEntity.getAmses().stream().map(AMSMapper::toDomain).toList(),
+            traceEntity.getAmses().stream().map(AMSMapper.INSTANCE::toDomain).toList(),
             traceEntity.isGroup(),
             traceEntity.getAiUseJustification(),
             traceEntity.getPersonalNote(),
@@ -47,7 +53,43 @@ public interface TraceMapper {
             traceEntity.getDeletedAt(),
             traceEntity.getLanguage());
     trace.setSkillLevels(
-        traceEntity.getSkillLevels().stream().map(SkillLevelProgressMapper::toDomain).toList());
+        traceEntity.getSkillLevels().stream()
+            .map(SkillLevelProgressMapper.INSTANCE::toDomain)
+            .toList());
     return trace;
+  }
+
+  @Override
+  public Trace toDomain(TraceEntity traceEntity, EntityGrapher<?> graph) {
+    var attributes = graph.attributes();
+    return Trace.toDomain(
+        traceEntity.getId(),
+        attributes.contains("user") ? UserMapper.INSTANCE.toDomain(traceEntity.getUser()) : null,
+        traceEntity.getTitle(),
+        attributes.contains("skillLevels")
+            ? traceEntity.getSkillLevels().stream()
+                .map(e -> SkillLevelProgressMapper.INSTANCE.toDomain(e, graph.from("skillLevels")))
+                .toList()
+            : List.of(),
+        attributes.contains("additionalSkillsProgresses")
+            ? traceEntity.getAdditionalSkillsProgresses().stream()
+                .map(
+                    e ->
+                        AdditionalSkillProgressMapper.INSTANCE.toDomain(
+                            e, graph.from("additionalSkillsProgresses")))
+                .toList()
+            : List.of(),
+        attributes.contains("amses")
+            ? traceEntity.getAmses().stream()
+                .map(e -> AMSMapper.INSTANCE.toDomain(e, graph.from("amses")))
+                .toList()
+            : List.of(),
+        traceEntity.isGroup(),
+        traceEntity.getAiUseJustification(),
+        traceEntity.getPersonalNote(),
+        traceEntity.getCreatedAt(),
+        traceEntity.getUpdatedAt(),
+        traceEntity.getDeletedAt(),
+        traceEntity.getLanguage());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/repository/TraceDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/repository/TraceDatabaseRepository.java
@@ -18,6 +18,7 @@ import fr.avenirsesr.portfolio.trace.infrastructure.adapter.model.TraceEntity;
 import fr.avenirsesr.portfolio.trace.infrastructure.adapter.specification.TraceFilterSpecificationBuilder;
 import fr.avenirsesr.portfolio.trace.infrastructure.adapter.specification.TraceSpecification;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Where;
 import org.springframework.data.domain.PageRequest;
@@ -33,7 +34,7 @@ public class TraceDatabaseRepository
   private final TraceJpaRepository jpaRepository;
 
   public TraceDatabaseRepository(TraceJpaRepository jpaRepository) {
-    super(jpaRepository, jpaRepository, TraceMapper::fromDomain, TraceMapper::toDomain);
+    super(jpaRepository, jpaRepository, TraceEntity.class, TraceMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
   }
 
@@ -102,6 +103,12 @@ public class TraceDatabaseRepository
   @Override
   public List<Trace> linkedWith(SkillLevelProgress skillLevelProgress) {
     return findAll(TraceSpecification.ofSkillLevelProgress(skillLevelProgress));
+  }
+
+  @Override
+  public Map<SkillLevelProgress, List<Trace>> linkedWith(
+      List<SkillLevelProgress> skillLevelProgresses) {
+    return Map.of();
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecification.java
@@ -20,7 +20,7 @@ import org.springframework.data.jpa.domain.Specification;
 public class TraceSpecification {
   public static Specification<TraceEntity> ofUser(User user) {
     return (root, query, criteriaBuilder) ->
-        criteriaBuilder.equal(root.get("user"), UserMapper.fromDomain(user));
+        criteriaBuilder.equal(root.get("user"), UserMapper.INSTANCE.fromDomain(user));
   }
 
   public static Specification<TraceEntity> unassociated() {
@@ -71,21 +71,22 @@ public class TraceSpecification {
 
   public static Specification<TraceEntity> ofAms(AMS ams) {
     return (root, query, criteriaBuilder) ->
-        criteriaBuilder.isMember(AMSMapper.fromDomain(ams), root.get("amses"));
+        criteriaBuilder.isMember(AMSMapper.INSTANCE.fromDomain(ams), root.get("amses"));
   }
 
   public static Specification<TraceEntity> ofSkillLevelProgress(
       SkillLevelProgress skillLevelProgress) {
     return (root, query, criteriaBuilder) ->
         criteriaBuilder.isMember(
-            SkillLevelProgressMapper.fromDomain(skillLevelProgress), root.get("skillLevels"));
+            SkillLevelProgressMapper.INSTANCE.fromDomain(skillLevelProgress),
+            root.get("skillLevels"));
   }
 
   public static Specification<TraceEntity> ofAdditionalSkillProgress(
       AdditionalSkillProgress additionalSkillProgress) {
     return (root, query, criteriaBuilder) ->
         criteriaBuilder.isMember(
-            AdditionalSkillProgressMapper.fromDomain(additionalSkillProgress),
+            AdditionalSkillProgressMapper.INSTANCE.fromDomain(additionalSkillProgress),
             root.get("additionalSkillsProgresses"));
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/ExternalUserMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/ExternalUserMapper.java
@@ -1,27 +1,32 @@
 package fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.user.domain.model.ExternalUser;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.ExternalUserEntity;
 
-public interface ExternalUserMapper {
-  static ExternalUserEntity fromDomain(ExternalUser externalUser) {
+public class ExternalUserMapper implements Mapper<ExternalUserEntity, ExternalUser> {
+  public static final ExternalUserMapper INSTANCE = new ExternalUserMapper();
+
+  @Override
+  public ExternalUserEntity fromDomain(ExternalUser externalUser) {
     return ExternalUserEntity.of(
         externalUser.getId(),
         externalUser.getExternalId(),
         externalUser.getSource(),
-        UserMapper.fromDomain(externalUser.getUser()),
+        UserMapper.INSTANCE.fromDomain(externalUser.getUser()),
         externalUser.getCategory(),
         externalUser.getEmail(),
         externalUser.getFirstName(),
         externalUser.getLastName());
   }
 
-  static ExternalUser toDomain(ExternalUserEntity externalUserEntity) {
+  @Override
+  public ExternalUser toDomain(ExternalUserEntity externalUserEntity) {
     return ExternalUser.toDomain(
         externalUserEntity.getId(),
         externalUserEntity.getCreatedAt(),
         externalUserEntity.getUpdatedAt(),
-        UserMapper.toDomain(externalUserEntity.getUser()),
+        UserMapper.INSTANCE.toDomain(externalUserEntity.getUser()),
         externalUserEntity.getExternalId(),
         externalUserEntity.getSource(),
         externalUserEntity.getCategory(),

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/StudentMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/StudentMapper.java
@@ -1,16 +1,32 @@
 package fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.StudentEntity;
 
-public interface StudentMapper {
-  static StudentEntity fromDomain(Student student) {
-    return StudentEntity.of(UserMapper.fromDomain(student.getUser()), student.getBio());
+public class StudentMapper implements Mapper<StudentEntity, Student> {
+  public static final StudentMapper INSTANCE = new StudentMapper();
+
+  @Override
+  public StudentEntity fromDomain(Student student) {
+    return StudentEntity.of(UserMapper.INSTANCE.fromDomain(student.getUser()), student.getBio());
   }
 
-  static Student toDomain(StudentEntity studentEntity) {
+  @Override
+  public Student toDomain(StudentEntity studentEntity) {
     return Student.toDomain(
-        UserMapper.toDomain(studentEntity.getUser()),
+        UserMapper.INSTANCE.toDomain(studentEntity.getUser()),
+        studentEntity.getBio(),
+        studentEntity.getCreatedAt(),
+        studentEntity.getUpdatedAt());
+  }
+
+  @Override
+  public Student toDomain(StudentEntity studentEntity, EntityGrapher<?> graph) {
+    var attributes = graph.attributes();
+    return Student.toDomain(
+        attributes.contains("user") ? UserMapper.INSTANCE.toDomain(studentEntity.getUser()) : null,
         studentEntity.getBio(),
         studentEntity.getCreatedAt(),
         studentEntity.getUpdatedAt());

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/TeacherMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/TeacherMapper.java
@@ -1,16 +1,21 @@
 package fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper;
 
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.user.domain.model.Teacher;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.TeacherEntity;
 
-public interface TeacherMapper {
-  static TeacherEntity fromDomain(Teacher teacher) {
-    return TeacherEntity.of(UserMapper.fromDomain(teacher.getUser()), teacher.getBio());
+public class TeacherMapper implements Mapper<TeacherEntity, Teacher> {
+  public static final TeacherMapper INSTANCE = new TeacherMapper();
+
+  @Override
+  public TeacherEntity fromDomain(Teacher teacher) {
+    return TeacherEntity.of(UserMapper.INSTANCE.fromDomain(teacher.getUser()), teacher.getBio());
   }
 
-  static Teacher toDomain(TeacherEntity teacherEntity) {
+  @Override
+  public Teacher toDomain(TeacherEntity teacherEntity) {
     return Teacher.toDomain(
-        UserMapper.toDomain(teacherEntity.getUser()),
+        UserMapper.INSTANCE.toDomain(teacherEntity.getUser()),
         teacherEntity.getBio(),
         teacherEntity.getCreatedAt(),
         teacherEntity.getUpdatedAt());

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/UserMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/UserMapper.java
@@ -1,16 +1,21 @@
 package fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.UserEntity;
 
-public interface UserMapper {
-  static UserEntity fromDomain(User user) {
+public class UserMapper implements Mapper<UserEntity, User> {
+  public static final UserMapper INSTANCE = new UserMapper();
+
+  @Override
+  public UserEntity fromDomain(User user) {
     return user != null
         ? UserEntity.of(user.getId(), user.getFirstName(), user.getLastName(), user.getEmail())
         : null;
   }
 
-  static User toDomain(UserEntity userEntity) {
+  @Override
+  public User toDomain(UserEntity userEntity) {
     return userEntity != null
         ? User.toDomain(
             userEntity.getId(),

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/ExternalUserDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/ExternalUserDatabaseRepository.java
@@ -13,7 +13,6 @@ public class ExternalUserDatabaseRepository
     implements ExternalUserRepository {
 
   public ExternalUserDatabaseRepository(ExternalUserJpaRepository jpaRepository) {
-    super(
-        jpaRepository, jpaRepository, ExternalUserMapper::fromDomain, ExternalUserMapper::toDomain);
+    super(jpaRepository, jpaRepository, ExternalUserEntity.class, ExternalUserMapper.INSTANCE);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/GenericUserJpaRepositoryAdapter.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/GenericUserJpaRepositoryAdapter.java
@@ -1,12 +1,12 @@
 package fr.avenirsesr.portfolio.user.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.AvenirsBaseModel;
+import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.model.AvenirsBaseEntity;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.repository.GenericJpaRepositoryAdapter;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.specification.StudentSpecification;
 import java.util.UUID;
-import java.util.function.Function;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -18,9 +18,9 @@ public abstract class GenericUserJpaRepositoryAdapter<
   protected GenericUserJpaRepositoryAdapter(
       JpaRepository<E, UUID> jpaRepository,
       JpaSpecificationExecutor<E> jpaSpecificationExecutor,
-      Function<D, E> fromDomain,
-      Function<E, D> toDomain) {
-    super(jpaRepository, jpaSpecificationExecutor, fromDomain, toDomain);
+      Class<E> entityClass,
+      Mapper<E, D> mapper) {
+    super(jpaRepository, jpaSpecificationExecutor, entityClass, mapper);
   }
 
   protected Specification<E> hasStudent(Student student) {

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/StudentDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/StudentDatabaseRepository.java
@@ -18,7 +18,7 @@ public class StudentDatabaseRepository extends GenericJpaRepositoryAdapter<Stude
   private final StudentJpaRepository jpaRepository;
 
   public StudentDatabaseRepository(StudentJpaRepository repository) {
-    super(repository, repository, StudentMapper::fromDomain, StudentMapper::toDomain);
+    super(repository, repository, StudentEntity.class, StudentMapper.INSTANCE);
     this.jpaRepository = repository;
   }
 
@@ -28,7 +28,7 @@ public class StudentDatabaseRepository extends GenericJpaRepositoryAdapter<Stude
         jpaRepository.findById(student.getId()).orElseThrow(UserNotFoundException::new);
     studentEntity
         .getSelfKnowledgeCategories()
-        .addAll(categories.stream().map(SelfKnowledgeCategoryMapper::fromDomain).toList());
+        .addAll(categories.stream().map(SelfKnowledgeCategoryMapper.INSTANCE::fromDomain).toList());
     jpaRepository.save(studentEntity);
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/TeacherDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/TeacherDatabaseRepository.java
@@ -13,7 +13,7 @@ public class TeacherDatabaseRepository extends GenericJpaRepositoryAdapter<Teach
   private final TeacherJpaRepository jpaRepository;
 
   public TeacherDatabaseRepository(TeacherJpaRepository repository) {
-    super(repository, repository, TeacherMapper::fromDomain, TeacherMapper::toDomain);
+    super(repository, repository, TeacherEntity.class, TeacherMapper.INSTANCE);
     this.jpaRepository = repository;
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/UserDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/repository/UserDatabaseRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 public class UserDatabaseRepository extends GenericJpaRepositoryAdapter<User, UserEntity>
     implements UserRepository {
   public UserDatabaseRepository(UserJpaRepository jpaRepository) {
-    super(jpaRepository, jpaRepository, UserMapper::fromDomain, UserMapper::toDomain);
+    super(jpaRepository, jpaRepository, UserEntity.class, UserMapper.INSTANCE);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/TeacherSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/TeacherSeeder.java
@@ -39,7 +39,7 @@ public class TeacherSeeder {
       teachers.add(FakeTeacher.create(user).toEntity());
     }
 
-    teacherRepository.saveAll(teachers.stream().map(TeacherMapper::toDomain).toList());
+    teacherRepository.saveAll(teachers.stream().map(TeacherMapper.INSTANCE::toDomain).toList());
     log.info("✔ {} teachers synced", teachers.size());
 
     return teachers;

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/UserSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/UserSeeder.java
@@ -40,7 +40,7 @@ public class UserSeeder {
 
     List<UserEntity> users =
         fakeUsers.stream().map(FakeUser::toEntity).collect(Collectors.toList());
-    userRepository.saveAll(users.stream().map(UserMapper::toDomain).toList());
+    userRepository.saveAll(users.stream().map(UserMapper.INSTANCE::toDomain).toList());
 
     var externalUsers =
         users.stream()
@@ -55,7 +55,7 @@ public class UserSeeder {
             .toList();
 
     externalUserRepository.saveAll(
-        externalUsers.stream().map(ExternalUserMapper::toDomain).toList());
+        externalUsers.stream().map(ExternalUserMapper.INSTANCE::toDomain).toList());
 
     log.info("✔ {} externalUsers created", externalUsers.size());
     log.info("✔ {} users created", users.size());

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/specification/StudentSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/specification/StudentSpecification.java
@@ -9,6 +9,6 @@ import org.springframework.data.jpa.domain.Specification;
 public final class StudentSpecification {
   public static <T> Specification<T> hasStudent(Student student) {
     return (root, query, criteriaBuilder) ->
-        criteriaBuilder.equal(root.get("student"), StudentMapper.fromDomain(student));
+        criteriaBuilder.equal(root.get("student"), StudentMapper.INSTANCE.fromDomain(student));
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/additionalskill/infrastructure/adapter/mapper/AdditionalSkillMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/additionalskill/infrastructure/adapter/mapper/AdditionalSkillMapperTest.java
@@ -33,7 +33,7 @@ class AdditionalSkillMapperTest {
     entity.setUpdatedAt(updatedAt);
 
     BddLogger.when("mapping to domain");
-    AdditionalSkill domain = AdditionalSkillMapper.toDomain(entity);
+    AdditionalSkill domain = AdditionalSkillMapper.INSTANCE.toDomain(entity);
 
     BddLogger.then("it should map all fields correctly");
     assertNotNull(domain);
@@ -54,7 +54,7 @@ class AdditionalSkillMapperTest {
             id, externalSkillId, libelle, type, pathSegments, createdAt, updatedAt);
 
     BddLogger.when("mapping to entity");
-    AdditionalSkillEntity entity = AdditionalSkillMapper.fromDomain(domain);
+    AdditionalSkillEntity entity = AdditionalSkillMapper.INSTANCE.fromDomain(domain);
 
     BddLogger.then("it should map all fields correctly");
     assertNotNull(entity);
@@ -74,7 +74,7 @@ class AdditionalSkillMapperTest {
     entity.setUpdatedAt(updatedAt);
 
     BddLogger.when("mapping to domain");
-    AdditionalSkill domain = AdditionalSkillMapper.toDomain(entity);
+    AdditionalSkill domain = AdditionalSkillMapper.INSTANCE.toDomain(entity);
 
     BddLogger.then("it should map with empty pathSegments list");
     assertNotNull(domain);
@@ -93,7 +93,7 @@ class AdditionalSkillMapperTest {
         AdditionalSkill.toDomain(id, externalSkillId, libelle, type, null, createdAt, updatedAt);
 
     BddLogger.when("mapping to entity");
-    AdditionalSkillEntity entity = AdditionalSkillMapper.fromDomain(domain);
+    AdditionalSkillEntity entity = AdditionalSkillMapper.INSTANCE.fromDomain(domain);
 
     BddLogger.then("it should map with empty pathSegments list");
     assertNotNull(entity);
@@ -115,7 +115,7 @@ class AdditionalSkillMapperTest {
     entity.setUpdatedAt(updatedAt);
 
     BddLogger.when("mapping to domain");
-    AdditionalSkill domain = AdditionalSkillMapper.toDomain(entity);
+    AdditionalSkill domain = AdditionalSkillMapper.INSTANCE.toDomain(entity);
 
     BddLogger.then("it should map with empty pathSegments");
     assertNotNull(domain);
@@ -131,10 +131,10 @@ class AdditionalSkillMapperTest {
             id, externalSkillId, libelle, type, pathSegments, createdAt, updatedAt);
 
     BddLogger.when("mapping to entity and back to domain");
-    AdditionalSkillEntity entity = AdditionalSkillMapper.fromDomain(originalDomain);
+    AdditionalSkillEntity entity = AdditionalSkillMapper.INSTANCE.fromDomain(originalDomain);
     entity.setCreatedAt(createdAt);
     entity.setUpdatedAt(updatedAt);
-    AdditionalSkill resultDomain = AdditionalSkillMapper.toDomain(entity);
+    AdditionalSkill resultDomain = AdditionalSkillMapper.INSTANCE.toDomain(entity);
 
     BddLogger.then("all fields should be preserved");
     assertNotNull(resultDomain);
@@ -157,7 +157,7 @@ class AdditionalSkillMapperTest {
     entity.setUpdatedAt(updatedAt);
 
     BddLogger.when("mapping to domain");
-    AdditionalSkill domain = AdditionalSkillMapper.toDomain(entity);
+    AdditionalSkill domain = AdditionalSkillMapper.INSTANCE.toDomain(entity);
 
     BddLogger.then("all segments should be preserved");
     assertNotNull(domain);
@@ -182,7 +182,7 @@ class AdditionalSkillMapperTest {
       entity.setCreatedAt(createdAt);
       entity.setUpdatedAt(updatedAt);
 
-      AdditionalSkill domain = AdditionalSkillMapper.toDomain(entity);
+      AdditionalSkill domain = AdditionalSkillMapper.INSTANCE.toDomain(entity);
 
       BddLogger.then("the type should be correctly mapped");
       assertEquals(skillType, domain.getType());

--- a/src/test/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/mapper/AMSMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/mapper/AMSMapperTest.java
@@ -55,7 +55,7 @@ class AMSMapperTest {
   void shouldMapFromDomainToEntity() {
     BddLogger.given("an AMS mapper");
     BddLogger.when("mapping a domain AMS to AMSEntity");
-    AMSEntity entity = AMSMapper.fromDomain(ams);
+    AMSEntity entity = AMSMapper.INSTANCE.fromDomain(ams);
 
     BddLogger.then("it should return a correct AMSEntity");
     assertNotNull(entity);
@@ -71,7 +71,7 @@ class AMSMapperTest {
     BddLogger.given("an AMS mapper");
     AMSEntity entity = new AMSEntity();
     entity.setId(id);
-    entity.setStudent(StudentMapper.fromDomain(student));
+    entity.setStudent(StudentMapper.INSTANCE.fromDomain(student));
     entity.setStatus(status);
     entity.setStartDate(startDate);
     entity.setEndDate(endDate);
@@ -86,7 +86,7 @@ class AMSMapperTest {
     entity.setTranslations(translations);
 
     BddLogger.when("mapping an AMSEntity to domain AMS");
-    AMS mappedAms = AMSMapper.toDomain(entity);
+    AMS mappedAms = AMSMapper.INSTANCE.toDomain(entity);
 
     BddLogger.then("it should return a correct domain AMS");
     assertNotNull(mappedAms);
@@ -101,7 +101,7 @@ class AMSMapperTest {
     BddLogger.given("an AMS mapper");
     AMSEntity entity = new AMSEntity();
     entity.setId(id);
-    entity.setStudent(StudentMapper.fromDomain(student));
+    entity.setStudent(StudentMapper.INSTANCE.fromDomain(student));
     entity.setStatus(status);
     entity.setStartDate(startDate);
     entity.setEndDate(endDate);
@@ -118,7 +118,7 @@ class AMSMapperTest {
     entity.setTranslations(translations);
 
     BddLogger.when("mapping an empty collection to domain AMS");
-    AMS mappedAms = AMSMapper.toDomain(entity);
+    AMS mappedAms = AMSMapper.INSTANCE.toDomain(entity);
 
     BddLogger.then("it should return a correct domain AMS");
     assertNotNull(mappedAms);

--- a/src/test/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/mapper/CohortMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/ams/infrastructure/adapter/mapper/CohortMapperTest.java
@@ -52,7 +52,7 @@ class CohortMapperTest {
             .toModel();
 
     BddLogger.when("mapping a domain Cohort to CohortEntity");
-    CohortEntity entity = CohortMapper.fromDomain(cohort);
+    CohortEntity entity = CohortMapper.INSTANCE.fromDomain(cohort);
 
     BddLogger.when("it should return a correct CohortEntity");
     assertNotNull(entity);
@@ -133,7 +133,7 @@ class CohortMapperTest {
     entity.setAmsEntities(new HashSet<>());
 
     BddLogger.when("mapping a CohortEntity to domain Cohort");
-    Cohort mappedCohort = CohortMapper.toDomain(entity);
+    Cohort mappedCohort = CohortMapper.INSTANCE.toDomain(entity);
 
     BddLogger.when("it should return a correct domain Cohort");
     assertNotNull(mappedCohort);
@@ -204,7 +204,7 @@ class CohortMapperTest {
     assertTrue(entity.getAmsEntities().isEmpty());
 
     BddLogger.when("mapping an empty collection to domain Cohort");
-    Cohort mappedCohort = CohortMapper.toDomain(entity);
+    Cohort mappedCohort = CohortMapper.INSTANCE.toDomain(entity);
 
     BddLogger.then("it should return a correct domain Cohort");
     assertNotNull(mappedCohort);

--- a/src/test/java/fr/avenirsesr/portfolio/ams/infrastructure/fixture/AMSFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/ams/infrastructure/fixture/AMSFixture.java
@@ -25,7 +25,7 @@ public class AMSFixture {
 
   private AMSFixture() {
     var fakeStudent = StudentFixture.create().toModel();
-    var base = FakeAMS.of(StudentMapper.fromDomain(fakeStudent)).toEntity();
+    var base = FakeAMS.of(StudentMapper.INSTANCE.fromDomain(fakeStudent)).toEntity();
     this.id = base.getId();
     this.student = fakeStudent;
     this.title = "fake ams title";

--- a/src/test/java/fr/avenirsesr/portfolio/file/infrastructure/fixture/TraceAttachmentFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/file/infrastructure/fixture/TraceAttachmentFixture.java
@@ -32,7 +32,7 @@ public class TraceAttachmentFixture {
     Trace defaultTrace = TraceFixture.create().toModel();
     var entity =
         FakeTraceAttachment.of(
-                FakeTrace.of(UserMapper.fromDomain(defaultTrace.getUser())).toEntity())
+                FakeTrace.of(UserMapper.INSTANCE.fromDomain(defaultTrace.getUser())).toEntity())
             .toEntity();
     var user = UserFixture.create().toModel();
     this.id = entity.getId();

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -168,25 +168,4 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
         .andExpect(jsonPath("$.page.page").value(0))
         .andExpect(jsonPath("$.page.pageSize").value(5));
   }
-
-  @Transactional
-  @Test
-  void shouldReturnEmptyContentWhenNoDeclaredExperienceExists() throws Exception {
-    BddLogger.given("no declared experience exists for the student");
-    BddLogger.when("performing a GET on /view");
-    BddLogger.then("it should return an empty paged response");
-
-    mockMvc
-        .perform(
-            get(BASE_PATH + "/view")
-                .param("page", "0")
-                .param("pageSize", "10")
-                .header("X-Signed-Context", studentPayload)
-                .header("X-Context-Kid", secretKey)
-                .header("X-Context-Signature", studentSignature))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data").isArray())
-        .andExpect(jsonPath("$.data").isEmpty())
-        .andExpect(jsonPath("$.page.totalElements").value(0));
-  }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/imported/domain/service/StudentProgressServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/imported/domain/service/StudentProgressServiceImplTest.java
@@ -919,7 +919,7 @@ public class StudentProgressServiceImplTest {
                 .toModel();
 
         BddLogger.when("calling the method with a given student and additionalSkillProgressId");
-        when(additionalSkillProgressRepository.findById(additionalSkillProgress.getId()))
+        when(additionalSkillProgressRepository.findById(any(), any()))
             .thenReturn(Optional.of(additionalSkillProgress));
         when(traceService.getTracesLinkedWithAdditionalSkillProgress(
                 student.getUser(), additionalSkillProgress))
@@ -983,7 +983,7 @@ public class StudentProgressServiceImplTest {
 
         BddLogger.when(
             "calling the method with another given student and additionalSkillProgressId");
-        when(additionalSkillProgressRepository.findById(additionalSkillProgress.getId()))
+        when(additionalSkillProgressRepository.findById(any(), any()))
             .thenReturn(Optional.of(additionalSkillProgress));
         assertThrows(
             UserNotAuthorizedException.class,

--- a/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/fixture/TraceFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/fixture/TraceFixture.java
@@ -35,16 +35,16 @@ public class TraceFixture {
 
   private TraceFixture() {
     var fakeUser = UserFixture.create().toModel();
-    var base = FakeTrace.of(UserMapper.fromDomain(fakeUser)).toEntity();
+    var base = FakeTrace.of(UserMapper.INSTANCE.fromDomain(fakeUser)).toEntity();
     this.id = base.getId();
     this.user = fakeUser;
     this.title = base.getTitle();
     this.skillLevels =
-        base.getSkillLevels().stream().map(SkillLevelProgressMapper::toDomain).toList();
-    this.amses = base.getAmses().stream().map(AMSMapper::toDomain).toList();
+        base.getSkillLevels().stream().map(SkillLevelProgressMapper.INSTANCE::toDomain).toList();
+    this.amses = base.getAmses().stream().map(AMSMapper.INSTANCE::toDomain).toList();
     this.additionalSkillProgresses =
         base.getAdditionalSkillsProgresses().stream()
-            .map(AdditionalSkillProgressMapper::toDomain)
+            .map(AdditionalSkillProgressMapper.INSTANCE::toDomain)
             .toList();
     this.createdAt = base.getCreatedAt();
     this.updatedAt = base.getUpdatedAt();


### PR DESCRIPTION
## 🚀 Correctif de performance – Introduction de FetchGraph et optimisation du chargement des données

### 🔗 Issue liée
closes https://github.com/orgs/avenirs-esr/projects/18?pane=issue&itemId=146626882&issue=avenirs-esr%7CAVENIRS-Project%7C870

related to https://github.com/avenirs-esr/avenirs-portfolio-common/pull/30

---

## 🧩 Contexte

Certaines pages présentaient des temps de chargement importants dus à :
- un usage massif du **lazy loading**
- l’absence de mécanisme permettant de **contrôler précisément les données fetchées**
- des **mappers forçant un chargement récursif profond** des entités

Cette PR introduit une première réponse structurelle à ce problème.

---

## ✨ Contenu de la PR

### 1️⃣ Introduction de `FetchGraph`

Un nouvel utilitaire **`FetchGraph`** a été ajouté afin de permettre à l’appelant de :
- définir explicitement un **graphe d’intention de fetch**
- exprimer **quelles relations doivent être chargées** selon le cas d’usage

Ce `FetchGraph` est ensuite :
- traduit côté infrastructure vers un **`EntityGrapher` Hibernate**
- utilisé pour **optimiser les requêtes SQL** (réduction du lazy loading et des N+1 queries)
- transmis aux **mappers**, qui ne chargent désormais **que les données présentes dans le graph**

👉 Le chargement des données est désormais **piloté par l’intention métier**, et non plus subi.

---

### 2️⃣ Optimisation du mapping des entités

Les mappers ont été adaptés afin de :
- ne plus forcer un chargement lazy profond et récursif
- mapper uniquement les relations **explicitement définies dans le `FetchGraph`**

Cela permet :
- de réduire drastiquement les accès inutiles à la base
- de mieux maîtriser les performances lors des évolutions du modèle

---

### 3️⃣ Améliorations annexes

#### 🔹 Évolution des mappers
- Les mappers implémentent désormais une **interface**
- Les repositories ne reçoivent plus deux méthodes (`toDomain` / `fromDomain`)
- Ils prennent désormais **directement le mapper** en dépendance

👉 Simplification de l’API des repositories et meilleure cohérence globale.

---

## ⚠️ État actuel et limites

- La migration **n’est pas encore complète**
- Toutes les requêtes n’utilisent pas encore `FetchGraph`

👉 Il reste à :
- migrer l’ensemble des méthodes de repository afin d’utiliser systématiquement `FetchGraph`
- adapter les mappers concernés

---

## ❗ Comportement actuel hors FetchGraph

À ce jour :
- l’utilisation des méthodes de repository **sans `FetchGraph`**
- ou des mappers **sans graph explicite**

entraîne toujours :
- un **fetch profond en lazy loading**
- des risques de dégradation de performance

---

## 🧭 Prochaines étapes recommandées

- Généraliser l’utilisation de `FetchGraph` sur toutes les requêtes critiques
- Définir des **graphes de fetch par cas d’usage**
- Sécuriser les nouveaux développements en évitant toute requête sans graph explicite

---

## ✅ Résultat attendu

- Réduction du nombre de requêtes SQL
- Temps de réponse plus stables et prévisibles
- Meilleure maîtrise des performances à long terme