### PR TITLE
refactor(declared-skills): remove externalSkillId

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/domain/model/DeclaredSkill.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/domain/model/DeclaredSkill.java
@@ -12,7 +12,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class DeclaredSkill extends AvenirsBaseModel {
-  private UUID externalSkillId;
   private String libelle;
   private EExternalSkillType type;
 
@@ -21,36 +20,31 @@ public class DeclaredSkill extends AvenirsBaseModel {
 
   private DeclaredSkill(
       UUID id,
-      UUID externalSkillId,
       String libelle,
       EExternalSkillType type,
       List<String> pathSegments,
       Instant createdAt,
       Instant updatedAt) {
     super(id, createdAt, updatedAt);
-    this.externalSkillId = externalSkillId;
     this.libelle = libelle;
     this.type = type;
     this.pathSegments = pathSegments != null ? pathSegments : List.of();
   }
 
   public static DeclaredSkill create(
-      UUID externalSkillId, String libelle, EExternalSkillType type, List<String> pathSegments) {
+      UUID id, String libelle, EExternalSkillType type, List<String> pathSegments) {
     Instant now = Instant.now();
-    return new DeclaredSkill(
-        UUID.randomUUID(), externalSkillId, libelle, type, pathSegments, now, now);
+    return new DeclaredSkill(id, libelle, type, pathSegments, now, now);
   }
 
   public static DeclaredSkill toDomain(
       UUID id,
-      UUID externalSkillId,
       String libelle,
       EExternalSkillType type,
       List<String> pathSegments,
       Instant createdAt,
       Instant updatedAt) {
-    return new DeclaredSkill(
-        id, externalSkillId, libelle, type, pathSegments, createdAt, updatedAt);
+    return new DeclaredSkill(id, libelle, type, pathSegments, createdAt, updatedAt);
   }
 
   public void setPathSegments(List<String> pathSegments) {

--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/domain/port/input/DeclaredSkillSyncService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/domain/port/input/DeclaredSkillSyncService.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface DeclaredSkillSyncService {
-  Optional<DeclaredSkill> getOrCreateFromExternalSkill(UUID externalSkillId);
+  Optional<DeclaredSkill> getOrCreateFromExternalSkill(UUID id);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/domain/port/output/repository/DeclaredSkillRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/domain/port/output/repository/DeclaredSkillRepository.java
@@ -2,11 +2,7 @@ package fr.avenirsesr.portfolio.declaredskill.domain.port.output.repository;
 
 import fr.avenirsesr.portfolio.common.data.domain.port.output.repository.GenericRepositoryPort;
 import fr.avenirsesr.portfolio.declaredskill.domain.model.DeclaredSkill;
-import java.util.Optional;
-import java.util.UUID;
 
 public interface DeclaredSkillRepository extends GenericRepositoryPort<DeclaredSkill> {
-  Optional<DeclaredSkill> findByExternalSkillId(UUID externalSkillId);
-
   DeclaredSkill saveOrGet(DeclaredSkill declaredSkill);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/domain/service/DeclaredSkillSyncServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/domain/service/DeclaredSkillSyncServiceImpl.java
@@ -19,20 +19,19 @@ public class DeclaredSkillSyncServiceImpl implements DeclaredSkillSyncService {
   private final ExternalSkillClient externalSkillClient;
 
   @Override
-  public Optional<DeclaredSkill> getOrCreateFromExternalSkill(UUID externalSkillId) {
-    Optional<DeclaredSkill> existing =
-        declaredSkillRepository.findByExternalSkillId(externalSkillId);
+  public Optional<DeclaredSkill> getOrCreateFromExternalSkill(UUID id) {
+    Optional<DeclaredSkill> existing = declaredSkillRepository.findById(id);
 
     if (existing.isPresent()) {
-      log.debug("DeclaredSkill already exists for external skill: {}", externalSkillId);
+      log.debug("DeclaredSkill already exists for external skill: {}", id);
       return existing;
     }
 
-    log.debug("Fetching external skill from interoperability: {}", externalSkillId);
-    Optional<ExternalSkillDTO> externalSkillDTO = externalSkillClient.getById(externalSkillId);
+    log.debug("Fetching external skill from interoperability: {}", id);
+    Optional<ExternalSkillDTO> externalSkillDTO = externalSkillClient.getById(id);
 
     if (externalSkillDTO.isEmpty()) {
-      log.warn("External skill not found in interoperability: {}", externalSkillId);
+      log.warn("External skill not found in interoperability: {}", id);
       return Optional.empty();
     }
 
@@ -45,7 +44,7 @@ public class DeclaredSkillSyncServiceImpl implements DeclaredSkillSyncService {
             dto.pathSegments());
 
     DeclaredSkill saved = declaredSkillRepository.saveOrGet(newSkill);
-    log.info("Created new DeclaredSkill from external skill: {}", externalSkillId);
+    log.info("Created new DeclaredSkill from external skill: {}", id);
     return Optional.of(saved);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/client/ExternalSkillClient.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/client/ExternalSkillClient.java
@@ -33,14 +33,14 @@ public class ExternalSkillClient {
     this.webClient = webClient;
   }
 
-  @Cacheable(value = "externalSkillById", key = "#externalSkillId")
-  public Optional<ExternalSkillDTO> getById(UUID externalSkillId) {
+  @Cacheable(value = "externalSkillById", key = "#id")
+  public Optional<ExternalSkillDTO> getById(UUID id) {
     try {
-      log.debug("Fetching external skill from interoperability: {}", externalSkillId);
+      log.debug("Fetching external skill from interoperability: {}", id);
       ExternalSkillDetailsDTO details =
           webClient
               .get()
-              .uri(externalSkillEndpoint + "/" + externalSkillId)
+              .uri(externalSkillEndpoint + "/" + id)
               .header(AvenirsSecurityHeaders.API_KEY, apiKey)
               .retrieve()
               .bodyToMono(ExternalSkillDetailsDTO.class)
@@ -61,7 +61,7 @@ public class ExternalSkillClient {
     } catch (Exception e) {
       log.error(
           "Failed to fetch external skill {} from interoperability at '{}'. Error: {}",
-          externalSkillId,
+          id,
           externalSkillEndpoint,
           e.getMessage());
       log.debug("Full error details:", e);
@@ -69,14 +69,14 @@ public class ExternalSkillClient {
     }
   }
 
-  @Cacheable(value = "externalSkillDetails", key = "#externalSkillId")
-  public Optional<ExternalSkillDetailsDTO> getExternalSkillDetails(UUID externalSkillId) {
+  @Cacheable(value = "externalSkillDetails", key = "#id")
+  public Optional<ExternalSkillDetailsDTO> getExternalSkillDetails(UUID id) {
     try {
-      log.debug("Fetching external skill details from interoperability: {}", externalSkillId);
+      log.debug("Fetching external skill details from interoperability: {}", id);
       ExternalSkillDetailsDTO result =
           webClient
               .get()
-              .uri(externalSkillEndpoint + "/" + externalSkillId)
+              .uri(externalSkillEndpoint + "/" + id)
               .header(AvenirsSecurityHeaders.API_KEY, apiKey)
               .retrieve()
               .bodyToMono(ExternalSkillDetailsDTO.class)
@@ -85,7 +85,7 @@ public class ExternalSkillClient {
     } catch (Exception e) {
       log.error(
           "Failed to fetch external skill details {} from interoperability at '{}'. Error: {}",
-          externalSkillId,
+          id,
           externalSkillEndpoint,
           e.getMessage());
       log.debug("Full error details:", e);

--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/mapper/DeclaredSkillMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/mapper/DeclaredSkillMapper.java
@@ -12,7 +12,6 @@ public class DeclaredSkillMapper implements Mapper<DeclaredSkillEntity, Declared
   public DeclaredSkill toDomain(DeclaredSkillEntity entity) {
     return DeclaredSkill.toDomain(
         entity.getId(),
-        entity.getExternalSkillId(),
         entity.getLibelle(),
         entity.getType(),
         entity.getPathSegments(),
@@ -23,10 +22,6 @@ public class DeclaredSkillMapper implements Mapper<DeclaredSkillEntity, Declared
   @Override
   public DeclaredSkillEntity fromDomain(DeclaredSkill domain) {
     return DeclaredSkillEntity.of(
-        domain.getId(),
-        domain.getExternalSkillId(),
-        domain.getLibelle(),
-        domain.getType(),
-        domain.getPathSegments());
+        domain.getId(), domain.getLibelle(), domain.getType(), domain.getPathSegments());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/model/DeclaredSkillEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/model/DeclaredSkillEntity.java
@@ -12,16 +12,11 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(
-    name = "declared_skill",
-    uniqueConstraints = @UniqueConstraint(columnNames = {"external_skill_id", "type"}))
+@Table(name = "declared_skill", uniqueConstraints = @UniqueConstraint(columnNames = {"type"}))
 @NoArgsConstructor
 @Getter
 @Setter
 public class DeclaredSkillEntity extends AvenirsBaseEntity {
-
-  @Column(nullable = false, name = "external_skill_id")
-  private UUID externalSkillId;
 
   @Column(name = "libelle")
   private String libelle;
@@ -36,30 +31,21 @@ public class DeclaredSkillEntity extends AvenirsBaseEntity {
   private List<String> pathSegments;
 
   private DeclaredSkillEntity(
-      UUID id,
-      UUID externalSkillId,
-      String libelle,
-      EExternalSkillType type,
-      List<String> pathSegments) {
+      UUID id, String libelle, EExternalSkillType type, List<String> pathSegments) {
     setId(id);
-    this.externalSkillId = externalSkillId;
     this.libelle = libelle;
     this.type = type;
     this.pathSegments = pathSegments != null ? pathSegments : List.of();
   }
 
   public static DeclaredSkillEntity of(
-      UUID id,
-      UUID externalSkillId,
-      String libelle,
-      EExternalSkillType type,
-      List<String> pathSegments) {
-    return new DeclaredSkillEntity(id, externalSkillId, libelle, type, pathSegments);
+      UUID id, String libelle, EExternalSkillType type, List<String> pathSegments) {
+    return new DeclaredSkillEntity(id, libelle, type, pathSegments);
   }
 
   public static DeclaredSkillEntity create(
-      UUID externalSkillId, String libelle, EExternalSkillType type, List<String> pathSegments) {
-    return new DeclaredSkillEntity(UUID.randomUUID(), externalSkillId, libelle, type, pathSegments);
+      UUID id, String libelle, EExternalSkillType type, List<String> pathSegments) {
+    return new DeclaredSkillEntity(id, libelle, type, pathSegments);
   }
 
   public void setPathSegments(List<String> pathSegments) {

--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/repository/DeclaredSkillDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/repository/DeclaredSkillDatabaseRepository.java
@@ -22,10 +22,8 @@ public class DeclaredSkillDatabaseRepository
   }
 
   @Override
-  public Optional<DeclaredSkill> findByExternalSkillId(UUID externalSkillId) {
-    return jpaRepository
-        .findByExternalSkillId(externalSkillId)
-        .map(DeclaredSkillMapper.INSTANCE::toDomain);
+  public Optional<DeclaredSkill> findById(UUID id) {
+    return jpaRepository.findById(id).map(DeclaredSkillMapper.INSTANCE::toDomain);
   }
 
   @Override
@@ -33,7 +31,7 @@ public class DeclaredSkillDatabaseRepository
     try {
       return save(declaredSkill);
     } catch (DataIntegrityViolationException e) {
-      return findByExternalSkillId(declaredSkill.getExternalSkillId()).orElseThrow(() -> e);
+      return findById(declaredSkill.getId()).orElseThrow(() -> e);
     }
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/repository/DeclaredSkillJpaRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/repository/DeclaredSkillJpaRepository.java
@@ -1,13 +1,10 @@
 package fr.avenirsesr.portfolio.declaredskill.infrastructure.adapter.repository;
 
 import fr.avenirsesr.portfolio.declaredskill.infrastructure.adapter.model.DeclaredSkillEntity;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface DeclaredSkillJpaRepository
     extends JpaRepository<DeclaredSkillEntity, UUID>,
-        JpaSpecificationExecutor<DeclaredSkillEntity> {
-  Optional<DeclaredSkillEntity> findByExternalSkillId(UUID externalSkillId);
-}
+        JpaSpecificationExecutor<DeclaredSkillEntity> {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImpl.java
@@ -66,7 +66,7 @@ public class DeclaredSkillProgressServiceImpl implements DeclaredSkillProgressSe
   public DeclaredSkillProgress createDeclaredSkillProgress(
       UUID declaredSkillId, EExternalSkillType type, EDeclaredSkillLevel level, String reflection) {
     Student student = loggedInUserService.getLoggedInStudent();
-    requireNotNull("externalSkillId", declaredSkillId);
+    requireNotNull("id", declaredSkillId);
     requireNotNull("type", type);
     requireNotNull("level", level);
     try {
@@ -131,11 +131,11 @@ public class DeclaredSkillProgressServiceImpl implements DeclaredSkillProgressSe
     List<Trace> traces =
         traceService.getTracesLinkedWithDeclaredSkillProgress(declaredSkillProgress);
 
-    UUID externalSkillId = declaredSkillProgress.getSkill().getExternalSkillId();
+    UUID id = declaredSkillProgress.getSkill().getId();
     ExternalSkillDetailsDTO externalSkillDetails =
         externalSkillClient
-            .getExternalSkillDetails(externalSkillId)
-            .orElse(new ExternalSkillDetailsDTO(externalSkillId, "", List.of(), null));
+            .getExternalSkillDetails(id)
+            .orElse(new ExternalSkillDetailsDTO(id, "", List.of(), null));
 
     return new DeclaredSkillProgressDetails(
         declaredSkillProgress,

--- a/src/test/java/fr/avenirsesr/portfolio/declaredskill/domain/model/DeclaredSkillTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/declaredskill/domain/model/DeclaredSkillTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 class DeclaredSkillTest {
 
-  private final UUID externalSkillId = UUID.randomUUID();
+  private final UUID id = UUID.randomUUID();
   private final String libelle = "Java Programming";
   private final EExternalSkillType type = EExternalSkillType.ROME4;
   private final List<String> pathSegments = List.of("Domain", "Issue", "MacroSkill", "Skill");
@@ -21,12 +21,12 @@ class DeclaredSkillTest {
     BddLogger.given("valid declared skill data");
 
     BddLogger.when("creating a new DeclaredSkill");
-    DeclaredSkill skill = DeclaredSkill.create(externalSkillId, libelle, type, pathSegments);
+    DeclaredSkill skill = DeclaredSkill.create(id, libelle, type, pathSegments);
 
     BddLogger.then("it should create an instance with all fields set");
     assertNotNull(skill);
     assertNotNull(skill.getId());
-    assertEquals(externalSkillId, skill.getExternalSkillId());
+    assertEquals(id, skill.getId());
     assertEquals(libelle, skill.getLibelle());
     assertEquals(type, skill.getType());
     assertEquals(pathSegments, skill.getPathSegments());
@@ -39,7 +39,7 @@ class DeclaredSkillTest {
     BddLogger.given("valid declared skill data");
 
     BddLogger.when("creating a new DeclaredSkill");
-    DeclaredSkill skill = DeclaredSkill.create(externalSkillId, libelle, type, pathSegments);
+    DeclaredSkill skill = DeclaredSkill.create(id, libelle, type, pathSegments);
 
     BddLogger.then("it should generate an ID automatically");
     assertNotNull(skill.getId());
@@ -52,7 +52,7 @@ class DeclaredSkillTest {
     Instant beforeCreation = Instant.now();
 
     BddLogger.when("creating a new DeclaredSkill");
-    DeclaredSkill skill = DeclaredSkill.create(externalSkillId, libelle, type, pathSegments);
+    DeclaredSkill skill = DeclaredSkill.create(id, libelle, type, pathSegments);
 
     BddLogger.then("it should set createdAt and updatedAt to current time");
     assertNotNull(skill.getCreatedAt());
@@ -67,19 +67,16 @@ class DeclaredSkillTest {
   @Test
   void shouldCreateFromDomainWithAllFields() {
     BddLogger.given("complete domain data");
-    UUID id = UUID.randomUUID();
     Instant createdAt = Instant.now().minusSeconds(3600);
     Instant updatedAt = Instant.now();
 
     BddLogger.when("creating DeclaredSkill from domain data");
     DeclaredSkill skill =
-        DeclaredSkill.toDomain(
-            id, externalSkillId, libelle, type, pathSegments, createdAt, updatedAt);
+        DeclaredSkill.toDomain(id, libelle, type, pathSegments, createdAt, updatedAt);
 
     BddLogger.then("it should create an instance with all provided fields");
     assertNotNull(skill);
     assertEquals(id, skill.getId());
-    assertEquals(externalSkillId, skill.getExternalSkillId());
     assertEquals(libelle, skill.getLibelle());
     assertEquals(type, skill.getType());
     assertEquals(pathSegments, skill.getPathSegments());
@@ -92,13 +89,13 @@ class DeclaredSkillTest {
     BddLogger.given("declared skill data with null pathSegments");
 
     BddLogger.when("creating a new DeclaredSkill");
-    DeclaredSkill skill = DeclaredSkill.create(externalSkillId, libelle, type, null);
+    DeclaredSkill skill = DeclaredSkill.create(id, libelle, type, null);
 
     BddLogger.then("it should convert null pathSegments to empty list");
     assertNotNull(skill);
     assertNotNull(skill.getPathSegments());
     assertTrue(skill.getPathSegments().isEmpty());
-    assertEquals(externalSkillId, skill.getExternalSkillId());
+    assertEquals(id, skill.getId());
     assertEquals(libelle, skill.getLibelle());
     assertEquals(type, skill.getType());
   }
@@ -109,7 +106,7 @@ class DeclaredSkillTest {
     List<String> emptyPathSegments = List.of();
 
     BddLogger.when("creating a new DeclaredSkill");
-    DeclaredSkill skill = DeclaredSkill.create(externalSkillId, libelle, type, emptyPathSegments);
+    DeclaredSkill skill = DeclaredSkill.create(id, libelle, type, emptyPathSegments);
 
     BddLogger.then("it should accept empty pathSegments");
     assertNotNull(skill);
@@ -120,21 +117,18 @@ class DeclaredSkillTest {
   @Test
   void shouldAllowSettersForAllFields() {
     BddLogger.given("an DeclaredSkill instance");
-    DeclaredSkill skill = DeclaredSkill.create(externalSkillId, libelle, type, pathSegments);
+    DeclaredSkill skill = DeclaredSkill.create(id, libelle, type, pathSegments);
 
     BddLogger.when("using setters to modify fields");
-    UUID newExternalSkillId = UUID.randomUUID();
     String newLibelle = "New Skill";
     EExternalSkillType newType = EExternalSkillType.XXI;
     List<String> newPathSegments = List.of("A", "B", "C");
 
-    skill.setExternalSkillId(newExternalSkillId);
     skill.setLibelle(newLibelle);
     skill.setType(newType);
     skill.setPathSegments(newPathSegments);
 
     BddLogger.then("all fields should be updated");
-    assertEquals(newExternalSkillId, skill.getExternalSkillId());
     assertEquals(newLibelle, skill.getLibelle());
     assertEquals(newType, skill.getType());
     assertEquals(newPathSegments, skill.getPathSegments());
@@ -144,8 +138,7 @@ class DeclaredSkillTest {
   void shouldPreserveImmutablePathSegmentsList() {
     BddLogger.given("an DeclaredSkill with pathSegments");
     List<String> originalPathSegments = List.of("A", "B", "C");
-    DeclaredSkill skill =
-        DeclaredSkill.create(externalSkillId, libelle, type, originalPathSegments);
+    DeclaredSkill skill = DeclaredSkill.create(id, libelle, type, originalPathSegments);
 
     BddLogger.when("getting pathSegments");
     List<String> retrievedPathSegments = skill.getPathSegments();

--- a/src/test/java/fr/avenirsesr/portfolio/declaredskill/domain/service/DeclaredSkillSyncServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/declaredskill/domain/service/DeclaredSkillSyncServiceImplTest.java
@@ -32,15 +32,13 @@ class DeclaredSkillSyncServiceImplTest {
   @Test
   void shouldReturnExistingDeclaredSkillWhenAlreadyExists() {
     BddLogger.given("an existing DeclaredSkill in database");
-    UUID externalSkillId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
     DeclaredSkill existing =
-        DeclaredSkill.create(
-            externalSkillId, "Existing Skill", EExternalSkillType.ROME4, List.of("A", "B"));
-    when(declaredSkillRepository.findByExternalSkillId(externalSkillId))
-        .thenReturn(Optional.of(existing));
+        DeclaredSkill.create(id, "Existing Skill", EExternalSkillType.ROME4, List.of("A", "B"));
+    when(declaredSkillRepository.findById(id)).thenReturn(Optional.of(existing));
 
     BddLogger.when("calling getOrCreateFromExternalSkill");
-    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(externalSkillId);
+    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(id);
 
     BddLogger.then("it should return the existing skill without calling external API");
     assertThat(result).isPresent();
@@ -52,28 +50,21 @@ class DeclaredSkillSyncServiceImplTest {
   @Test
   void shouldCreateNewDeclaredSkillWhenNotExists() {
     BddLogger.given("no existing DeclaredSkill and a valid external skill");
-    UUID externalSkillId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
     ExternalSkillDTO externalSkillDTO =
         new ExternalSkillDTO(
-            externalSkillId,
-            "Java Programming",
-            List.of("IT", "Development"),
-            EExternalSkillType.ROME4);
+            id, "Java Programming", List.of("IT", "Development"), EExternalSkillType.ROME4);
 
-    when(declaredSkillRepository.findByExternalSkillId(externalSkillId))
-        .thenReturn(Optional.empty());
-    when(externalSkillClient.getById(externalSkillId)).thenReturn(Optional.of(externalSkillDTO));
+    when(declaredSkillRepository.findById(id)).thenReturn(Optional.empty());
+    when(externalSkillClient.getById(id)).thenReturn(Optional.of(externalSkillDTO));
 
     DeclaredSkill savedSkill =
         DeclaredSkill.create(
-            externalSkillId,
-            "Java Programming",
-            EExternalSkillType.ROME4,
-            List.of("IT", "Development"));
+            id, "Java Programming", EExternalSkillType.ROME4, List.of("IT", "Development"));
     when(declaredSkillRepository.saveOrGet(any(DeclaredSkill.class))).thenReturn(savedSkill);
 
     BddLogger.when("calling getOrCreateFromExternalSkill");
-    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(externalSkillId);
+    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(id);
 
     BddLogger.then("it should create and save a new DeclaredSkill");
     assertThat(result).isPresent();
@@ -82,7 +73,7 @@ class DeclaredSkillSyncServiceImplTest {
     verify(declaredSkillRepository).saveOrGet(captor.capture());
 
     DeclaredSkill captured = captor.getValue();
-    assertThat(captured.getExternalSkillId()).isEqualTo(externalSkillId);
+    assertThat(captured.getId()).isEqualTo(id);
     assertThat(captured.getLibelle()).isEqualTo("Java Programming");
     assertThat(captured.getType()).isEqualTo(EExternalSkillType.ROME4);
     assertThat(captured.getPathSegments()).containsExactly("IT", "Development");
@@ -91,14 +82,13 @@ class DeclaredSkillSyncServiceImplTest {
   @Test
   void shouldReturnEmptyWhenExternalSkillNotFoundInInteroperability() {
     BddLogger.given("no existing DeclaredSkill and external skill not found in interoperability");
-    UUID externalSkillId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
 
-    when(declaredSkillRepository.findByExternalSkillId(externalSkillId))
-        .thenReturn(Optional.empty());
-    when(externalSkillClient.getById(externalSkillId)).thenReturn(Optional.empty());
+    when(declaredSkillRepository.findById(id)).thenReturn(Optional.empty());
+    when(externalSkillClient.getById(id)).thenReturn(Optional.empty());
 
     BddLogger.when("calling getOrCreateFromExternalSkill");
-    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(externalSkillId);
+    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(id);
 
     BddLogger.then("it should return empty and not save anything");
     assertThat(result).isEmpty();
@@ -108,20 +98,19 @@ class DeclaredSkillSyncServiceImplTest {
   @Test
   void shouldHandleNullPathSegments() {
     BddLogger.given("external skill with null pathSegments");
-    UUID externalSkillId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
     ExternalSkillDTO externalSkillDTO =
-        new ExternalSkillDTO(externalSkillId, "Simple Skill", null, EExternalSkillType.XXI);
+        new ExternalSkillDTO(id, "Simple Skill", null, EExternalSkillType.XXI);
 
-    when(declaredSkillRepository.findByExternalSkillId(externalSkillId))
-        .thenReturn(Optional.empty());
-    when(externalSkillClient.getById(externalSkillId)).thenReturn(Optional.of(externalSkillDTO));
+    when(declaredSkillRepository.findById(id)).thenReturn(Optional.empty());
+    when(externalSkillClient.getById(id)).thenReturn(Optional.of(externalSkillDTO));
 
     DeclaredSkill savedSkill =
-        DeclaredSkill.create(externalSkillId, "Simple Skill", EExternalSkillType.XXI, null);
+        DeclaredSkill.create(id, "Simple Skill", EExternalSkillType.XXI, null);
     when(declaredSkillRepository.saveOrGet(any(DeclaredSkill.class))).thenReturn(savedSkill);
 
     BddLogger.when("calling getOrCreateFromExternalSkill");
-    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(externalSkillId);
+    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(id);
 
     BddLogger.then("it should create skill with empty pathSegments list");
     assertThat(result).isPresent();
@@ -137,24 +126,24 @@ class DeclaredSkillSyncServiceImplTest {
   @Test
   void shouldMapExternalSkillTypeToDeclaredSkillType() {
     BddLogger.given("external skills with different types");
-    UUID externalSkillId1 = UUID.randomUUID();
-    UUID externalSkillId2 = UUID.randomUUID();
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
 
     ExternalSkillDTO rome4Skill =
-        new ExternalSkillDTO(externalSkillId1, "ROME4 Skill", List.of(), EExternalSkillType.ROME4);
+        new ExternalSkillDTO(id1, "ROME4 Skill", List.of(), EExternalSkillType.ROME4);
     ExternalSkillDTO xxiSkill =
-        new ExternalSkillDTO(externalSkillId2, "XXI Skill", List.of(), EExternalSkillType.XXI);
+        new ExternalSkillDTO(id2, "XXI Skill", List.of(), EExternalSkillType.XXI);
 
-    when(declaredSkillRepository.findByExternalSkillId(any())).thenReturn(Optional.empty());
-    when(externalSkillClient.getById(externalSkillId1)).thenReturn(Optional.of(rome4Skill));
-    when(externalSkillClient.getById(externalSkillId2)).thenReturn(Optional.of(xxiSkill));
+    when(declaredSkillRepository.findById(any())).thenReturn(Optional.empty());
+    when(externalSkillClient.getById(id1)).thenReturn(Optional.of(rome4Skill));
+    when(externalSkillClient.getById(id2)).thenReturn(Optional.of(xxiSkill));
 
     when(declaredSkillRepository.saveOrGet(any(DeclaredSkill.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     BddLogger.when("creating skills with different types");
-    service.getOrCreateFromExternalSkill(externalSkillId1);
-    service.getOrCreateFromExternalSkill(externalSkillId2);
+    service.getOrCreateFromExternalSkill(id1);
+    service.getOrCreateFromExternalSkill(id2);
 
     BddLogger.then("types should be correctly mapped");
     ArgumentCaptor<DeclaredSkill> captor = ArgumentCaptor.forClass(DeclaredSkill.class);
@@ -168,35 +157,29 @@ class DeclaredSkillSyncServiceImplTest {
   @Test
   void shouldReturnExistingDeclaredSkillWhenSaveFailsWithUniqueConstraint() {
     BddLogger.given("no existing DeclaredSkill at first check but a concurrent insert occurs");
-    UUID externalSkillId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
     ExternalSkillDTO externalSkillDTO =
         new ExternalSkillDTO(
-            externalSkillId,
-            "Concurrent Skill",
-            List.of("IT", "Development"),
-            EExternalSkillType.ROME4);
+            id, "Concurrent Skill", List.of("IT", "Development"), EExternalSkillType.ROME4);
 
     DeclaredSkill existingSkill =
         DeclaredSkill.create(
-            externalSkillId,
-            "Concurrent Skill",
-            EExternalSkillType.ROME4,
-            List.of("IT", "Development"));
+            id, "Concurrent Skill", EExternalSkillType.ROME4, List.of("IT", "Development"));
 
-    when(declaredSkillRepository.findByExternalSkillId(externalSkillId))
+    when(declaredSkillRepository.findById(id))
         .thenReturn(Optional.empty())
         .thenReturn(Optional.of(existingSkill));
-    when(externalSkillClient.getById(externalSkillId)).thenReturn(Optional.of(externalSkillDTO));
+    when(externalSkillClient.getById(id)).thenReturn(Optional.of(externalSkillDTO));
     when(declaredSkillRepository.saveOrGet(any(DeclaredSkill.class))).thenReturn(existingSkill);
 
     BddLogger.when("calling getOrCreateFromExternalSkill while a concurrent insert happens");
-    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(externalSkillId);
+    Optional<DeclaredSkill> result = service.getOrCreateFromExternalSkill(id);
 
     BddLogger.then("it should return the existing skill created by the concurrent operation");
     assertThat(result).isPresent();
     assertThat(result.get()).isEqualTo(existingSkill);
 
-    verify(declaredSkillRepository, times(1)).findByExternalSkillId(externalSkillId);
+    verify(declaredSkillRepository, times(1)).findById(id);
     verify(declaredSkillRepository).saveOrGet(any(DeclaredSkill.class));
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/client/ExternalSkillClientStub.java
+++ b/src/test/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/client/ExternalSkillClientStub.java
@@ -27,20 +27,20 @@ public class ExternalSkillClientStub extends ExternalSkillClient {
   }
 
   @Override
-  public Optional<ExternalSkillDTO> getById(UUID externalSkillId) {
-    if (externalSkillId.equals(notFoundExternalSkillId)) {
+  public Optional<ExternalSkillDTO> getById(UUID id) {
+    if (id.equals(notFoundExternalSkillId)) {
       return Optional.empty();
     }
     return Optional.of(
         new ExternalSkillDTO(
-            externalSkillId,
-            "External Skill " + externalSkillId,
+            id,
+            "External Skill " + id,
             List.of("Domaine", "Issue", "Target"),
             EExternalSkillType.ROME4));
   }
 
   @Override
-  public Optional<ExternalSkillDetailsDTO> getExternalSkillDetails(UUID externalSkillId) {
+  public Optional<ExternalSkillDetailsDTO> getExternalSkillDetails(UUID id) {
     List<ExternalSkillCategoryDTO> categoryPath =
         List.of(
             new ExternalSkillCategoryDTO("Domaine 1", EExternalSkillCategoryType.DOMAIN),
@@ -49,7 +49,7 @@ public class ExternalSkillClientStub extends ExternalSkillClient {
 
     return Optional.of(
         new ExternalSkillDetailsDTO(
-            externalSkillId, "External Skill Details", categoryPath, EExternalSkillType.ROME4));
+            id, "External Skill Details", categoryPath, EExternalSkillType.ROME4));
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/mapper/DeclaredSkillMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/mapper/DeclaredSkillMapperTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DeclaredSkillMapperTest {
 
   private final UUID id = UUID.randomUUID();
-  private final UUID externalSkillId = UUID.randomUUID();
   private final String libelle = "Java Programming";
   private final EExternalSkillType type = EExternalSkillType.ROME4;
   private final List<String> pathSegments = List.of("Domain", "Issue", "MacroSkill", "Skill");
@@ -27,8 +26,7 @@ class DeclaredSkillMapperTest {
   @Test
   void shouldMapEntityToDomain() {
     BddLogger.given("an DeclaredSkillEntity");
-    DeclaredSkillEntity entity =
-        DeclaredSkillEntity.of(id, externalSkillId, libelle, type, pathSegments);
+    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, libelle, type, pathSegments);
     entity.setCreatedAt(createdAt);
     entity.setUpdatedAt(updatedAt);
 
@@ -38,7 +36,6 @@ class DeclaredSkillMapperTest {
     BddLogger.then("it should map all fields correctly");
     assertNotNull(domain);
     assertEquals(id, domain.getId());
-    assertEquals(externalSkillId, domain.getExternalSkillId());
     assertEquals(libelle, domain.getLibelle());
     assertEquals(type, domain.getType());
     assertEquals(pathSegments, domain.getPathSegments());
@@ -50,8 +47,7 @@ class DeclaredSkillMapperTest {
   void shouldMapDomainToEntity() {
     BddLogger.given("an DeclaredSkill domain model");
     DeclaredSkill domain =
-        DeclaredSkill.toDomain(
-            id, externalSkillId, libelle, type, pathSegments, createdAt, updatedAt);
+        DeclaredSkill.toDomain(id, libelle, type, pathSegments, createdAt, updatedAt);
 
     BddLogger.when("mapping to entity");
     DeclaredSkillEntity entity = DeclaredSkillMapper.INSTANCE.fromDomain(domain);
@@ -59,7 +55,6 @@ class DeclaredSkillMapperTest {
     BddLogger.then("it should map all fields correctly");
     assertNotNull(entity);
     assertEquals(id, entity.getId());
-    assertEquals(externalSkillId, entity.getExternalSkillId());
     assertEquals(libelle, entity.getLibelle());
     assertEquals(type, entity.getType());
     assertEquals(pathSegments, entity.getPathSegments());
@@ -68,7 +63,7 @@ class DeclaredSkillMapperTest {
   @Test
   void shouldMapEntityToDomainWithNullPathSegments() {
     BddLogger.given("an entity with null pathSegments");
-    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, externalSkillId, libelle, type, null);
+    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, libelle, type, null);
     entity.setCreatedAt(createdAt);
     entity.setUpdatedAt(updatedAt);
 
@@ -80,7 +75,6 @@ class DeclaredSkillMapperTest {
     assertNotNull(domain.getPathSegments());
     assertTrue(domain.getPathSegments().isEmpty());
     assertEquals(id, domain.getId());
-    assertEquals(externalSkillId, domain.getExternalSkillId());
     assertEquals(libelle, domain.getLibelle());
     assertEquals(type, domain.getType());
   }
@@ -88,8 +82,7 @@ class DeclaredSkillMapperTest {
   @Test
   void shouldMapDomainToEntityWithNullPathSegments() {
     BddLogger.given("a domain model with null pathSegments");
-    DeclaredSkill domain =
-        DeclaredSkill.toDomain(id, externalSkillId, libelle, type, null, createdAt, updatedAt);
+    DeclaredSkill domain = DeclaredSkill.toDomain(id, libelle, type, null, createdAt, updatedAt);
 
     BddLogger.when("mapping to entity");
     DeclaredSkillEntity entity = DeclaredSkillMapper.INSTANCE.fromDomain(domain);
@@ -99,7 +92,6 @@ class DeclaredSkillMapperTest {
     assertNotNull(entity.getPathSegments());
     assertTrue(entity.getPathSegments().isEmpty());
     assertEquals(id, entity.getId());
-    assertEquals(externalSkillId, entity.getExternalSkillId());
     assertEquals(libelle, entity.getLibelle());
     assertEquals(type, entity.getType());
   }
@@ -108,8 +100,7 @@ class DeclaredSkillMapperTest {
   void shouldMapEntityToDomainWithEmptyPathSegments() {
     BddLogger.given("an entity with empty pathSegments");
     List<String> emptyPathSegments = List.of();
-    DeclaredSkillEntity entity =
-        DeclaredSkillEntity.of(id, externalSkillId, libelle, type, emptyPathSegments);
+    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, libelle, type, emptyPathSegments);
     entity.setCreatedAt(createdAt);
     entity.setUpdatedAt(updatedAt);
 
@@ -126,8 +117,7 @@ class DeclaredSkillMapperTest {
   void shouldPreserveAllFieldsInRoundTripMapping() {
     BddLogger.given("a complete domain model");
     DeclaredSkill originalDomain =
-        DeclaredSkill.toDomain(
-            id, externalSkillId, libelle, type, pathSegments, createdAt, updatedAt);
+        DeclaredSkill.toDomain(id, libelle, type, pathSegments, createdAt, updatedAt);
 
     BddLogger.when("mapping to entity and back to domain");
     DeclaredSkillEntity entity = DeclaredSkillMapper.INSTANCE.fromDomain(originalDomain);
@@ -138,7 +128,6 @@ class DeclaredSkillMapperTest {
     BddLogger.then("all fields should be preserved");
     assertNotNull(resultDomain);
     assertEquals(originalDomain.getId(), resultDomain.getId());
-    assertEquals(originalDomain.getExternalSkillId(), resultDomain.getExternalSkillId());
     assertEquals(originalDomain.getLibelle(), resultDomain.getLibelle());
     assertEquals(originalDomain.getType(), resultDomain.getType());
     assertEquals(originalDomain.getPathSegments(), resultDomain.getPathSegments());
@@ -150,8 +139,7 @@ class DeclaredSkillMapperTest {
   void shouldMapMultipleSegmentsCorrectly() {
     BddLogger.given("an entity with multiple path segments");
     List<String> multipleSegments = List.of("A", "B", "C", "D", "E");
-    DeclaredSkillEntity entity =
-        DeclaredSkillEntity.of(id, externalSkillId, libelle, type, multipleSegments);
+    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, libelle, type, multipleSegments);
     entity.setCreatedAt(createdAt);
     entity.setUpdatedAt(updatedAt);
 
@@ -176,8 +164,7 @@ class DeclaredSkillMapperTest {
 
     for (EExternalSkillType skillType : types) {
       BddLogger.when("mapping entity with type " + skillType);
-      DeclaredSkillEntity entity =
-          DeclaredSkillEntity.of(id, externalSkillId, libelle, skillType, pathSegments);
+      DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, libelle, skillType, pathSegments);
       entity.setCreatedAt(createdAt);
       entity.setUpdatedAt(updatedAt);
 

--- a/src/test/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/model/DeclaredSkillEntityTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/model/DeclaredSkillEntityTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import fr.avenirsesr.portfolio.common.externalskill.domain.model.enums.EExternalSkillType;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.declaredskill.infrastructure.adapter.converter.PathSegmentsConverter;
-import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -16,57 +15,24 @@ import org.junit.jupiter.api.Test;
 
 class DeclaredSkillEntityTest {
 
-  private final UUID externalSkillId = UUID.randomUUID();
+  private final UUID id = UUID.randomUUID();
   private final String libelle = "Java Programming";
   private final EExternalSkillType type = EExternalSkillType.ROME4;
   private final List<String> pathSegments = List.of("Domain", "Issue", "MacroSkill", "Skill");
 
   @Test
   void shouldCreateEntityWithOfMethod() {
-    BddLogger.given("valid entity data with ID");
-    UUID id = UUID.randomUUID();
+    BddLogger.given("valid entity data");
 
     BddLogger.when("creating entity with of method");
-    DeclaredSkillEntity entity =
-        DeclaredSkillEntity.of(id, externalSkillId, libelle, type, pathSegments);
+    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, libelle, type, pathSegments);
 
     BddLogger.then("it should create an entity with all fields set");
     assertNotNull(entity);
     assertEquals(id, entity.getId());
-    assertEquals(externalSkillId, entity.getExternalSkillId());
     assertEquals(libelle, entity.getLibelle());
     assertEquals(type, entity.getType());
     assertEquals(pathSegments, entity.getPathSegments());
-  }
-
-  @Test
-  void shouldCreateEntityWithCreateMethod() {
-    BddLogger.given("valid entity data without ID");
-
-    BddLogger.when("creating entity with create method");
-    DeclaredSkillEntity entity =
-        DeclaredSkillEntity.create(externalSkillId, libelle, type, pathSegments);
-
-    BddLogger.then("it should generate an ID and set all fields");
-    assertNotNull(entity);
-    assertNotNull(entity.getId());
-    assertEquals(externalSkillId, entity.getExternalSkillId());
-    assertEquals(libelle, entity.getLibelle());
-    assertEquals(type, entity.getType());
-    assertEquals(pathSegments, entity.getPathSegments());
-  }
-
-  @Test
-  void shouldGenerateIdAutomatically() {
-    BddLogger.given("valid entity data");
-
-    BddLogger.when("creating entity with create method");
-    DeclaredSkillEntity entity =
-        DeclaredSkillEntity.create(externalSkillId, libelle, type, pathSegments);
-
-    BddLogger.then("it should generate a non-null ID");
-    assertNotNull(entity.getId());
-    assertNotEquals(UUID.fromString("00000000-0000-0000-0000-000000000000"), entity.getId());
   }
 
   @Test
@@ -75,21 +41,18 @@ class DeclaredSkillEntityTest {
     DeclaredSkillEntity entity = new DeclaredSkillEntity();
 
     BddLogger.when("setting all fields with setters");
-    UUID id = UUID.randomUUID();
-    UUID newExternalSkillId = UUID.randomUUID();
+    UUID newId = UUID.randomUUID();
     String newLibelle = "Python Programming";
     EExternalSkillType newType = EExternalSkillType.XXI;
     List<String> newPathSegments = List.of("A", "B", "C");
 
-    entity.setId(id);
-    entity.setExternalSkillId(newExternalSkillId);
+    entity.setId(newId);
     entity.setLibelle(newLibelle);
     entity.setType(newType);
     entity.setPathSegments(newPathSegments);
 
     BddLogger.then("all fields should be set correctly");
-    assertEquals(id, entity.getId());
-    assertEquals(newExternalSkillId, entity.getExternalSkillId());
+    assertEquals(newId, entity.getId());
     assertEquals(newLibelle, entity.getLibelle());
     assertEquals(newType, entity.getType());
     assertEquals(newPathSegments, entity.getPathSegments());
@@ -105,7 +68,6 @@ class DeclaredSkillEntityTest {
     BddLogger.then("it should create an instance with null fields");
     assertNotNull(entity);
     assertNull(entity.getId());
-    assertNull(entity.getExternalSkillId());
     assertNull(entity.getLibelle());
     assertNull(entity.getType());
     assertNull(entity.getPathSegments());
@@ -114,15 +76,13 @@ class DeclaredSkillEntityTest {
   @Test
   void shouldHandleNullPathSegments() {
     BddLogger.given("entity data with null pathSegments");
-    UUID id = UUID.randomUUID();
 
     BddLogger.when("creating entity with null pathSegments");
-    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, externalSkillId, libelle, type, null);
+    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, libelle, type, null);
 
     BddLogger.then("it should convert null pathSegments to empty list");
     assertNotNull(entity);
     assertEquals(id, entity.getId());
-    assertEquals(externalSkillId, entity.getExternalSkillId());
     assertEquals(libelle, entity.getLibelle());
     assertEquals(type, entity.getType());
     assertNotNull(entity.getPathSegments());
@@ -132,12 +92,10 @@ class DeclaredSkillEntityTest {
   @Test
   void shouldHandleEmptyPathSegments() {
     BddLogger.given("entity data with empty pathSegments");
-    UUID id = UUID.randomUUID();
     List<String> emptyPathSegments = List.of();
 
     BddLogger.when("creating entity with empty pathSegments");
-    DeclaredSkillEntity entity =
-        DeclaredSkillEntity.of(id, externalSkillId, libelle, type, emptyPathSegments);
+    DeclaredSkillEntity entity = DeclaredSkillEntity.of(id, libelle, type, emptyPathSegments);
 
     BddLogger.then("it should accept empty pathSegments");
     assertNotNull(entity);
@@ -174,24 +132,6 @@ class DeclaredSkillEntityTest {
           "Should use PathSegmentsConverter");
     } catch (NoSuchFieldException e) {
       fail("pathSegments field should exist");
-    }
-  }
-
-  @Test
-  void shouldHaveExternalSkillIdNotNullable() {
-    BddLogger.given("the externalSkillId field");
-
-    BddLogger.when("checking the @Column annotation");
-    try {
-      var field = DeclaredSkillEntity.class.getDeclaredField("externalSkillId");
-      Column columnAnnotation = field.getAnnotation(Column.class);
-
-      BddLogger.then("it should be marked as not nullable");
-      assertNotNull(columnAnnotation);
-      assertFalse(columnAnnotation.nullable(), "externalSkillId should not be nullable");
-      assertEquals("external_skill_id", columnAnnotation.name());
-    } catch (NoSuchFieldException e) {
-      fail("externalSkillId field should exist");
     }
   }
 

--- a/src/test/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/repository/DeclaredSkillDatabaseRepositoryTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/declaredskill/infrastructure/adapter/repository/DeclaredSkillDatabaseRepositoryTest.java
@@ -22,12 +22,12 @@ class DeclaredSkillDatabaseRepositoryTest extends ContainerConfigurationTest {
   @Test
   void shouldSaveDeclaredSkill() {
     BddLogger.given("a new DeclaredSkill");
-    UUID externalSkillId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
     String libelle = "Java Programming";
     EExternalSkillType type = EExternalSkillType.ROME4;
     List<String> pathSegments = List.of("Domain", "Issue", "MacroSkill", "Skill");
 
-    DeclaredSkill skill = DeclaredSkill.create(externalSkillId, libelle, type, pathSegments);
+    DeclaredSkill skill = DeclaredSkill.create(id, libelle, type, pathSegments);
 
     BddLogger.when("saving the skill");
     DeclaredSkill savedSkill = repository.save(skill);
@@ -35,7 +35,7 @@ class DeclaredSkillDatabaseRepositoryTest extends ContainerConfigurationTest {
     BddLogger.then("it should be persisted with all fields");
     assertNotNull(savedSkill);
     assertNotNull(savedSkill.getId());
-    assertEquals(externalSkillId, savedSkill.getExternalSkillId());
+    assertEquals(id, savedSkill.getId());
     assertEquals(libelle, savedSkill.getLibelle());
     assertEquals(type, savedSkill.getType());
     assertEquals(pathSegments, savedSkill.getPathSegments());
@@ -44,11 +44,11 @@ class DeclaredSkillDatabaseRepositoryTest extends ContainerConfigurationTest {
   @Test
   void shouldSaveWithPathSegments() {
     BddLogger.given("an DeclaredSkill with path segments");
-    UUID externalSkillId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
     List<String> pathSegments = List.of("A", "B", "C", "D");
 
     DeclaredSkill skill =
-        DeclaredSkill.create(externalSkillId, "Test Skill", EExternalSkillType.XXI, pathSegments);
+        DeclaredSkill.create(id, "Test Skill", EExternalSkillType.XXI, pathSegments);
 
     BddLogger.when("saving and retrieving the skill");
     DeclaredSkill savedSkill = repository.save(skill);
@@ -74,7 +74,7 @@ class DeclaredSkillDatabaseRepositoryTest extends ContainerConfigurationTest {
     BddLogger.then("it should return the skill");
     assertTrue(result.isPresent());
     assertEquals(savedEntity.getId(), result.get().getId());
-    assertEquals(savedEntity.getExternalSkillId(), result.get().getExternalSkillId());
+    assertEquals(savedEntity.getId(), result.get().getId());
     assertEquals(savedEntity.getLibelle(), result.get().getLibelle());
   }
 
@@ -91,29 +91,12 @@ class DeclaredSkillDatabaseRepositoryTest extends ContainerConfigurationTest {
   }
 
   @Test
-  void shouldFindByExternalSkillId() {
-    BddLogger.given("a saved DeclaredSkill");
-    UUID externalSkillId = UUID.randomUUID();
-    DeclaredSkillEntity entity =
-        DeclaredSkillEntity.create(
-            externalSkillId, "Test Skill", EExternalSkillType.CASOC, List.of("A", "B"));
-    jpaRepository.save(entity);
+  void shouldReturnEmptyWhenIdNotFound() {
+    BddLogger.given("a non-existent ID");
+    UUID nonExistentId = UUID.randomUUID();
 
-    BddLogger.when("finding by external skill ID");
-    Optional<DeclaredSkill> result = repository.findByExternalSkillId(externalSkillId);
-
-    BddLogger.then("it should return the skill");
-    assertTrue(result.isPresent());
-    assertEquals(externalSkillId, result.get().getExternalSkillId());
-  }
-
-  @Test
-  void shouldReturnEmptyWhenExternalSkillIdNotFound() {
-    BddLogger.given("a non-existent external skill ID");
-    UUID nonExistentExternalId = UUID.randomUUID();
-
-    BddLogger.when("finding by external skill ID");
-    Optional<DeclaredSkill> result = repository.findByExternalSkillId(nonExistentExternalId);
+    BddLogger.when("finding by ID");
+    Optional<DeclaredSkill> result = repository.findById(nonExistentId);
 
     BddLogger.then("it should return empty");
     assertTrue(result.isEmpty());
@@ -122,10 +105,9 @@ class DeclaredSkillDatabaseRepositoryTest extends ContainerConfigurationTest {
   @Test
   void shouldUpdateDeclaredSkill() {
     BddLogger.given("a saved DeclaredSkill");
-    UUID externalSkillId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
     DeclaredSkill skill =
-        DeclaredSkill.create(
-            externalSkillId, "Original Skill", EExternalSkillType.ROME4, List.of("A", "B"));
+        DeclaredSkill.create(id, "Original Skill", EExternalSkillType.ROME4, List.of("A", "B"));
     DeclaredSkill savedSkill = repository.save(skill);
 
     BddLogger.when("updating the skill");
@@ -236,25 +218,23 @@ class DeclaredSkillDatabaseRepositoryTest extends ContainerConfigurationTest {
   }
 
   @Test
-  void shouldReturnExistingSkillWhenSaveOrGetOnDuplicateExternalSkillIdAndType() {
-    BddLogger.given("an existing DeclaredSkillEntity with a given externalSkillId and type");
-    UUID externalSkillId = UUID.randomUUID();
+  void shouldReturnExistingSkillWhenSaveOrGetOnDuplicateIdAndType() {
+    BddLogger.given("an existing DeclaredSkillEntity with a given id and type");
+    UUID id = UUID.randomUUID();
     EExternalSkillType type = EExternalSkillType.ROME4;
 
     DeclaredSkillEntity existingEntity =
-        DeclaredSkillEntity.create(externalSkillId, "Existing Skill", type, List.of("A", "B"));
+        DeclaredSkillEntity.create(id, "Existing Skill", type, List.of("A", "B"));
     existingEntity = jpaRepository.save(existingEntity);
 
-    BddLogger.when(
-        "calling saveOrGet with a domain object having the same externalSkillId and type");
-    DeclaredSkill toSave =
-        DeclaredSkill.create(externalSkillId, "New Name", type, List.of("X", "Y"));
+    BddLogger.when("calling saveOrGet with a domain object having the same id and type");
+    DeclaredSkill toSave = DeclaredSkill.create(id, "New Name", type, List.of("X", "Y"));
 
     DeclaredSkill result = repository.saveOrGet(toSave);
 
-    BddLogger.then("it should return a skill with the same externalSkillId and type");
+    BddLogger.then("it should return a skill with the same id and type");
     assertNotNull(result);
-    assertEquals(existingEntity.getExternalSkillId(), result.getExternalSkillId());
+    assertEquals(existingEntity.getId(), result.getId());
     assertEquals(existingEntity.getType(), result.getType());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/controller/DeclaredSkillProgressControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/controller/DeclaredSkillProgressControllerIT.java
@@ -70,7 +70,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
   @Test
   void shouldCreateDeclaredSkillProgress() throws Exception {
     var declaredSkill = declaredSkillRepository.findAll().stream().findFirst().orElseThrow();
-    UUID externalSkillId = declaredSkill.getExternalSkillId();
+    UUID id = declaredSkill.getId();
 
     webTestClient
         .post()
@@ -79,7 +79,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
         .header("X-Context-Kid", secretKey)
         .header("X-Context-Signature", studentSignature)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(buildDeclaredSkillsJson(externalSkillId))
+        .bodyValue(buildDeclaredSkillsJson(id))
         .exchange()
         .expectStatus()
         .isCreated();
@@ -89,7 +89,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
   void shouldReturnConflictWhenDeclaredSkillAlreadyExists() throws Exception {
     var declaredSkill =
         declaredSkillRepository.findAll().stream().skip(1).findFirst().orElseThrow();
-    UUID externalSkillId = declaredSkill.getExternalSkillId();
+    UUID id = declaredSkill.getId();
 
     webTestClient
         .post()
@@ -98,7 +98,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
         .header("X-Context-Kid", secretKey)
         .header("X-Context-Signature", studentSignature)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(buildDeclaredSkillsJson(externalSkillId))
+        .bodyValue(buildDeclaredSkillsJson(id))
         .exchange()
         .expectStatus()
         .isCreated();
@@ -110,7 +110,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
         .header("X-Context-Kid", secretKey)
         .header("X-Context-Signature", studentSignature)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(buildDeclaredSkillsJson(externalSkillId))
+        .bodyValue(buildDeclaredSkillsJson(id))
         .exchange()
         .expectStatus()
         .isEqualTo(409);
@@ -335,7 +335,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
     // First create a declared skill progress
     var declaredSkill =
         declaredSkillRepository.findAll().stream().skip(3).findFirst().orElseThrow();
-    UUID externalSkillId = declaredSkill.getExternalSkillId();
+    UUID id = declaredSkill.getId();
 
     // Create the declared skill progress
     var createResponse =
@@ -346,7 +346,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
             .header("X-Context-Kid", secretKey)
             .header("X-Context-Signature", studentSignature)
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(buildDeclaredSkillsJson(externalSkillId))
+            .bodyValue(buildDeclaredSkillsJson(id))
             .exchange()
             .expectStatus()
             .isCreated()
@@ -389,7 +389,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
     // First create a declared skill progress
     var declaredSkill =
         declaredSkillRepository.findAll().stream().skip(4).findFirst().orElseThrow();
-    UUID externalSkillId = declaredSkill.getExternalSkillId();
+    UUID id = declaredSkill.getId();
 
     // Create the declared skill progress
     var createResponse =
@@ -400,7 +400,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
             .header("X-Context-Kid", secretKey)
             .header("X-Context-Signature", studentSignature)
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(buildDeclaredSkillsJson(externalSkillId))
+            .bodyValue(buildDeclaredSkillsJson(id))
             .exchange()
             .expectStatus()
             .isCreated()
@@ -441,7 +441,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
 
     var declaredSkill =
         declaredSkillRepository.findAll().stream().skip(5).findFirst().orElseThrow();
-    UUID externalSkillId = declaredSkill.getExternalSkillId();
+    UUID id = declaredSkill.getId();
 
     var createResponse =
         webTestClient
@@ -451,7 +451,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
             .header("X-Context-Kid", secretKey)
             .header("X-Context-Signature", studentSignature)
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(buildDeclaredSkillsJson(externalSkillId))
+            .bodyValue(buildDeclaredSkillsJson(id))
             .exchange()
             .expectStatus()
             .isCreated()
@@ -499,7 +499,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
 
     var declaredSkill =
         declaredSkillRepository.findAll().stream().skip(6).findFirst().orElseThrow();
-    UUID externalSkillId = declaredSkill.getExternalSkillId();
+    UUID id = declaredSkill.getId();
 
     var createResponse =
         webTestClient
@@ -509,7 +509,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
             .header("X-Context-Kid", secretKey)
             .header("X-Context-Signature", studentSignature)
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(buildDeclaredSkillsJson(externalSkillId))
+            .bodyValue(buildDeclaredSkillsJson(id))
             .exchange()
             .expectStatus()
             .isCreated()
@@ -629,7 +629,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
 
     var declaredSkill =
         declaredSkillRepository.findAll().stream().skip(7).findFirst().orElseThrow();
-    UUID externalSkillId = declaredSkill.getExternalSkillId();
+    UUID id = declaredSkill.getId();
 
     var createResponse =
         webTestClient
@@ -639,7 +639,7 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
             .header("X-Context-Kid", secretKey)
             .header("X-Context-Signature", studentSignature)
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(buildDeclaredSkillsJson(externalSkillId))
+            .bodyValue(buildDeclaredSkillsJson(id))
             .exchange()
             .expectStatus()
             .isCreated()

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImplTest.java
@@ -139,7 +139,7 @@ public class DeclaredSkillProgressServiceImplTest {
                 new ExternalSkillCategoryDTO("Issue", EExternalSkillCategoryType.ISSUE));
         ExternalSkillDetailsDTO externalSkillDetails =
             new ExternalSkillDetailsDTO(
-                declaredSkillProgress.getSkill().getExternalSkillId(),
+                declaredSkillProgress.getSkill().getId(),
                 "Test Skill",
                 categories,
                 EExternalSkillType.ROME4);


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR removes the redundant `externalSkillId` field from the `DeclaredSkill` domain model, replacing its usage with the existing `id` field. Since the skill's UUID `id` already serves as the unique identifier, maintaining a separate `externalSkillId` was unnecessary and increased complexity across the codebase.

**Main changes:**
- ♻️ Removes `externalSkillId` field and its getter/setter from `DeclaredSkill` domain model
- ♻️ Updates `DeclaredSkill.create()` factory method to use `id` instead of `externalSkillId`
- 🔥 Removes `findByExternalSkillId()` from `DeclaredSkillRepository` port, replaced by `findById()`
- ♻️ Updates `DeclaredSkillSyncServiceImpl` to look up skills by `id`
- ♻️ Updates `ExternalSkillClient` adapter to pass `id` directly
- ♻️ Updates `DeclaredSkillMapper` to map without `externalSkillId`
- 🔥 Removes `externalSkillId` column mapping from `DeclaredSkillEntity` JPA entity
- ✅ Updates all unit tests and integration tests accordingly

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1411

---

### Documentation
No documentation changes required. The refactor is purely internal — the external API contract and behavior remain unchanged.

**Modified files (18 files, -152 net lines):**
- `DeclaredSkill.java` — Remove `externalSkillId` field and related methods
- `DeclaredSkillSyncService.java` — Update port interface
- `DeclaredSkillRepository.java` — Remove `findByExternalSkillId` method
- `DeclaredSkillSyncServiceImpl.java` — Use `findById` instead of `findByExternalSkillId`
- `ExternalSkillClient.java` — Simplify adapter
- `DeclaredSkillMapper.java` — Update mapping logic
- `DeclaredSkillEntity.java` — Remove `externalSkillId` JPA column
- `DeclaredSkillDatabaseRepository.java` — Update repository implementation
- `DeclaredSkillJpaRepository.java` — Remove `findByExternalSkillId` query method
- `DeclaredSkillProgressServiceImpl.java` — Update service
- All related test files updated accordingly

---

### Target Branch
`develop`

---

### Additional Notes
The `externalSkillId` was originally introduced to track the identifier from the external referential (interoperability service). However, since the internal `id` of `DeclaredSkill` is set from the same UUID provided by the external system, having both fields was redundant. This refactor simplifies the model and reduces the persistence layer complexity by removing an unnecessary column and query method.

---

### Known Limitations or Side Effects
This refactor requires a database migration to remove the `external_skill_id` column from the `declared_skill` table if it exists in any deployed environment.

---

## ✅ Checklist

- [x] a11y tested (N/A — backend only)
- [x] Tests provided (unit and integration tests updated)
- [x] i18n handled (N/A — no text changes)
- [x] Performance tests (no performance impact expected)
- [x] No unnecessary code (redundant field and methods removed)
- [x] Code style and formatting rules respected (follows existing conventions)
- [x] Semantic Versioning respected (conventional commit: refactor)
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process