### PR TITLE
fix(declared-experience): introduce new endpoint for delete

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
@@ -11,6 +11,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.port.input.DeclaredExperienceService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -86,5 +87,11 @@ public class DeclaredExperienceController {
             request.endDate());
 
     return ResponseEntity.ok(DeclaredExperienceMapper.toDTO(experience));
+  }
+
+  @DeleteMapping("/")
+  public ResponseEntity<String> deleteDeclaredExperiences(@RequestBody List<UUID> experienceIds) {
+    declaredExperienceService.delete(experienceIds);
+    return ResponseEntity.ok("Declared experiences successfully deleted");
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
@@ -5,6 +5,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 public interface DeclaredExperienceService {
@@ -48,6 +49,8 @@ public interface DeclaredExperienceService {
       String externalLink,
       LocalDate startDate,
       LocalDate endDate);
+
+  void delete(List<UUID> experienceIds);
 
   DeclaredExperience get(UUID experienceId);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
@@ -3,6 +3,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.experience.domain.serv
 import static fr.avenirsesr.portfolio.common.validation.domain.constraints.FieldMaxLengths.*;
 import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.*;
 
+import fr.avenirsesr.portfolio.common.data.domain.model.AvenirsBaseModel;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
@@ -15,6 +16,8 @@ import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.port.
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.StudentRepository;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -208,6 +211,26 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
     requireNotNull("startDate", startDate);
     validateDateOrder(startDate, endDate);
     validateUrl(externalLink);
+  }
+
+  @Override
+  public void delete(List<UUID> experienceIds) {
+    Student student = loggedInUserService.getLoggedInStudent();
+    log.info("Deleting experienceIds {} by {}", experienceIds, student);
+
+    var experiences = experienceRepository.findAllById(experienceIds);
+
+    if (experiences.stream().anyMatch(experience -> !experience.getStudent().equals(student))) {
+      throw new UserNotAuthorizedException();
+    }
+
+    if (!new HashSet<>(experiences.stream().map(AvenirsBaseModel::getId).toList())
+        .containsAll(experienceIds)) {
+      throw new DeclaredExperienceNotFoundException();
+    }
+
+    experienceRepository.removeAllFromDatabase(experiences);
+    log.info("ExperienceIds {} successfully deleted", experienceIds);
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -30,6 +30,12 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
   @Value("${user.student.signature}")
   private String studentSignature;
 
+  @Value("${user.second.student.payload}")
+  private String otherStudentPayload;
+
+  @Value("${user.second.student.signature}")
+  private String otherStudentSignature;
+
   private final String notFoundDeclaredExperienceId = "00000000-0000-0000-0000-000000000000";
 
   @BeforeAll
@@ -90,7 +96,6 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
             .andExpect(status().isCreated())
             .andReturn();
 
-    // Extract ID from creation response
     String responseBody = result.getResponse().getContentAsString();
     String createdId =
         responseBody.substring(responseBody.indexOf(":") + 2, responseBody.indexOf(",") - 1);
@@ -295,5 +300,116 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(invalidUpdateJson))
         .andExpect(status().isBadRequest());
+  }
+
+  @Transactional
+  @Test
+  void shouldDeleteDeclaredExperiences() throws Exception {
+    BddLogger.given("an existing declared experience");
+    var result =
+        mockMvc
+            .perform(
+                post(BASE_PATH + "/")
+                    .header("X-Signed-Context", studentPayload)
+                    .header("X-Context-Kid", secretKey)
+                    .header("X-Context-Signature", studentSignature)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(buildCreateExperienceJson()))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+    String createdId =
+        result
+            .getResponse()
+            .getContentAsString()
+            .substring(
+                result.getResponse().getContentAsString().indexOf(":") + 2,
+                result.getResponse().getContentAsString().indexOf(",") - 1);
+
+    BddLogger.when("performing DELETE on that declared experience");
+    BddLogger.then("it should delete successfully");
+
+    String deleteJson = "[\"" + createdId + "\"]";
+
+    mockMvc
+        .perform(
+            delete(BASE_PATH + "/")
+                .header("X-Signed-Context", studentPayload)
+                .header("X-Context-Kid", secretKey)
+                .header("X-Context-Signature", studentSignature)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(deleteJson))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("successfully deleted")));
+
+    BddLogger.then("trying to GET the deleted experience should return 404");
+
+    mockMvc
+        .perform(
+            get(BASE_PATH + "/" + createdId)
+                .header("X-Signed-Context", studentPayload)
+                .header("X-Context-Kid", secretKey)
+                .header("X-Context-Signature", studentSignature))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenDeletingNonExistingExperience() throws Exception {
+    BddLogger.given("a non existing declared experience id");
+    BddLogger.when("performing DELETE with unknown id");
+    BddLogger.then("it should return not found");
+
+    String deleteJson = "[\"" + notFoundDeclaredExperienceId + "\"]";
+
+    mockMvc
+        .perform(
+            delete(BASE_PATH + "/")
+                .header("X-Signed-Context", studentPayload)
+                .header("X-Context-Kid", secretKey)
+                .header("X-Context-Signature", studentSignature)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(deleteJson))
+        .andExpect(status().isNotFound());
+  }
+
+  @Transactional
+  @Test
+  void shouldReturnUnauthorizedWhenDeletingOtherStudentsExperience() throws Exception {
+    BddLogger.given("an existing declared experience for another student");
+
+    var result =
+        mockMvc
+            .perform(
+                post(BASE_PATH + "/")
+                    .header("X-Signed-Context", otherStudentPayload)
+                    .header("X-Context-Kid", secretKey)
+                    .header("X-Context-Signature", otherStudentSignature)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(buildCreateExperienceJson()))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+    String otherId =
+        result
+            .getResponse()
+            .getContentAsString()
+            .substring(
+                result.getResponse().getContentAsString().indexOf(":") + 2,
+                result.getResponse().getContentAsString().indexOf(",") - 1);
+
+    BddLogger.when("performing DELETE on that experience as another student");
+    BddLogger.then("it should return unauthorized");
+
+    String deleteJson = "[\"" + otherId + "\"]";
+
+    mockMvc
+        .perform(
+            delete(BASE_PATH + "/")
+                .header("X-Signed-Context", studentPayload)
+                .header("X-Context-Kid", secretKey)
+                .header("X-Context-Signature", studentSignature)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(deleteJson))
+        .andExpect(status().isForbidden());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
@@ -15,6 +15,7 @@ import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.StudentRepository;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -825,5 +826,86 @@ class DeclaredExperienceServiceImplTest {
     verify(experience).setEndDate(end);
 
     verify(experienceRepository).save(experience);
+  }
+
+  @Test
+  void shouldDeleteExperiencesWhenStudentIsOwner() {
+    Student loggedIn = student;
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    DeclaredExperience exp1 = mock(DeclaredExperience.class);
+    DeclaredExperience exp2 = mock(DeclaredExperience.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(exp1.getStudent()).thenReturn(loggedIn);
+    when(exp2.getStudent()).thenReturn(loggedIn);
+    when(exp1.getId()).thenReturn(id1);
+    when(exp2.getId()).thenReturn(id2);
+    when(experienceRepository.findAllById(List.of(id1, id2))).thenReturn(List.of(exp1, exp2));
+
+    service.delete(List.of(id1, id2));
+
+    verify(experienceRepository).findAllById(List.of(id1, id2));
+    verify(experienceRepository).removeAllFromDatabase(List.of(exp1, exp2));
+  }
+
+  @Test
+  void shouldThrowWhenExperienceNotFoundOnDelete() {
+    Student loggedIn = student;
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    DeclaredExperience exp1 = mock(DeclaredExperience.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(exp1.getStudent()).thenReturn(loggedIn);
+
+    when(experienceRepository.findAllById(List.of(id1, id2))).thenReturn(List.of(exp1));
+
+    assertThrows(
+        DeclaredExperienceNotFoundException.class, () -> service.delete(List.of(id1, id2)));
+  }
+
+  @Test
+  void shouldThrowWhenOneExperienceBelongsToAnotherStudent() {
+    Student loggedIn = student;
+    Student other = StudentFixture.create().withId(UUID.randomUUID()).toModel();
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    DeclaredExperience exp1 = mock(DeclaredExperience.class);
+    DeclaredExperience exp2 = mock(DeclaredExperience.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(exp1.getStudent()).thenReturn(loggedIn);
+    when(exp2.getStudent()).thenReturn(other);
+
+    when(experienceRepository.findAllById(List.of(id1, id2))).thenReturn(List.of(exp1, exp2));
+
+    assertThrows(UserNotAuthorizedException.class, () -> service.delete(List.of(id1, id2)));
+  }
+
+  @Test
+  void shouldThrowWhenNoExperienceFoundAtAll() {
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(experienceRepository.findAllById(anyList())).thenReturn(List.of());
+
+    assertThrows(
+        DeclaredExperienceNotFoundException.class,
+        () -> service.delete(List.of(UUID.randomUUID())));
+  }
+
+  @Test
+  void shouldHandleSingleIdDeletion() {
+    Student loggedIn = student;
+    UUID id = UUID.randomUUID();
+    DeclaredExperience exp = mock(DeclaredExperience.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(exp.getStudent()).thenReturn(loggedIn);
+    when(exp.getId()).thenReturn(id);
+    when(experienceRepository.findAllById(List.of(id))).thenReturn(List.of(exp));
+
+    service.delete(List.of(id));
+
+    verify(experienceRepository).removeAllFromDatabase(List.of(exp));
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
introduce new endpoint `DELETE /me/declared/experinces` that expect a list of ids as body and delete the related declared experiences

---

### Reference to an Issue, Feature, Task, User Story or another PR
closes https://github.com/avenirs-esr/AVENIRS-Project/issues/908

---

### Target Branch
develop

---