### PR TITLE
chore: rollback changelogs and create new one

### DIFF
--- a/src/main/resources/db/changelog/generated/changelog_2025-09-20__09-40-32.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2025-09-20__09-40-32.xml
@@ -513,8 +513,8 @@
             <column name="email" type="VARCHAR(255)"/>
             <column name="student_bio" type="VARCHAR(255)"/>
             <column name="student_is_active" type="BOOLEAN"/>
-            <column name="staff_bio" type="VARCHAR(255)"/>
-            <column name="staff_is_active" type="BOOLEAN"/>
+            <column name="teacher_bio" type="VARCHAR(255)"/>
+            <column name="teacher_is_active" type="BOOLEAN"/>
             <column defaultValueComputed="CURRENT_TIMESTAMP" name="created_at" type="TIMESTAMP WITH TIME ZONE">
                 <constraints nullable="false"/>
             </column>

--- a/src/main/resources/db/changelog/generated/changelog_2025-10-17__16-18-21.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2025-10-17__16-18-21.xml
@@ -28,9 +28,9 @@
         </createTable>
     </changeSet>
     <changeSet author="bilelbanelhaq (generated)" id="1760717905973-2">
-        <createTable tableName="staff">
+        <createTable tableName="teacher">
             <column name="id" type="UUID">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="staffPK"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="teacherPK"/>
             </column>
             <column defaultValueComputed="CURRENT_TIMESTAMP" name="created_at" type="TIMESTAMP WITH TIME ZONE">
                 <constraints nullable="false"/>
@@ -53,7 +53,7 @@
         <addUniqueConstraint columnNames="user_id" constraintName="UC_STUDENTUSER_ID_COL" tableName="student"/>
     </changeSet>
     <changeSet author="bilelbanelhaq (generated)" id="1760717905973-6">
-        <addUniqueConstraint columnNames="user_id" constraintName="UC_STAFFUSER_ID_COL" tableName="staff"/>
+        <addUniqueConstraint columnNames="user_id" constraintName="UC_TEACHERUSER_ID_COL" tableName="teacher"/>
     </changeSet>
     <changeSet author="bilelbanelhaq (generated)" id="1760717905973-7">
         <addForeignKeyConstraint baseColumnNames="student_id" baseTableName="ams" constraintName="FK29yky9jptfmqhqn4l6cersqy" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="student" validate="true"/>
@@ -65,7 +65,7 @@
         <addForeignKeyConstraint baseColumnNames="student_id" baseTableName="skill_level_progress" constraintName="FKedbx4lwc4vqlweeuky0s9mehd" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="student" validate="true"/>
     </changeSet>
     <changeSet author="bilelbanelhaq (generated)" id="1760717905973-11">
-        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="staff" constraintName="FKf3nb30ggdsojitnha20fcd0jv" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="user" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="teacher" constraintName="FKf3nb30ggdsojitnha20fcd0jv" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="user" validate="true"/>
     </changeSet>
     <changeSet author="bilelbanelhaq (generated)" id="1760717905973-12">
         <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="student" constraintName="FKhl0igmb8xve6vd1rc42ldf4p9" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="user" validate="true"/>
@@ -80,10 +80,10 @@
         <dropColumn columnName="student_is_active" tableName="user"/>
     </changeSet>
     <changeSet author="bilelbanelhaq (generated)" id="1760717905973-23">
-        <dropColumn columnName="staff_bio" tableName="user"/>
+        <dropColumn columnName="teacher_bio" tableName="user"/>
     </changeSet>
     <changeSet author="bilelbanelhaq (generated)" id="1760717905973-24">
-        <dropColumn columnName="staff_is_active" tableName="user"/>
+        <dropColumn columnName="teacher_is_active" tableName="user"/>
     </changeSet>
     <changeSet author="bilelbanelhaq (generated)" id="1760717905973-25">
         <dropColumn columnName="user_id" tableName="ams"/>

--- a/src/main/resources/db/changelog/generated/changelog_2026-01-06__10-49-24.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-01-06__10-49-24.xml
@@ -114,7 +114,7 @@
         <modifyDataType columnName="bio" newDataType="VARCHAR(400)" tableName="student"/>
     </changeSet>
     <changeSet id="1767692913055-4" author="nathp">
-        <modifyDataType columnName="bio" newDataType="VARCHAR(400)" tableName="staff"/>
+        <modifyDataType columnName="bio" newDataType="VARCHAR(400)" tableName="teacher"/>
     </changeSet>
     <changeSet id="1767692913055-5" author="nathp">
         <modifyDataType columnName="description" newDataType="VARCHAR(400)" tableName="cohort"/>

--- a/src/main/resources/db/changelog/generated/changelog_2026-04-08__09-08-56.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-04-08__09-08-56.xml
@@ -1,0 +1,33 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="pbeger (generated)" id="1775639342890-4">
+        <dropForeignKeyConstraint baseTableName="teacher" constraintName="FKf3nb30ggdsojitnha20fcd0jv"/>
+    </changeSet>
+    <changeSet author="pbeger (generated)" id="1775639342890-1">
+        <createTable tableName="staff">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="staffPK"/>
+            </column>
+            <column defaultValueComputed="CURRENT_TIMESTAMP" name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueComputed="CURRENT_TIMESTAMP" name="updated_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="bio" type="VARCHAR(400)"/>
+            <column name="user_id" type="UUID"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="pbeger (generated)" id="1775639342890-2">
+        <addUniqueConstraint columnNames="user_id" constraintName="UC_STAFFUSER_ID_COL" tableName="staff"/>
+    </changeSet>
+    <changeSet author="pbeger (generated)" id="1775639342890-3">
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="staff" constraintName="FK4i3t4vgl7l6p28i1hm6eq0ny6" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="user" validate="true"/>
+    </changeSet>
+    <changeSet author="pbeger (generated)" id="1775639342890-5">
+        <dropUniqueConstraint constraintName="uc_teacheruser_id_col" tableName="teacher"/>
+    </changeSet>
+    <changeSet author="pbeger (generated)" id="1775639342890-6">
+        <dropTable tableName="teacher"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR corrects the Liquibase changelog approach for the `teacher` → `staff` table rename. The previous PR (#251) incorrectly modified already-applied changelogs in-place, which would break Liquibase checksum validation on existing environments. This PR reverts those changelog edits and instead introduces a proper new migration changelog.

**Main changes:**
- ♻️ Reverts in-place edits on `changelog_2025-09-20__09-40-32.xml` — restores `teacher_bio`/`teacher_is_active` column names (original state)
- ♻️ Reverts in-place edits on `changelog_2025-10-17__16-18-21.xml` — restores `teacher` table name, `teacherPK`, `UC_TEACHERUSER_ID_COL`, and related FK names (original state)
- ♻️ Reverts in-place edit on `changelog_2026-01-06__10-49-24.xml` — restores `bio` column modification target to `teacher` table (original state)
- ✨ Adds new migration `changelog_2026-04-08__09-08-56.xml` with proper changesets:
  - Drop FK on `teacher`
  - Create new `staff` table with `staffPK`, `UC_STAFFUSER_ID_COL`, and FK to `user`
  - Drop unique constraint and drop `teacher` table

---

### Reference to an Issue, Feature, Task, User Story or another PR
Relates to https://github.com/avenirs-esr/AVENIRS-Project/issues/1392

Companion to avenirs-esr/avenirs-portfolio-api#251

---

### Documentation
Liquibase best practice: never modify an already-applied changelog. This PR replaces the incorrect in-place edits with a forward-only migration script that is safe to apply on top of any existing environment.

**Modified files:**
- `src/main/resources/db/changelog/generated/changelog_2025-09-20__09-40-32.xml` — reverted to original
- `src/main/resources/db/changelog/generated/changelog_2025-10-17__16-18-21.xml` — reverted to original
- `src/main/resources/db/changelog/generated/changelog_2026-01-06__10-49-24.xml` — reverted to original
- `src/main/resources/db/changelog/generated/changelog_2026-04-08__09-08-56.xml` — new migration: teacher → staff table rename

---

### Target Branch
`develop`

---

### Additional Notes
This PR should be reviewed and merged together with (or after) PR #251 (`refactor/1392-replace-teacher-with-staff`). The two PRs together produce a correct and migration-safe rename of the `teacher` table to `staff`.

The new changelog follows the existing naming convention (`YYYY-MM-DD__HH-mm-ss`) and was generated from the current database state.

---

### Known Limitations or Side Effects
- Environments that already applied the incorrect in-place changelog edits from PR #251 will need a `liquibase clearChecksums` or database reset before applying this PR.

---

## ✅ Checklist

- [ ] a11y tested (backend module, not applicable)
- [ ] Tests provided (migration-only change, no Java tests required)
- [ ] i18n handled (backend module, not applicable)
- [ ] Performance tests (no performance impact)
- [x] No unnecessary code (no debug logs or commented code)
- [x] Code style and formatting rules respected (Liquibase conventions followed)
- [x] Semantic Versioning respected (conventional commit used)
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process (new Liquibase changelog: creates `staff` table, drops `teacher` table)