### PR TITLE
feat(traces): implement attachment download

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/file/application/adapter/controller/TraceAttachmentController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/application/adapter/controller/TraceAttachmentController.java
@@ -3,12 +3,17 @@ package fr.avenirsesr.portfolio.file.application.adapter.controller;
 import fr.avenirsesr.portfolio.file.application.adapter.dto.AttachmentUploadDTO;
 import fr.avenirsesr.portfolio.file.application.adapter.mapper.AttachmentUploadDTOMapper;
 import fr.avenirsesr.portfolio.file.domain.port.input.TraceAttachmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -42,5 +47,32 @@ public class TraceAttachmentController {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(AttachmentUploadDTOMapper.fromDomain(attachment));
+  }
+
+  @GetMapping("/attachments/{attachmentId}")
+  @Operation(
+      summary = "Download an attachment",
+      description =
+          "Retrieves the binary content of a specific attachment associated with a trace.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "File downloaded successfully",
+            content =
+                @Content(
+                    mediaType = "application/octet-stream",
+                    schema = @Schema(type = "string", format = "binary"))),
+        @ApiResponse(responseCode = "404", description = "Attachment not found")
+      })
+  public ResponseEntity<byte[]> downloadAttachment(@Valid @PathVariable UUID attachmentId)
+      throws IOException {
+    log.debug("Received attachment download request for attachment [{}]", attachmentId);
+    var attachment = service.downloadTraceAttachment(attachmentId);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=\"" + attachment.fileName() + "\"")
+        .body(attachment.content());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/file/domain/exception/AttachmentNotFoundException.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/domain/exception/AttachmentNotFoundException.java
@@ -1,0 +1,20 @@
+package fr.avenirsesr.portfolio.file.domain.exception;
+
+import fr.avenirsesr.portfolio.common.error.domain.exception.BusinessException;
+import fr.avenirsesr.portfolio.common.error.domain.model.enums.EErrorCode;
+import java.util.UUID;
+
+public class AttachmentNotFoundException extends BusinessException {
+
+  public AttachmentNotFoundException() {
+    super(EErrorCode.ATTACHMENT_NOT_FOUND);
+  }
+
+  public AttachmentNotFoundException(String customMessage) {
+    super(EErrorCode.ATTACHMENT_NOT_FOUND, customMessage);
+  }
+
+  public AttachmentNotFoundException(UUID attachmentId) {
+    super(EErrorCode.ATTACHMENT_NOT_FOUND, "Attachment id %s not found".formatted(attachmentId));
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/file/domain/model/TraceAttachmentDownload.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/domain/model/TraceAttachmentDownload.java
@@ -1,0 +1,3 @@
+package fr.avenirsesr.portfolio.file.domain.model;
+
+public record TraceAttachmentDownload(String fileName, byte[] content) {}

--- a/src/main/java/fr/avenirsesr/portfolio/file/domain/port/input/TraceAttachmentService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/domain/port/input/TraceAttachmentService.java
@@ -1,6 +1,7 @@
 package fr.avenirsesr.portfolio.file.domain.port.input;
 
 import fr.avenirsesr.portfolio.file.domain.model.TraceAttachment;
+import fr.avenirsesr.portfolio.file.domain.model.TraceAttachmentDownload;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import java.io.IOException;
 import java.util.List;
@@ -9,6 +10,8 @@ import java.util.UUID;
 public interface TraceAttachmentService {
   TraceAttachment uploadTraceAttachment(
       UUID traceId, String fileName, String mimeType, long size, byte[] content) throws IOException;
+
+  TraceAttachmentDownload downloadTraceAttachment(UUID attachmentId) throws IOException;
 
   List<TraceAttachment> findByTrace(Trace trace);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/file/domain/service/TraceAttachmentServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/domain/service/TraceAttachmentServiceImpl.java
@@ -1,8 +1,10 @@
 package fr.avenirsesr.portfolio.file.domain.service;
 
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
+import fr.avenirsesr.portfolio.file.domain.exception.AttachmentNotFoundException;
 import fr.avenirsesr.portfolio.file.domain.exception.FileSizeTooBigException;
 import fr.avenirsesr.portfolio.file.domain.model.TraceAttachment;
+import fr.avenirsesr.portfolio.file.domain.model.TraceAttachmentDownload;
 import fr.avenirsesr.portfolio.file.domain.model.shared.EFileType;
 import fr.avenirsesr.portfolio.file.domain.model.shared.FileResource;
 import fr.avenirsesr.portfolio.file.domain.port.input.TraceAttachmentService;
@@ -93,6 +95,23 @@ public class TraceAttachmentServiceImpl implements TraceAttachmentService {
         true,
         uri,
         student.getUser());
+  }
+
+  @Override
+  public TraceAttachmentDownload downloadTraceAttachment(UUID attachmentId) throws IOException {
+    var attachment = traceAttachmentRepository.findById(attachmentId);
+    if (attachment.isEmpty()) {
+      throw new AttachmentNotFoundException(attachmentId);
+    }
+
+    var trace = attachment.get().getTrace();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
+    if (!trace.getUser().equals(loggedInStudent.getUser())) {
+      throw new UserNotAuthorizedException();
+    }
+
+    return new TraceAttachmentDownload(
+        attachment.get().getName(), fileStorageService.get(attachment.get().getUri()));
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/file/application/adapter/controller/TraceAttachmentControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/file/application/adapter/controller/TraceAttachmentControllerTest.java
@@ -7,17 +7,17 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.file.application.adapter.dto.AttachmentUploadDTO;
+import fr.avenirsesr.portfolio.file.domain.model.TraceAttachmentDownload;
 import fr.avenirsesr.portfolio.file.domain.port.input.TraceAttachmentService;
-import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
@@ -29,16 +29,12 @@ public class TraceAttachmentControllerTest {
 
   @InjectMocks private TraceAttachmentController controller;
 
-  private User user;
-  private Trace trace;
   private UUID traceId;
 
   @BeforeEach
   void setup() {
     MockitoAnnotations.openMocks(this);
 
-    user = mock(User.class);
-    trace = mock(Trace.class);
     traceId = UUID.randomUUID();
 
     when(principal.getName()).thenReturn("user123");
@@ -65,5 +61,28 @@ public class TraceAttachmentControllerTest {
 
     verify(service)
         .uploadTraceAttachment(eq(traceId), anyString(), anyString(), anyLong(), any(byte[].class));
+  }
+
+  @Test
+  void downloadAttachment_success_shouldReturn200() throws IOException {
+    BddLogger.given("a TraceAttachmentController");
+    UUID attachmentId = UUID.randomUUID();
+    byte[] fileContent = "Test content".getBytes();
+    String fileName = "test.pdf";
+
+    when(service.downloadTraceAttachment(attachmentId))
+        .thenReturn(new TraceAttachmentDownload(fileName, fileContent));
+
+    BddLogger.when("the attachment download success");
+    ResponseEntity<byte[]> response = controller.downloadAttachment(attachmentId);
+
+    BddLogger.then("it should return a 200");
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody()).isEqualTo(fileContent);
+    assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION))
+        .isEqualTo("attachment; filename=\"test.pdf\"");
+
+    verify(service).downloadTraceAttachment(attachmentId);
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/file/domain/service/TraceAttachmentServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/file/domain/service/TraceAttachmentServiceImplTest.java
@@ -279,4 +279,61 @@ class TraceAttachmentServiceImplTest {
                     traceId, "file.txt", EFileType.TXT.getMimeType(), 1234L, "data".getBytes()))
         .isInstanceOf(InvalidTraceTypeException.class);
   }
+
+  @Test
+  void downloadTraceAttachment_shouldReturnFileContent() throws IOException {
+    BddLogger.given("a TraceAttachmentServiceImpl service");
+    UUID attachmentId = UUID.randomUUID();
+    String expectedContent = "File content".repeat(100); // 1200 bytes
+    String expectedFileName = "file.txt";
+    Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+    TraceAttachment attachment =
+        TraceAttachmentFixture.create()
+            .withId(attachmentId)
+            .withTrace(trace)
+            .withFileName(expectedFileName)
+            .withUri("uri/to/file.txt")
+            .toModel();
+
+    when(traceAttachmentRepository.findById(attachmentId))
+        .thenReturn(java.util.Optional.of(attachment));
+    when(fileStorageService.get("uri/to/file.txt")).thenReturn(expectedContent.getBytes());
+
+    BddLogger.when("downloading a trace attachment");
+    var result = service.downloadTraceAttachment(attachmentId);
+
+    BddLogger.then("it should return the file content");
+    assertThat(result).isNotNull();
+    assertThat(result.fileName()).isEqualTo(expectedFileName);
+    assertThat(result.content()).isEqualTo(expectedContent.getBytes());
+    verify(traceAttachmentRepository).findById(attachmentId);
+    verify(fileStorageService).get("uri/to/file.txt");
+  }
+
+  @Test
+  void downloadTraceAttachment_shouldPropagateIOException() throws IOException {
+    BddLogger.given("a TraceAttachmentServiceImpl service");
+    UUID attachmentId = UUID.randomUUID();
+    Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+    TraceAttachment attachment =
+        TraceAttachmentFixture.create()
+            .withId(attachmentId)
+            .withTrace(trace)
+            .withFileName("file.txt")
+            .withUri("uri/to/file.txt")
+            .toModel();
+
+    BddLogger.when("downloading a trace attachment and an IOException occurs");
+    when(traceAttachmentRepository.findById(attachmentId))
+        .thenReturn(java.util.Optional.of(attachment));
+    when(fileStorageService.get("uri/to/file.txt"))
+        .thenThrow(new IOException("Attachment not found"));
+
+    BddLogger.then("it should propagate the IOException");
+    assertThatThrownBy(() -> service.downloadTraceAttachment(attachmentId))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Attachment not found");
+    verify(traceAttachmentRepository).findById(attachmentId);
+    verify(fileStorageService).get("uri/to/file.txt");
+  }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds the trace attachment download flow to the portfolio API so authenticated students can retrieve files attached to their own traces.

**Main changes:**
- ✨ Adds a new `GET /api/traces/{traceId}/attachments/{attachmentId}` endpoint in the trace attachment controller
- ♻️ Extends the trace attachment domain service with authorization checks before reading the stored attachment
- ♻️ Adds file download support in the storage service implementations used in production and mock environments
- ✅ Adds controller and domain service tests covering successful downloads and propagated I/O failures

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1453

---

### Documentation
No user-facing documentation was updated.

Technical coverage added in code:
- Controller test for the new attachment download endpoint
- Domain service tests for successful download and I/O error propagation
- Storage service contract updated to support file download operations

---

### Target Branch
`develop`

---

### Additional Notes
The download path keeps the existing ownership rule by checking that the requested attachment belongs to a trace owned by the logged-in student before accessing storage. The storage adapter resolves files from the UUID-based naming convention already used for uploaded attachments.

---

### Known Limitations or Side Effects
The endpoint currently returns the attachment payload as `application/octet-stream` without a `Content-Disposition` filename header, so clients must manage the downloaded filename themselves.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
