### PR TITLE
feat(1346): allow link inclusion instead of file upload in traces

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/file/domain/service/TraceAttachmentServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/domain/service/TraceAttachmentServiceImpl.java
@@ -9,6 +9,7 @@ import fr.avenirsesr.portfolio.file.domain.port.input.TraceAttachmentService;
 import fr.avenirsesr.portfolio.file.domain.port.output.repository.TraceAttachmentRepository;
 import fr.avenirsesr.portfolio.file.domain.port.output.service.FileStorageService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.trace.domain.exception.InvalidTraceTypeException;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.trace.domain.port.input.TraceService;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
@@ -33,12 +34,16 @@ public class TraceAttachmentServiceImpl implements TraceAttachmentService {
       throws IOException {
     Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     var trace = traceService.getTraceById(traceId);
-    var allTraceAttachments = traceAttachmentRepository.findByTrace(trace);
 
     if (!trace.getUser().equals(loggedInStudent.getUser())) {
       throw new UserNotAuthorizedException();
     }
 
+    if (trace.getLink().isPresent()) {
+      throw new InvalidTraceTypeException();
+    }
+
+    var allTraceAttachments = traceAttachmentRepository.findByTrace(trace);
     try {
       var fileType = EFileType.fromMimeType(mimeType);
       if (fileType.getSizeLimit().isLessThan(size)) {

--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceController.java
@@ -1,6 +1,5 @@
 package fr.avenirsesr.portfolio.trace.application.adapter.controller;
 
-import fr.avenirsesr.portfolio.ams.domain.port.input.AMSService;
 import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultDeclaredActivityDTO;
 import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultDeclaredExperienceDTO;
 import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultDeclaredSkillIDTO;
@@ -12,8 +11,6 @@ import fr.avenirsesr.portfolio.common.data.domain.model.DateFilter;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.shared.application.adapter.dto.AssociationsCreationRequest;
-import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input.DeclaredSkillProgressService;
-import fr.avenirsesr.portfolio.student.progress.imported.domain.port.input.StudentProgressService;
 import fr.avenirsesr.portfolio.trace.application.adapter.dto.*;
 import fr.avenirsesr.portfolio.trace.application.adapter.mapper.*;
 import fr.avenirsesr.portfolio.trace.application.adapter.response.TracesCreationResponse;
@@ -38,9 +35,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/me/traces")
 public class TraceController {
   private final TraceService traceService;
-  private final AMSService amsService;
-  private final StudentProgressService studentProgressService;
-  private final DeclaredSkillProgressService declaredSkillProgressService;
 
   @GetMapping("/overview")
   public ResponseEntity<List<TraceOverviewDTO>> getTraceOverview(Principal principal) {
@@ -219,7 +213,8 @@ public class TraceController {
             createTraceDTO.language(),
             createTraceDTO.isGroup(),
             createTraceDTO.personalNote(),
-            createTraceDTO.iaJustification());
+            createTraceDTO.iaJustification(),
+            createTraceDTO.link());
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(new TracesCreationResponse(trace.getId()));

--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/CreateTraceDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/CreateTraceDTO.java
@@ -11,4 +11,5 @@ public record CreateTraceDTO(
     @Schema(ref = "#/components/schemas/ELanguage") ELanguage language,
     boolean isGroup,
     String personalNote,
-    String iaJustification) {}
+    String iaJustification,
+    String link) {}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/TraceDetailDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/TraceDetailDTO.java
@@ -14,6 +14,7 @@ import java.util.UUID;
       "isGroup",
       "aiUseJustification",
       "personalNote",
+      "link",
       "attachment",
       "createdAt",
       "updatedAt"
@@ -26,6 +27,7 @@ public record TraceDetailDTO(
     boolean isGroup,
     String aiUseJustification,
     String personalNote,
+    String link,
     AttachmentUploadDTO attachment,
     Instant createdAt,
     Instant updatedAt) {}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceDetailMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceDetailMapper.java
@@ -14,6 +14,7 @@ public interface TraceDetailMapper {
         traceDetail.isGroup(),
         traceDetail.aiUseJustification(),
         traceDetail.personalNote(),
+        traceDetail.link(),
         AttachmentUploadDTOMapper.fromDomain(traceDetail.attachment()),
         traceDetail.createdAt(),
         traceDetail.updatedAt());

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/data/TraceDetailData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/data/TraceDetailData.java
@@ -12,6 +12,7 @@ public record TraceDetailData(
     boolean isGroup,
     String aiUseJustification,
     String personalNote,
+    String link,
     TraceAttachment attachment,
     Instant createdAt,
     Instant updatedAt) {}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/exception/InvalidTraceTypeException.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/exception/InvalidTraceTypeException.java
@@ -1,0 +1,14 @@
+package fr.avenirsesr.portfolio.trace.domain.exception;
+
+import fr.avenirsesr.portfolio.common.error.domain.exception.BusinessException;
+import fr.avenirsesr.portfolio.common.error.domain.model.enums.EErrorCode;
+
+public class InvalidTraceTypeException extends BusinessException {
+  public InvalidTraceTypeException() {
+    super(EErrorCode.INVALID_TRACE_TYPE);
+  }
+
+  public InvalidTraceTypeException(String customMessage) {
+    super(EErrorCode.INVALID_TRACE_TYPE, customMessage);
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/model/Trace.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/model/Trace.java
@@ -33,6 +33,9 @@ public class Trace extends DeletableAvenirsBaseModel {
   @Getter(AccessLevel.NONE)
   private String personalNote;
 
+  @Getter(AccessLevel.NONE)
+  private String link;
+
   private Trace(
       UUID id,
       User user,
@@ -41,6 +44,7 @@ public class Trace extends DeletableAvenirsBaseModel {
       boolean isGroup,
       String aiUseJustification,
       String personalNote,
+      String link,
       List<SkillLevelProgress> skillLevels,
       List<DeclaredSkillProgress> declaredSkillProgresses,
       List<AMS> amses,
@@ -57,6 +61,7 @@ public class Trace extends DeletableAvenirsBaseModel {
     this.isGroup = isGroup;
     this.aiUseJustification = aiUseJustification;
     this.personalNote = personalNote;
+    this.link = link;
   }
 
   public static Trace create(
@@ -66,7 +71,8 @@ public class Trace extends DeletableAvenirsBaseModel {
       ELanguage language,
       boolean isGroup,
       String aiUseJustification,
-      String personalNote) {
+      String personalNote,
+      String link) {
 
     return new Trace(
         id,
@@ -76,6 +82,7 @@ public class Trace extends DeletableAvenirsBaseModel {
         isGroup,
         aiUseJustification,
         personalNote,
+        link,
         new ArrayList<>(),
         new ArrayList<>(),
         new ArrayList<>(),
@@ -94,6 +101,7 @@ public class Trace extends DeletableAvenirsBaseModel {
       boolean group,
       String aiUseJustification,
       String personalNote,
+      String link,
       Instant createdAt,
       Instant updatedAt,
       Instant deletedAt,
@@ -106,6 +114,7 @@ public class Trace extends DeletableAvenirsBaseModel {
         group,
         aiUseJustification,
         personalNote,
+        link,
         skillLevels,
         declaredSkillProgresses,
         amses,
@@ -120,6 +129,10 @@ public class Trace extends DeletableAvenirsBaseModel {
 
   public Optional<String> getPersonalNote() {
     return Optional.ofNullable(personalNote);
+  }
+
+  public Optional<String> getLink() {
+    return Optional.ofNullable(link);
   }
 
   public boolean isUnassociated() {

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/input/TraceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/input/TraceService.java
@@ -45,7 +45,8 @@ public interface TraceService {
       ELanguage language,
       boolean isGroup,
       String personalNote,
-      String aiJustification);
+      String aiJustification,
+      String link);
 
   Trace createTrace(
       UUID traceId,
@@ -54,7 +55,8 @@ public interface TraceService {
       ELanguage language,
       boolean isGroup,
       String personalNote,
-      String aiJustification);
+      String aiJustification,
+      String link);
 
   TraceDetailData updateTrace(
       UUID traceId,

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/output/seeder/TraceDataGenerator.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/output/seeder/TraceDataGenerator.java
@@ -8,4 +8,6 @@ public interface TraceDataGenerator extends DataGeneratorInterface {
   String traceAiJustification();
 
   String tracePersonalNote();
+
+  String traceLink();
 }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
@@ -1,8 +1,11 @@
 package fr.avenirsesr.portfolio.trace.domain.service;
 
 import static fr.avenirsesr.portfolio.common.validation.domain.constraints.CommonLimits.MAX_TRACES_OVERVIEW;
+import static fr.avenirsesr.portfolio.common.validation.domain.constraints.FieldMaxLengths.LINK_LENGTH;
 import static fr.avenirsesr.portfolio.common.validation.domain.constraints.FieldMaxLengths.TITLE_LENGTH;
 import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.requireNotBlankAndMaxLength;
+import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.validateOptionalTextMaxLength;
+import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.validateUrl;
 
 import fr.avenirsesr.portfolio.ams.domain.model.AMS;
 import fr.avenirsesr.portfolio.association.domain.data.AssociationData;
@@ -188,6 +191,7 @@ public class TraceServiceImpl implements TraceService {
         trace.isGroup(),
         trace.getAiUseJustification().orElse(null),
         trace.getPersonalNote().orElse(null),
+        trace.getLink().orElse(null),
         traceAttachment,
         trace.getCreatedAt(),
         trace.getUpdatedAt());
@@ -255,7 +259,8 @@ public class TraceServiceImpl implements TraceService {
       ELanguage language,
       boolean isGroup,
       String personalNote,
-      String aiJustification) {
+      String aiJustification,
+      String link) {
     return createTrace(
         traceId,
         userService.getUser(userId),
@@ -263,7 +268,8 @@ public class TraceServiceImpl implements TraceService {
         language,
         isGroup,
         personalNote,
-        aiJustification);
+        aiJustification,
+        link);
   }
 
   @Override
@@ -272,10 +278,18 @@ public class TraceServiceImpl implements TraceService {
       ELanguage language,
       boolean isGroup,
       String personalNote,
-      String aiJustification) {
+      String aiJustification,
+      String link) {
     User loggedInUser = loggedInUserService.getLoggedInUser();
     return createTrace(
-        UUID.randomUUID(), loggedInUser, title, language, isGroup, personalNote, aiJustification);
+        UUID.randomUUID(),
+        loggedInUser,
+        title,
+        language,
+        isGroup,
+        personalNote,
+        aiJustification,
+        link);
   }
 
   private Trace createTrace(
@@ -285,10 +299,13 @@ public class TraceServiceImpl implements TraceService {
       ELanguage language,
       boolean isGroup,
       String personalNote,
-      String aiJustification) {
+      String aiJustification,
+      String link) {
     requireNotBlankAndMaxLength("title", title, TITLE_LENGTH);
+    validateOptionalTextMaxLength("link", link, LINK_LENGTH);
+    validateUrl(link);
     var trace =
-        Trace.create(traceId, user, title, language, isGroup, aiJustification, personalNote);
+        Trace.create(traceId, user, title, language, isGroup, aiJustification, personalNote, link);
 
     return traceRepository.save(trace);
   }
@@ -323,6 +340,7 @@ public class TraceServiceImpl implements TraceService {
         savedTrace.isGroup(),
         savedTrace.getAiUseJustification().orElse(null),
         savedTrace.getPersonalNote().orElse(null),
+        savedTrace.getLink().orElse(null),
         traceAttachment,
         savedTrace.getCreatedAt(),
         savedTrace.getUpdatedAt());

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/mapper/TraceMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/mapper/TraceMapper.java
@@ -28,6 +28,7 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
         trace.isGroup(),
         trace.getAiUseJustification().orElse(null),
         trace.getPersonalNote().orElse(null),
+        trace.getLink().orElse(null),
         trace.getCreatedAt(),
         trace.getUpdatedAt(),
         trace.getDeletedAt().orElse(null));
@@ -48,6 +49,7 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
             traceEntity.isGroup(),
             traceEntity.getAiUseJustification(),
             traceEntity.getPersonalNote(),
+            traceEntity.getLink(),
             traceEntity.getCreatedAt(),
             traceEntity.getUpdatedAt(),
             traceEntity.getDeletedAt(),
@@ -87,6 +89,7 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
         traceEntity.isGroup(),
         traceEntity.getAiUseJustification(),
         traceEntity.getPersonalNote(),
+        traceEntity.getLink(),
         traceEntity.getCreatedAt(),
         traceEntity.getUpdatedAt(),
         traceEntity.getDeletedAt(),

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/model/TraceEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/model/TraceEntity.java
@@ -77,6 +77,10 @@ public class TraceEntity extends DeletableAvenirsBaseEntity {
   @Column(name = "personal_note")
   private String personalNote;
 
+  @Size(max = LINK_LENGTH, message = "link can not exceed {max} characters")
+  @Column(name = "link")
+  private String link;
+
   private TraceEntity(
       UUID id,
       UserEntity user,
@@ -88,6 +92,7 @@ public class TraceEntity extends DeletableAvenirsBaseEntity {
       boolean isGroup,
       String aiUseJustification,
       String personalNote,
+      String link,
       Instant createdAt,
       Instant updatedAt,
       Instant deletedAt) {
@@ -104,6 +109,7 @@ public class TraceEntity extends DeletableAvenirsBaseEntity {
     this.isGroup = isGroup;
     this.aiUseJustification = aiUseJustification;
     this.personalNote = personalNote;
+    this.link = link;
   }
 
   public static TraceEntity of(
@@ -117,6 +123,7 @@ public class TraceEntity extends DeletableAvenirsBaseEntity {
       boolean isGroup,
       String aiUseJustification,
       String personalNote,
+      String link,
       Instant createdAt,
       Instant updatedAt,
       Instant deletedAt) {
@@ -131,6 +138,7 @@ public class TraceEntity extends DeletableAvenirsBaseEntity {
         isGroup,
         aiUseJustification,
         personalNote,
+        link,
         createdAt,
         updatedAt,
         deletedAt);

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/FakeTrace.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/FakeTrace.java
@@ -37,12 +37,14 @@ public class FakeTrace {
                 false,
                 null,
                 null,
+                null,
                 Instant.now(),
                 Instant.now(),
                 null));
 
     if (new Random().nextBoolean()) fakeTrace = fakeTrace.withAiUseJustification();
     if (new Random().nextBoolean()) fakeTrace = fakeTrace.withPersonalNote();
+    if (new Random().nextBoolean()) fakeTrace = fakeTrace.withLink();
     if (new Random().nextBoolean()) fakeTrace = fakeTrace.isGroup();
 
     return fakeTrace;
@@ -86,6 +88,11 @@ public class FakeTrace {
 
   public FakeTrace withPersonalNote() {
     trace.setPersonalNote("Personal note : %s".formatted(faker().lorem().sentence(5)));
+    return this;
+  }
+
+  public FakeTrace withLink() {
+    trace.setLink(faker().internet().url());
     return this;
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/TraceSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/TraceSeeder.java
@@ -81,7 +81,8 @@ public class TraceSeeder {
                   data.language(),
                   data.isGroup(),
                   data.personalNote(),
-                  data.aiJustification());
+                  data.aiJustification(),
+                  data.link());
           traces.add(trace);
 
           RequestContext.set(
@@ -132,20 +133,23 @@ public class TraceSeeder {
                     entity.getLanguage(),
                     entity.getAiUseJustification(),
                     entity.getPersonalNote(),
-                    IntStream.range(
-                            1,
-                            dataGenerator
-                                .with("number")
-                                .number(SeederConfig.MAX_ATTACHMENT_PER_TRACE))
-                        .mapToObj(i -> FakeTraceAttachment.of(entity).toEntity())
-                        .map(
-                            attachmentEntity ->
-                                new TraceAttachementCreationData(
-                                    attachmentEntity.getName(),
-                                    attachmentEntity.getFileType(),
-                                    attachmentEntity.getSize(),
-                                    attachmentEntity.getUploadedAt()))
-                        .toList()))
+                    entity.getLink(),
+                    entity.getLink() == null
+                        ? IntStream.range(
+                                1,
+                                dataGenerator
+                                    .with("number")
+                                    .number(SeederConfig.MAX_ATTACHMENT_PER_TRACE))
+                            .mapToObj(i -> FakeTraceAttachment.of(entity).toEntity())
+                            .map(
+                                attachmentEntity ->
+                                    new TraceAttachementCreationData(
+                                        attachmentEntity.getName(),
+                                        attachmentEntity.getFileType(),
+                                        attachmentEntity.getSize(),
+                                        attachmentEntity.getUploadedAt()))
+                            .toList()
+                        : null))
         .toList();
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/data/TraceCreationData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/data/TraceCreationData.java
@@ -12,4 +12,9 @@ public record TraceCreationData(
     ELanguage language,
     String aiJustification,
     String personalNote,
-    List<TraceAttachementCreationData> attachements) {}
+    String link,
+    List<TraceAttachementCreationData> attachements) {
+  public TraceCreationData {
+    if (attachements == null) attachements = List.of();
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/data/TraceFakerDataGenerator.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/data/TraceFakerDataGenerator.java
@@ -30,4 +30,9 @@ public class TraceFakerDataGenerator extends DataGenerator implements TraceDataG
   public String tracePersonalNote() {
     return "Personal note : %s".formatted(faker().lorem().sentence(5));
   }
+
+  @Override
+  public String traceLink() {
+    return faker().internet().url();
+  }
 }

--- a/src/main/resources/db/changelog/generated/changelog_2026-04-17__14-33-04.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-04-17__14-33-04.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="user (generated)" id="1776436399663-1">
+        <addColumn tableName="trace">
+            <column name="link" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/seeder/traces.json
+++ b/src/main/resources/seeder/traces.json
@@ -118,5 +118,15 @@
         "uploadedAt": "2025-11-30T10:05:00.000000Z"
       }
     ]
+  },
+  {
+    "traceId": "ca745573-544c-4c4c-9768-724f02c690a1",
+    "userId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "title": "Lien vers travaux personnels",
+    "isGroup": false,
+    "language": "FRENCH",
+    "aiJustification": "Utilisation de l’IA pour réaliser les documentations techniques.",
+    "personalNote": "Portfolio technique des projets réalisés durant mon temps libre.",
+    "link": "https://example.com"
   }
 ]

--- a/src/test/java/fr/avenirsesr/portfolio/file/application/adapter/controller/TraceAttachmentControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/file/application/adapter/controller/TraceAttachmentControllerIT.java
@@ -167,4 +167,43 @@ class TraceAttachmentControllerIT extends ContainerConfigurationTest {
         .jsonPath("$.code")
         .isEqualTo("USER_NOT_AUTHORIZED");
   }
+
+  @Test
+  void shouldReturn400WhenInvalidTraceType() {
+    BddLogger.given("the " + BASE_PATH + " endpoint");
+
+    UUID existingTraceId = UUID.fromString("ca745573-544c-4c4c-9768-724f02c690a1");
+
+    byte[] fileContent = "Contenu du fichier de test".getBytes(StandardCharsets.UTF_8);
+
+    MultipartBodyBuilder builder = new MultipartBodyBuilder();
+    builder
+        .part(
+            "file",
+            new ByteArrayResource(fileContent) {
+              @Override
+              public String getFilename() {
+                return "test-file.txt";
+              }
+            })
+        .contentType(MediaType.TEXT_PLAIN);
+
+    BddLogger.when("performing a MULTIPART with a trace of a different type");
+    BddLogger.then("it should return 400");
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH, existingTraceId)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(builder.build())
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .jsonPath("$.code")
+        .isEqualTo("INVALID_TRACE_TYPE");
+  }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/file/domain/service/TraceAttachmentServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/file/domain/service/TraceAttachmentServiceImplTest.java
@@ -16,6 +16,7 @@ import fr.avenirsesr.portfolio.file.domain.port.output.repository.TraceAttachmen
 import fr.avenirsesr.portfolio.file.domain.port.output.service.FileStorageService;
 import fr.avenirsesr.portfolio.file.infrastructure.fixture.TraceAttachmentFixture;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.trace.domain.exception.InvalidTraceTypeException;
 import fr.avenirsesr.portfolio.trace.domain.exception.TraceNotFoundException;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.trace.domain.port.input.TraceService;
@@ -259,5 +260,23 @@ class TraceAttachmentServiceImplTest {
                 service.uploadTraceAttachment(
                     traceId, "file.txt", EFileType.TXT.getMimeType(), 1234L, "data".getBytes()))
         .isInstanceOf(UserNotAuthorizedException.class);
+  }
+
+  @Test
+  void uploadTraceAttachment_shouldThrowInvalidTraceTypeException() {
+    BddLogger.given("a TraceAttachmentServiceImpl service");
+    UUID traceId = UUID.randomUUID();
+    Trace trace =
+        TraceFixture.create().withUser(student.getUser()).withLink("https://example.com").toModel();
+
+    BddLogger.when("uploading a trace attachment with a trace of a different type");
+    when(traceService.getTraceById(traceId)).thenReturn(trace);
+
+    BddLogger.then("it should throw InvalidTraceTypeException");
+    assertThatThrownBy(
+            () ->
+                service.uploadTraceAttachment(
+                    traceId, "file.txt", EFileType.TXT.getMimeType(), 1234L, "data".getBytes()))
+        .isInstanceOf(InvalidTraceTypeException.class);
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerIT.java
@@ -192,7 +192,8 @@ class TraceControllerIT extends ContainerConfigurationTest {
   @Test
   void shouldCreateNewTrace() throws Exception {
     CreateTraceDTO dto =
-        new CreateTraceDTO("Nouvelle trace", ELanguage.FRENCH, false, "Note", "Justification");
+        new CreateTraceDTO(
+            "Nouvelle trace", ELanguage.FRENCH, false, "Note", "Justification", null);
 
     webTestClient
         .post()

--- a/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerTest.java
@@ -75,11 +75,17 @@ class TraceControllerTest {
   void shouldCreateTraceSuccessfully() {
     BddLogger.given("a TraceController");
     when(traceService.createTrace(
-            anyString(), any(ELanguage.class), anyBoolean(), anyString(), anyString()))
+            anyString(), any(ELanguage.class), anyBoolean(), anyString(), anyString(), anyString()))
         .thenReturn(trace);
 
     CreateTraceDTO dto =
-        new CreateTraceDTO("My Trace", ELanguage.FRENCH, true, "Personal note", "Justification IA");
+        new CreateTraceDTO(
+            "My Trace",
+            ELanguage.FRENCH,
+            true,
+            "Personal note",
+            "Justification IA",
+            "https://example.com");
 
     BddLogger.when("creating a trace");
     ResponseEntity<TracesCreationResponse> response = controller.createTrace(principal, dto);
@@ -95,16 +101,18 @@ class TraceControllerTest {
             eq(ELanguage.FRENCH),
             eq(true),
             eq("Personal note"),
-            eq("Justification IA"));
+            eq("Justification IA"),
+            eq("https://example.com"));
   }
 
   @Test
   void shouldCreateTraceWithNullFields() {
     BddLogger.given("a TraceController");
-    when(traceService.createTrace("Trace sans IA", ELanguage.FRENCH, false, null, null))
+    when(traceService.createTrace("Trace sans IA", ELanguage.FRENCH, false, null, null, null))
         .thenReturn(trace);
 
-    CreateTraceDTO dto = new CreateTraceDTO("Trace sans IA", ELanguage.FRENCH, false, null, null);
+    CreateTraceDTO dto =
+        new CreateTraceDTO("Trace sans IA", ELanguage.FRENCH, false, null, null, null);
 
     BddLogger.when("creating a trace with null fields");
     ResponseEntity<TracesCreationResponse> response = controller.createTrace(principal, dto);
@@ -112,6 +120,6 @@ class TraceControllerTest {
     BddLogger.then("it should create the trace with null fields successfully");
     assertEquals(201, response.getStatusCode().value());
 
-    verify(traceService).createTrace("Trace sans IA", ELanguage.FRENCH, false, null, null);
+    verify(traceService).createTrace("Trace sans IA", ELanguage.FRENCH, false, null, null, null);
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImplTest.java
@@ -276,9 +276,10 @@ public class TraceServiceImplTest {
       boolean isGroup = true;
       String personalNote = "Some personal note";
       String iaJustification = "Justified by AI";
+      String link = "https://example.com";
 
       BddLogger.when("creating a new trace");
-      traceService.createTrace(title, language, isGroup, personalNote, iaJustification);
+      traceService.createTrace(title, language, isGroup, personalNote, iaJustification, link);
 
       BddLogger.then("it should create and save the new trace");
       ArgumentCaptor<Trace> captor = ArgumentCaptor.forClass(Trace.class);
@@ -296,6 +297,9 @@ public class TraceServiceImplTest {
       assertTrue(trace.getPersonalNote().isPresent());
       assertEquals(personalNote, trace.getPersonalNote().get());
 
+      assertTrue(trace.getLink().isPresent());
+      assertEquals(link, trace.getLink().get());
+
       assertTrue(trace.getAiUseJustification().isPresent());
       assertEquals(iaJustification, trace.getAiUseJustification().get());
     }
@@ -306,7 +310,7 @@ public class TraceServiceImplTest {
       String title = "Trace with null fields";
 
       BddLogger.when("creating a new trace with null fields");
-      traceService.createTrace(title, ELanguage.FRENCH, false, null, null);
+      traceService.createTrace(title, ELanguage.FRENCH, false, null, null, null);
 
       BddLogger.then("it should create and save the new trace with null fields");
       ArgumentCaptor<Trace> captor = ArgumentCaptor.forClass(Trace.class);
@@ -317,6 +321,7 @@ public class TraceServiceImplTest {
       assertEquals(title, trace.getTitle());
       assertEquals(ELanguage.FRENCH, trace.getLanguage());
       assertTrue(trace.getPersonalNote().isEmpty());
+      assertTrue(trace.getLink().isEmpty());
       assertTrue(trace.getAiUseJustification().isEmpty());
     }
 
@@ -326,7 +331,7 @@ public class TraceServiceImplTest {
       BddLogger.when("creating a new trace with a blank title");
       assertThrows(
           Exception.class,
-          () -> traceService.createTrace("   ", ELanguage.FRENCH, false, null, null));
+          () -> traceService.createTrace("   ", ELanguage.FRENCH, false, null, null, null));
       BddLogger.then("it should throw a validation exception");
       verify(traceRepository, never()).save(any());
     }

--- a/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/TraceSeederTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/TraceSeederTest.java
@@ -1,7 +1,6 @@
 package fr.avenirsesr.portfolio.trace.infrastructure.adapter.seeder;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.model.AvenirsBaseEntity;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;

--- a/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
@@ -247,6 +247,7 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
             false,
             null,
             null,
+            null,
             Instant.now(),
             Instant.now(),
             null);

--- a/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/fixture/TraceFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/fixture/TraceFixture.java
@@ -31,6 +31,7 @@ public class TraceFixture {
   private boolean isGroup;
   private String aiUseJustification;
   private String personalNote;
+  private String link;
   private ELanguage language = ELanguage.FRENCH;
 
   private TraceFixture() {
@@ -117,6 +118,11 @@ public class TraceFixture {
     return this;
   }
 
+  public TraceFixture withLink(String link) {
+    this.link = link;
+    return this;
+  }
+
   public List<Trace> withCount(int count) {
     List<Trace> traces = new ArrayList<>();
     for (int i = 0; i < count; i++) {
@@ -141,6 +147,7 @@ public class TraceFixture {
         isGroup,
         aiUseJustification,
         personalNote,
+        link,
         createdAt,
         updatedAt,
         deletedAt,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- _`InvalidTraceTypeException`_ introduced: New exception thrown when an action is incompatible with the trace's current type
- Link support on trace creation: A _`link`_ field can now be provided when creating a trace, as an alternative to an _`attachment`_. Both are mutually exclusive (providing an _`attachment`_ when a _`link`_ is already set throws an _`InvalidTraceTypeException`_)

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1346
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1452
- Requires PR https://github.com/avenirs-esr/avenirs-portfolio-common/pull/55

---

### Documentation
- A _`link`_ field is now available when calling the API to create a trace
- An _`INVALID_TRACE_TYPE`_ error code will be returned if the trace type is incompatible with the action being performed

---

### Target Branch
develop

---

### Known Limitations or Side Effects
- Link field cannot be updated after trace creation (expected behavior at this time)
- Although a generic exception _`InvalidTraceTypeException`_ now exists, traces do not yet have a dedicated _`type`_ field (likely to be added in a future task/US)

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process