### PR TITLE
feat(assocition-search): search association without providing ID

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/association/domain/model/EAssociationContextType.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/domain/model/EAssociationContextType.java
@@ -1,0 +1,23 @@
+package fr.avenirsesr.portfolio.association.domain.model;
+
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
+import fr.avenirsesr.portfolio.trace.domain.model.Trace;
+
+public enum EAssociationContextType {
+  TRACE(Trace.class),
+  DECLARED_ACTIVITY(DeclaredActivity.class),
+  DECLARED_SKILL(DeclaredSkillProgress.class),
+  DECLARED_EXPERIENCE(DeclaredExperience.class);
+
+  private final Class<?> contextClass;
+
+  EAssociationContextType(Class<?> contextClass) {
+    this.contextClass = contextClass;
+  }
+
+  public Class<?> toClass() {
+    return contextClass;
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/association/domain/service/AssociationSearchHelper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/domain/service/AssociationSearchHelper.java
@@ -45,11 +45,13 @@ public class AssociationSearchHelper {
       Predicate<T> additionalDisabledCondition) {
 
     Set<UUID> alreadyAssociatedIds =
-        associationService
-            .getAllOf(sourceEntityId, sourceEntityClass, List.of(associationType))
-            .stream()
-            .map(associationIdExtractor)
-            .collect(Collectors.toSet());
+        sourceEntityId != null
+            ? associationService
+                .getAllOf(sourceEntityId, sourceEntityClass, List.of(associationType))
+                .stream()
+                .map(associationIdExtractor)
+                .collect(Collectors.toSet())
+            : Set.of();
 
     var mappedContent =
         searchResults.content().stream()

--- a/src/main/java/fr/avenirsesr/portfolio/association/infrastructure/adapter/openapi/OpenApiAssociationEnumConfiguration.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/infrastructure/adapter/openapi/OpenApiAssociationEnumConfiguration.java
@@ -1,0 +1,16 @@
+package fr.avenirsesr.portfolio.association.infrastructure.adapter.openapi;
+
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiAssociationEnumConfiguration {
+  @Bean
+  public OpenApiCustomizer associationEnumCustomizer() {
+    return openApi ->
+        openApi
+            .getComponents()
+            .addSchemas("EAssociationContextType", SwaggerSchema.associationContextTypeSchema);
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/association/infrastructure/adapter/openapi/SwaggerSchema.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/infrastructure/adapter/openapi/SwaggerSchema.java
@@ -1,0 +1,14 @@
+package fr.avenirsesr.portfolio.association.infrastructure.adapter.openapi;
+
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import java.util.Arrays;
+
+public interface SwaggerSchema {
+  Schema<String> associationContextTypeSchema =
+      new StringSchema()
+          .name("EAssociationContextType")
+          ._enum(Arrays.stream(EAssociationContextType.values()).map(Enum::name).toList())
+          .description("Enum for association context type");
+}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityController.java
@@ -1,9 +1,11 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.controller;
 
+import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultDeclaredActivityDTO;
 import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultDeclaredSkillIDTO;
 import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultTraceDTO;
 import fr.avenirsesr.portfolio.association.application.adapter.mapper.AssociationSearchResultDTOMapper;
 import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.common.data.application.adapter.dto.PageInfoDTO;
 import fr.avenirsesr.portfolio.common.data.application.adapter.response.PagedResponse;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
@@ -190,6 +192,39 @@ public class DeclaredActivityController {
         declaredActivityService.associateActivityWithDeclaredSkills(
             declaredActivityId, body.idsToAssociate());
     return ResponseEntity.ok(DeclaredActivityAssociationsDTOMapper.toDTO(newAssociations));
+  }
+
+  @GetMapping("/search-for-association")
+  public ResponseEntity<PagedResponse<AssociationSearchResultDeclaredActivityDTO>>
+      searchDeclaredActivitiesForAssociation(
+          Principal principal,
+          @RequestParam(required = false) UUID excludeAssociatedWithElementId,
+          @RequestParam(required = false) EAssociationContextType contextType,
+          @RequestParam(required = false) String keyword,
+          @RequestParam(required = false) Integer page,
+          @RequestParam(required = false) Integer pageSize) {
+    var pageCriteria = new PageCriteria(page, pageSize);
+    log.debug(
+        "Received request to search declared activities for association (contextType={},"
+            + " excludeAssociatedWithElementId={}) by student [{}] (keyword={}, page={},"
+            + " pageSize={})",
+        contextType,
+        excludeAssociatedWithElementId,
+        principal.getName(),
+        keyword,
+        pageCriteria.page(),
+        pageCriteria.pageSize());
+
+    PagedResult<AssociationSearchResultData> pagedResult =
+        declaredActivityService.searchDeclaredActivitiesForAssociation(
+            excludeAssociatedWithElementId, contextType, keyword, pageCriteria);
+
+    return ResponseEntity.ok(
+        new PagedResponse<>(
+            pagedResult.content().stream()
+                .map(AssociationSearchResultDTOMapper::toDeclaredActivityDTO)
+                .toList(),
+            PageInfoDTO.fromDomain(pagedResult.pageInfo())));
   }
 
   @GetMapping("/{declaredActivityId}/search-for-association/traces")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.i
 
 import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.DeclaredActivityAssociationsData;
@@ -51,6 +52,12 @@ public interface DeclaredActivityService {
 
   PagedResult<AssociationSearchResultData> searchDeclaredSkillsForAssociation(
       UUID declaredActivityId, String keyword, PageCriteria pageCriteria);
+
+  PagedResult<AssociationSearchResultData> searchDeclaredActivitiesForAssociation(
+      UUID excludeAssociatedWithElementId,
+      EAssociationContextType contextType,
+      String keyword,
+      PageCriteria pageCriteria);
 
   List<DeclaredActivity> findAllDeclaredActivitiesByIds(List<UUID> ids);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -9,6 +9,7 @@ import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
 import fr.avenirsesr.portfolio.association.domain.data.AssociationData;
 import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
 import fr.avenirsesr.portfolio.association.domain.model.Association;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.association.domain.service.AssociationSearchHelper;
@@ -319,6 +320,41 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
   }
 
   @Override
+  public PagedResult<AssociationSearchResultData> searchDeclaredActivitiesForAssociation(
+      UUID excludeAssociatedWithElementId,
+      EAssociationContextType contextType,
+      String keyword,
+      PageCriteria pageCriteria) {
+    var activities = searchDeclaredActivity(keyword, pageCriteria);
+
+    if (contextType == null) {
+      return associationSearchHelper.searchForAssociation(
+          null,
+          null,
+          null,
+          null,
+          activities,
+          AvenirsBaseModel::getId,
+          da -> da.getActivity().getTitle(),
+          da -> da.getActivity().getThematic().name(),
+          da -> da.getFinishedAt().isPresent());
+    }
+
+    EAssociationType associationType = getAssociationType(contextType);
+
+    return associationSearchHelper.searchForAssociation(
+        excludeAssociatedWithElementId,
+        contextType.toClass(),
+        associationType,
+        Association::getId1,
+        activities,
+        AvenirsBaseModel::getId,
+        da -> da.getActivity().getTitle(),
+        da -> da.getActivity().getThematic().name(),
+        da -> da.getFinishedAt().isPresent());
+  }
+
+  @Override
   public List<DeclaredActivity> findAllDeclaredActivitiesByIds(List<UUID> ids) {
     return declaredActivityRepository.findAllById(ids);
   }
@@ -420,5 +456,13 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
       throw new UserNotAuthorizedException();
     }
     return declaredActivity;
+  }
+
+  private EAssociationType getAssociationType(EAssociationContextType contextType) {
+    return switch (contextType) {
+      case TRACE -> EAssociationType.DECLARED_ACTIVITY_TRACE;
+      case DECLARED_SKILL -> EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL;
+      case DECLARED_ACTIVITY, DECLARED_EXPERIENCE -> throw new UnsupportedOperationException();
+    };
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
@@ -1,5 +1,9 @@
 package fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.controller;
 
+import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultDeclaredExperienceDTO;
+import fr.avenirsesr.portfolio.association.application.adapter.mapper.AssociationSearchResultDTOMapper;
+import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.common.data.application.adapter.dto.PageInfoDTO;
 import fr.avenirsesr.portfolio.common.data.application.adapter.response.PagedResponse;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
@@ -95,6 +99,39 @@ public class DeclaredExperienceController {
   public ResponseEntity<String> deleteDeclaredExperiences(@RequestBody List<UUID> experienceIds) {
     declaredExperienceService.delete(experienceIds);
     return ResponseEntity.ok("Declared experiences successfully deleted");
+  }
+
+  @GetMapping("/search-for-association")
+  public ResponseEntity<PagedResponse<AssociationSearchResultDeclaredExperienceDTO>>
+      searchDeclaredExperiencesForAssociation(
+          Principal principal,
+          @RequestParam(required = false) UUID excludeAssociatedWithElementId,
+          @RequestParam(required = false) EAssociationContextType contextType,
+          @RequestParam(required = false) String keyword,
+          @RequestParam(required = false) Integer page,
+          @RequestParam(required = false) Integer pageSize) {
+    var pageCriteria = new PageCriteria(page, pageSize);
+    log.debug(
+        "Received request to search declared experiences for association (contextType={},"
+            + " excludeAssociatedWithElementId={}) by student [{}] (keyword={}, page={},"
+            + " pageSize={})",
+        contextType,
+        excludeAssociatedWithElementId,
+        principal.getName(),
+        keyword,
+        pageCriteria.page(),
+        pageCriteria.pageSize());
+
+    PagedResult<AssociationSearchResultData> pagedResult =
+        declaredExperienceService.searchDeclaredExperiencesForAssociation(
+            excludeAssociatedWithElementId, contextType, keyword, pageCriteria);
+
+    return ResponseEntity.ok(
+        new PagedResponse<>(
+            pagedResult.content().stream()
+                .map(AssociationSearchResultDTOMapper::toDeclaredExperienceDTO)
+                .toList(),
+            PageInfoDTO.fromDomain(pagedResult.pageInfo())));
   }
 
   @GetMapping("/{experienceId}/associations")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
@@ -1,5 +1,7 @@
 package fr.avenirsesr.portfolio.student.progress.declared.experience.domain.port.input;
 
+import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceAssociationsData;
@@ -62,4 +64,10 @@ public interface DeclaredExperienceService {
   PagedResult<DeclaredExperience> search(String keyword, PageCriteria pageCriteria);
 
   DeclaredExperienceAssociationsData getAssociations(UUID experienceId);
+
+  PagedResult<AssociationSearchResultData> searchDeclaredExperiencesForAssociation(
+      UUID excludeAssociatedWithElementId,
+      EAssociationContextType contextType,
+      String keyword,
+      PageCriteria pageCriteria);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
@@ -3,9 +3,12 @@ package fr.avenirsesr.portfolio.student.progress.declared.experience.domain.serv
 import static fr.avenirsesr.portfolio.common.validation.domain.constraints.FieldMaxLengths.*;
 import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.*;
 
+import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
 import fr.avenirsesr.portfolio.association.domain.model.Association;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
+import fr.avenirsesr.portfolio.association.domain.service.AssociationSearchHelper;
 import fr.avenirsesr.portfolio.common.data.domain.model.AvenirsBaseModel;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
@@ -36,6 +39,7 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
 
   private final LoggedInUserService loggedInUserService;
   private final AssociationService associationService;
+  private final AssociationSearchHelper associationSearchHelper;
   private final TraceService traceService;
   private final DeclaredExperienceRepository experienceRepository;
   private final StudentService studentService;
@@ -287,6 +291,41 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
   }
 
   @Override
+  public PagedResult<AssociationSearchResultData> searchDeclaredExperiencesForAssociation(
+      UUID excludeAssociatedWithElementId,
+      EAssociationContextType contextType,
+      String keyword,
+      PageCriteria pageCriteria) {
+    var experiences = search(keyword, pageCriteria);
+
+    if (contextType == null) {
+      return associationSearchHelper.searchForAssociation(
+          null,
+          null,
+          null,
+          null,
+          experiences,
+          AvenirsBaseModel::getId,
+          DeclaredExperience::getTitle,
+          de -> de.getExperienceType().name(),
+          de -> false);
+    }
+
+    EAssociationType associationType = getAssociationType(contextType);
+
+    return associationSearchHelper.searchForAssociation(
+        excludeAssociatedWithElementId,
+        contextType.toClass(),
+        associationType,
+        Association::getId2,
+        experiences,
+        AvenirsBaseModel::getId,
+        DeclaredExperience::getTitle,
+        de -> de.getExperienceType().name(),
+        de -> false);
+  }
+
+  @Override
   public DeclaredExperienceAssociationsData getAssociations(UUID experienceId) {
     var student = loggedInUserService.getLoggedInStudent();
     var experience =
@@ -311,5 +350,13 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
 
     return new DeclaredExperienceAssociationsData(
         traceAssociations.stream().map(a -> traceAssociationMapper(a, traces)).toList());
+  }
+
+  private EAssociationType getAssociationType(EAssociationContextType contextType) {
+    return switch (contextType) {
+      case TRACE -> EAssociationType.TRACE_DECLARED_EXPERIENCE;
+      case DECLARED_ACTIVITY, DECLARED_SKILL, DECLARED_EXPERIENCE ->
+          throw new UnsupportedOperationException();
+    };
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/service/DeclaredExperienceServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/service/DeclaredExperienceServiceConfig.java
@@ -1,6 +1,7 @@
 package fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructure.adapter.service;
 
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
+import fr.avenirsesr.portfolio.association.domain.service.AssociationSearchHelper;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.port.input.DeclaredExperienceService;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.port.output.repository.DeclaredExperienceRepository;
@@ -17,6 +18,7 @@ import org.springframework.context.annotation.Lazy;
 public class DeclaredExperienceServiceConfig {
   private final LoggedInUserService loggedInUserService;
   private final AssociationService associationService;
+  private final AssociationSearchHelper associationSearchHelper;
   private final DeclaredExperienceRepository experienceRepository;
   private final StudentService studentService;
 
@@ -25,6 +27,7 @@ public class DeclaredExperienceServiceConfig {
     return new DeclaredExperienceServiceImpl(
         loggedInUserService,
         associationService,
+        associationSearchHelper,
         traceService,
         experienceRepository,
         studentService);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/controller/DeclaredSkillProgressController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/controller/DeclaredSkillProgressController.java
@@ -1,8 +1,10 @@
 package fr.avenirsesr.portfolio.student.progress.declared.skill.application.adapter.controller;
 
 import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultDeclaredActivityDTO;
+import fr.avenirsesr.portfolio.association.application.adapter.dto.AssociationSearchResultDeclaredSkillIDTO;
 import fr.avenirsesr.portfolio.association.application.adapter.mapper.AssociationSearchResultDTOMapper;
 import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.common.data.application.adapter.dto.PageInfoDTO;
 import fr.avenirsesr.portfolio.common.data.application.adapter.response.PagedResponse;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
@@ -129,6 +131,39 @@ public class DeclaredSkillProgressController {
     declaredSkillProgressService.unassociateTraces(declaredSkillProgressId, traceIds);
 
     return ResponseEntity.ok("Trace successfully unassociated.");
+  }
+
+  @GetMapping("/search-for-association")
+  public ResponseEntity<PagedResponse<AssociationSearchResultDeclaredSkillIDTO>>
+      searchDeclaredSkillsForAssociation(
+          Principal principal,
+          @RequestParam(required = false) UUID excludeAssociatedWithElementId,
+          @RequestParam(required = false) EAssociationContextType contextType,
+          @RequestParam(required = false) String keyword,
+          @RequestParam(required = false) Integer page,
+          @RequestParam(required = false) Integer pageSize) {
+    var pageCriteria = new PageCriteria(page, pageSize);
+    log.debug(
+        "Received request to search declared skills for association (contextType={},"
+            + " excludeAssociatedWithElementId={}) by student [{}] (keyword={}, page={},"
+            + " pageSize={})",
+        contextType,
+        excludeAssociatedWithElementId,
+        principal.getName(),
+        keyword,
+        pageCriteria.page(),
+        pageCriteria.pageSize());
+
+    PagedResult<AssociationSearchResultData> pagedResult =
+        declaredSkillProgressService.searchDeclaredSkillsForAssociation(
+            excludeAssociatedWithElementId, contextType, keyword, pageCriteria);
+
+    return ResponseEntity.ok(
+        new PagedResponse<>(
+            pagedResult.content().stream()
+                .map(AssociationSearchResultDTOMapper::toDeclaredSkillDTO)
+                .toList(),
+            PageInfoDTO.fromDomain(pagedResult.pageInfo())));
   }
 
   @GetMapping("/{declaredSkillProgressId}/search-for-association/declared-activities")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/port/input/DeclaredSkillProgressService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/port/input/DeclaredSkillProgressService.java
@@ -1,6 +1,7 @@
 package fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input;
 
 import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.externalskill.domain.model.enums.EExternalSkillType;
@@ -26,6 +27,12 @@ public interface DeclaredSkillProgressService {
   void deleteDeclaredSkillProgresses(List<UUID> declaredSkillProgressIds);
 
   PagedResult<DeclaredSkillProgress> searchDeclaredSkill(String keyword, PageCriteria pageCriteria);
+
+  PagedResult<AssociationSearchResultData> searchDeclaredSkillsForAssociation(
+      UUID excludeAssociatedWithElementId,
+      EAssociationContextType contextType,
+      String keyword,
+      PageCriteria pageCriteria);
 
   PagedResult<AssociationSearchResultData> searchDeclaredActivityForAssociation(
       UUID declaredSkillProgressId, String keyword, PageCriteria pageCriteria);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImpl.java
@@ -7,6 +7,7 @@ import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValida
 import fr.avenirsesr.portfolio.association.domain.data.AssociationData;
 import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
 import fr.avenirsesr.portfolio.association.domain.model.Association;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.association.domain.service.AssociationSearchHelper;
@@ -298,6 +299,41 @@ public class DeclaredSkillProgressServiceImpl implements DeclaredSkillProgressSe
   }
 
   @Override
+  public PagedResult<AssociationSearchResultData> searchDeclaredSkillsForAssociation(
+      UUID excludeAssociatedWithElementId,
+      EAssociationContextType contextType,
+      String keyword,
+      PageCriteria pageCriteria) {
+    var skills = searchDeclaredSkill(keyword, pageCriteria);
+
+    if (contextType == null) {
+      return associationSearchHelper.searchForAssociation(
+          null,
+          null,
+          null,
+          null,
+          skills,
+          AvenirsBaseModel::getId,
+          ds -> ds.getSkill().getLibelle(),
+          ds -> ds.getSkill().getType().name(),
+          ds -> false);
+    }
+
+    EAssociationType associationType = getAssociationType(contextType);
+
+    return associationSearchHelper.searchForAssociation(
+        excludeAssociatedWithElementId,
+        contextType.toClass(),
+        associationType,
+        Association::getId2,
+        skills,
+        AvenirsBaseModel::getId,
+        ds -> ds.getSkill().getLibelle(),
+        ds -> ds.getSkill().getType().name(),
+        ds -> false);
+  }
+
+  @Override
   public PagedResult<AssociationSearchResultData> searchDeclaredActivityForAssociation(
       UUID declaredSkillProgressId, String keyword, PageCriteria pageCriteria) {
     fetchAndCheckLoggedInStudentAuthorization(declaredSkillProgressId);
@@ -317,5 +353,13 @@ public class DeclaredSkillProgressServiceImpl implements DeclaredSkillProgressSe
   @Override
   public List<DeclaredSkillProgress> findAllDeclaredSkillProgressesByIds(List<UUID> ids) {
     return declaredSkillProgressRepository.findAllById(ids);
+  }
+
+  private EAssociationType getAssociationType(EAssociationContextType contextType) {
+    return switch (contextType) {
+      case TRACE -> EAssociationType.TRACE_DECLARED_SKILL;
+      case DECLARED_ACTIVITY -> EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL;
+      case DECLARED_SKILL, DECLARED_EXPERIENCE -> throw new UnsupportedOperationException();
+    };
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -12,6 +12,7 @@ import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
 import fr.avenirsesr.portfolio.activity.infrastructure.fixture.ActivityFixture;
 import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
 import fr.avenirsesr.portfolio.association.domain.model.Association;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.association.domain.service.AssociationSearchHelper;
@@ -1269,5 +1270,206 @@ class DeclaredActivityServiceImplTest {
         .isInstanceOf(UserNotAuthorizedException.class);
 
     verify(associationService, never()).createAll(any());
+  }
+
+  @Test
+  void searchDeclaredActivitiesForAssociation_should_use_trace_association_when_context_is_Trace() {
+    BddLogger.given("A Trace context id and class");
+    UUID contextId = UUID.randomUUID();
+    PageCriteria pageCriteria = new PageCriteria(0, 10);
+    PageInfo pageInfo = new PageInfo(0, 10, 0);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findAllByStudent(
+            eq(student), eq("kw"), eq(pageCriteria), any(FetchGraph.class)))
+        .thenReturn(new PagedResult<>(List.of(), pageInfo));
+
+    PagedResult<AssociationSearchResultData> expected = new PagedResult<>(List.of(), pageInfo);
+    when(associationSearchHelper.searchForAssociation(
+            eq(contextId),
+            eq(Trace.class),
+            eq(EAssociationType.DECLARED_ACTIVITY_TRACE),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any()))
+        .thenReturn(expected);
+
+    BddLogger.when("searchDeclaredActivitiesForAssociation is called with TRACE context");
+    var result =
+        service.searchDeclaredActivitiesForAssociation(
+            contextId, EAssociationContextType.TRACE, "kw", pageCriteria);
+
+    BddLogger.then("The helper is invoked with DECLARED_ACTIVITY_TRACE and Trace.class");
+    assertThat(result).isSameAs(expected);
+    verify(associationSearchHelper)
+        .searchForAssociation(
+            eq(contextId),
+            eq(Trace.class),
+            eq(EAssociationType.DECLARED_ACTIVITY_TRACE),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
+
+  @Test
+  void searchDeclaredActivitiesForAssociation_should_use_skill_association_when_context_is_Skill() {
+    BddLogger.given("A DeclaredSkillProgress context id and class");
+    UUID contextId = UUID.randomUUID();
+    PageCriteria pageCriteria = new PageCriteria(0, 10);
+    PageInfo pageInfo = new PageInfo(0, 10, 0);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findAllByStudent(
+            eq(student), eq("kw"), eq(pageCriteria), any(FetchGraph.class)))
+        .thenReturn(new PagedResult<>(List.of(), pageInfo));
+
+    PagedResult<AssociationSearchResultData> expected = new PagedResult<>(List.of(), pageInfo);
+    when(associationSearchHelper.searchForAssociation(
+            eq(contextId),
+            eq(DeclaredSkillProgress.class),
+            eq(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any()))
+        .thenReturn(expected);
+
+    BddLogger.when("searchDeclaredActivitiesForAssociation is called with DECLARED_SKILL context");
+    var result =
+        service.searchDeclaredActivitiesForAssociation(
+            contextId, EAssociationContextType.DECLARED_SKILL, "kw", pageCriteria);
+
+    BddLogger.then("The helper is invoked with DECLARED_ACTIVITY_DECLARED_SKILL");
+    assertThat(result).isSameAs(expected);
+    verify(associationSearchHelper)
+        .searchForAssociation(
+            eq(contextId),
+            eq(DeclaredSkillProgress.class),
+            eq(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
+
+  @Test
+  void searchDeclaredActivitiesForAssociation_should_use_null_context_when_class_unknown() {
+    BddLogger.given("A null context class");
+    PageCriteria pageCriteria = new PageCriteria(0, 10);
+    PageInfo pageInfo = new PageInfo(0, 10, 0);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findAllByStudent(
+            eq(student), eq("kw"), eq(pageCriteria), any(FetchGraph.class)))
+        .thenReturn(new PagedResult<>(List.of(), pageInfo));
+
+    PagedResult<AssociationSearchResultData> expected = new PagedResult<>(List.of(), pageInfo);
+    when(associationSearchHelper.searchForAssociation(
+            eq(null), eq(null), eq(null), eq(null), any(), any(), any(), any(), any()))
+        .thenReturn(expected);
+
+    BddLogger.when("searchDeclaredActivitiesForAssociation is called with null context class");
+    var result = service.searchDeclaredActivitiesForAssociation(null, null, "kw", pageCriteria);
+
+    BddLogger.then("The helper is invoked with all association parameters null");
+    assertThat(result).isSameAs(expected);
+    verify(associationSearchHelper)
+        .searchForAssociation(
+            eq(null), eq(null), eq(null), eq(null), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void searchDeclaredSkillsForAssociation_should_delegate_to_helper_with_skill_association_type() {
+    BddLogger.given("A declared activity owned by the logged-in student");
+    UUID declaredActivityId = UUID.randomUUID();
+    PageCriteria pageCriteria = new PageCriteria(0, 10);
+    PageInfo pageInfo = new PageInfo(0, 10, 0);
+    DeclaredActivity declaredActivity = mock(DeclaredActivity.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
+        .thenReturn(Optional.of(declaredActivity));
+    when(declaredActivity.getStudent()).thenReturn(student);
+
+    PagedResult<DeclaredSkillProgress> skillSearch = new PagedResult<>(List.of(), pageInfo);
+    when(declaredSkillProgressService.searchDeclaredSkill("kw", pageCriteria))
+        .thenReturn(skillSearch);
+
+    PagedResult<AssociationSearchResultData> expected = new PagedResult<>(List.of(), pageInfo);
+    when(associationSearchHelper.searchForAssociation(
+            eq(declaredActivityId),
+            eq(DeclaredActivity.class),
+            eq(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL),
+            any(),
+            eq(skillSearch),
+            any(),
+            any(),
+            any(),
+            any()))
+        .thenReturn(expected);
+
+    BddLogger.when("searchDeclaredSkillsForAssociation is called");
+    var result = service.searchDeclaredSkillsForAssociation(declaredActivityId, "kw", pageCriteria);
+
+    BddLogger.then(
+        "The helper is invoked with DECLARED_ACTIVITY_DECLARED_SKILL and the skill search result");
+    assertThat(result).isSameAs(expected);
+  }
+
+  @Test
+  void searchDeclaredSkillsForAssociation_should_throw_when_activity_not_found() {
+    BddLogger.given("A non-existent declared activity");
+    UUID declaredActivityId = UUID.randomUUID();
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
+        .thenReturn(Optional.empty());
+
+    BddLogger.when("searchDeclaredSkillsForAssociation is called");
+
+    BddLogger.then("DeclaredActivityNotFoundException is thrown");
+    assertThatThrownBy(
+            () ->
+                service.searchDeclaredSkillsForAssociation(
+                    declaredActivityId, "kw", new PageCriteria(0, 10)))
+        .isInstanceOf(DeclaredActivityNotFoundException.class);
+
+    verify(associationSearchHelper, never())
+        .searchForAssociation(any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void searchDeclaredSkillsForAssociation_should_throw_when_activity_belongs_to_another_student() {
+    BddLogger.given("A declared activity belonging to another student");
+    UUID declaredActivityId = UUID.randomUUID();
+    Student anotherStudent = StudentFixture.create().toModel();
+    DeclaredActivity declaredActivity = mock(DeclaredActivity.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
+        .thenReturn(Optional.of(declaredActivity));
+    when(declaredActivity.getStudent()).thenReturn(anotherStudent);
+
+    BddLogger.when("searchDeclaredSkillsForAssociation is called");
+
+    BddLogger.then("UserNotAuthorizedException is thrown");
+    assertThatThrownBy(
+            () ->
+                service.searchDeclaredSkillsForAssociation(
+                    declaredActivityId, "kw", new PageCriteria(0, 10)))
+        .isInstanceOf(UserNotAuthorizedException.class);
+
+    verify(associationSearchHelper, never())
+        .searchForAssociation(any(), any(), any(), any(), any(), any(), any(), any(), any());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImplTest.java
@@ -7,10 +7,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import fr.avenirsesr.portfolio.association.domain.data.AssociationSearchResultData;
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.association.domain.service.AssociationSearchHelper;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
+import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.SortCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.ESortField;
@@ -740,5 +743,172 @@ public class DeclaredSkillProgressServiceImplTest {
         verifyNoInteractions(associationService);
       }
     }
+  }
+
+  @Test
+  void searchDeclaredSkillsForAssociation_should_use_TRACE_DECLARED_SKILL_when_context_is_Trace() {
+    UUID contextId = randomUUID();
+    PageCriteria pageCriteria = new PageCriteria(0, 10);
+    PagedResult<DeclaredSkillProgress> skillSearch =
+        new PagedResult<>(List.of(), new PageInfo(0, 10, 0));
+
+    when(declaredSkillProgressRepository.findAllByStudent(
+            eq(student),
+            eq(pageCriteria),
+            eq("kw"),
+            eq(new SortCriteria(ESortField.NAME, ESortOrder.ASC))))
+        .thenReturn(skillSearch);
+
+    PagedResult<AssociationSearchResultData> expected =
+        new PagedResult<>(List.of(), new PageInfo(0, 10, 0));
+    when(associationSearchHelper.searchForAssociation(
+            eq(contextId),
+            eq(Trace.class),
+            eq(EAssociationType.TRACE_DECLARED_SKILL),
+            any(),
+            eq(skillSearch),
+            any(),
+            any(),
+            any(),
+            any()))
+        .thenReturn(expected);
+
+    var result =
+        declaredSkillProgressService.searchDeclaredSkillsForAssociation(
+            contextId, EAssociationContextType.TRACE, "kw", pageCriteria);
+
+    assertThat(result).isSameAs(expected);
+  }
+
+  @Test
+  void
+      searchDeclaredSkillsForAssociation_should_use_DECLARED_ACTIVITY_DECLARED_SKILL_when_context_is_Activity() {
+    UUID contextId = randomUUID();
+    PageCriteria pageCriteria = new PageCriteria(0, 10);
+    PagedResult<DeclaredSkillProgress> skillSearch =
+        new PagedResult<>(List.of(), new PageInfo(0, 10, 0));
+
+    when(declaredSkillProgressRepository.findAllByStudent(
+            eq(student),
+            eq(pageCriteria),
+            eq("kw"),
+            eq(new SortCriteria(ESortField.NAME, ESortOrder.ASC))))
+        .thenReturn(skillSearch);
+
+    PagedResult<AssociationSearchResultData> expected =
+        new PagedResult<>(List.of(), new PageInfo(0, 10, 0));
+    when(associationSearchHelper.searchForAssociation(
+            eq(contextId),
+            eq(DeclaredActivity.class),
+            eq(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL),
+            any(),
+            eq(skillSearch),
+            any(),
+            any(),
+            any(),
+            any()))
+        .thenReturn(expected);
+
+    var result =
+        declaredSkillProgressService.searchDeclaredSkillsForAssociation(
+            contextId, EAssociationContextType.DECLARED_ACTIVITY, "kw", pageCriteria);
+
+    assertThat(result).isSameAs(expected);
+  }
+
+  @Test
+  void searchDeclaredSkillsForAssociation_should_pass_nulls_when_context_class_unknown() {
+    PageCriteria pageCriteria = new PageCriteria(0, 10);
+    PagedResult<DeclaredSkillProgress> skillSearch =
+        new PagedResult<>(List.of(), new PageInfo(0, 10, 0));
+
+    when(declaredSkillProgressRepository.findAllByStudent(
+            eq(student),
+            eq(pageCriteria),
+            eq("kw"),
+            eq(new SortCriteria(ESortField.NAME, ESortOrder.ASC))))
+        .thenReturn(skillSearch);
+
+    PagedResult<AssociationSearchResultData> expected =
+        new PagedResult<>(List.of(), new PageInfo(0, 10, 0));
+    when(associationSearchHelper.searchForAssociation(
+            eq(null), eq(null), eq(null), eq(null), eq(skillSearch), any(), any(), any(), any()))
+        .thenReturn(expected);
+
+    var result =
+        declaredSkillProgressService.searchDeclaredSkillsForAssociation(
+            null, null, "kw", pageCriteria);
+
+    assertThat(result).isSameAs(expected);
+  }
+
+  @Test
+  void
+      searchDeclaredActivityForAssociation_should_delegate_to_helper_when_skill_owned_by_student() {
+    UUID declaredSkillProgressId = randomUUID();
+    PageCriteria pageCriteria = new PageCriteria(0, 10);
+
+    DeclaredSkillProgress skill =
+        DeclaredSkillProgressFixture.create().withStudent(student).toModel();
+    when(declaredSkillProgressRepository.findById(declaredSkillProgressId))
+        .thenReturn(Optional.of(skill));
+
+    PagedResult<DeclaredActivity> activitySearch =
+        new PagedResult<>(List.of(), new PageInfo(0, 10, 0));
+    when(declaredActivityService.searchDeclaredActivity("kw", pageCriteria))
+        .thenReturn(activitySearch);
+
+    PagedResult<AssociationSearchResultData> expected =
+        new PagedResult<>(List.of(), new PageInfo(0, 10, 0));
+    when(associationSearchHelper.searchForAssociation(
+            eq(declaredSkillProgressId),
+            eq(DeclaredSkillProgress.class),
+            eq(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL),
+            any(),
+            eq(activitySearch),
+            any(),
+            any(),
+            any(),
+            any()))
+        .thenReturn(expected);
+
+    var result =
+        declaredSkillProgressService.searchDeclaredActivityForAssociation(
+            declaredSkillProgressId, "kw", pageCriteria);
+
+    assertThat(result).isSameAs(expected);
+  }
+
+  @Test
+  void searchDeclaredActivityForAssociation_should_throw_when_skill_not_found() {
+    UUID declaredSkillProgressId = randomUUID();
+    when(declaredSkillProgressRepository.findById(declaredSkillProgressId))
+        .thenReturn(Optional.empty());
+
+    assertThrows(
+        DeclaredSkillProgressNotFoundException.class,
+        () ->
+            declaredSkillProgressService.searchDeclaredActivityForAssociation(
+                declaredSkillProgressId, "kw", new PageCriteria(0, 10)));
+
+    verifyNoInteractions(associationSearchHelper);
+  }
+
+  @Test
+  void searchDeclaredActivityForAssociation_should_throw_when_skill_belongs_to_another_student() {
+    UUID declaredSkillProgressId = randomUUID();
+    Student anotherStudent = StudentFixture.create().toModel();
+    DeclaredSkillProgress skill =
+        DeclaredSkillProgressFixture.create().withStudent(anotherStudent).toModel();
+    when(declaredSkillProgressRepository.findById(declaredSkillProgressId))
+        .thenReturn(Optional.of(skill));
+
+    assertThrows(
+        UserNotAuthorizedException.class,
+        () ->
+            declaredSkillProgressService.searchDeclaredActivityForAssociation(
+                declaredSkillProgressId, "kw", new PageCriteria(0, 10)));
+
+    verifyNoInteractions(associationSearchHelper);
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

Adding endpoints to search for association an `DeclaredActivity`, `DeclaredSkill` or `DeclaredExperience` without providing an ID.

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
<!-- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/### -->

Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1470

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

develop

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process