### PR TITLE
fix(declared experience): update description and summary column size limit

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/model/DeclaredExperienceEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/model/DeclaredExperienceEntity.java
@@ -52,6 +52,7 @@ public class DeclaredExperienceEntity extends PeriodEntity<LocalDate> {
   private String location;
 
   @Size(max = DESCRIPTION_LENGTH, message = "description can not exceed {max} characters")
+  @Column(length = DESCRIPTION_LENGTH)
   private String description;
 
   @Size(
@@ -61,6 +62,7 @@ public class DeclaredExperienceEntity extends PeriodEntity<LocalDate> {
   private String sourceOfInformation;
 
   @Size(max = SUMMARY_LENGTH, message = "summary can not exceed {max} characters")
+  @Column(length = SUMMARY_LENGTH)
   private String summary;
 
   @Column(name = "external_link")

--- a/src/main/resources/db/changelog/generated/changelog_2026-05-06__09-46-34.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-05-06__09-46-34.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="pbeger (generated)" id="1778060799782-1">
+        <modifyDataType columnName="description" newDataType="varchar(400)" tableName="declared_experience"/>
+    </changeSet>
+    <changeSet author="pbeger (generated)" id="1778060799782-2">
+        <modifyDataType columnName="summary" newDataType="varchar(400)" tableName="declared_experience"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes a database error occurring when updating a `DeclaredExperience` with a `description` or `summary` field exceeding 255 characters. The JPA entity was missing the `@Column(length = ...)` annotation on these fields, causing Hibernate to generate `varchar(255)` columns in the database despite the domain validation allowing up to 400 characters.

**Main changes:**
- 🐛 Add `@Column(length = DESCRIPTION_LENGTH)` on `description` field in `DeclaredExperienceEntity`
- 🐛 Add `@Column(length = SUMMARY_LENGTH)` on `summary` field in `DeclaredExperienceEntity`
- 🔧 Add Liquibase migration to alter existing columns to `varchar(400)` in the `declared_experience` table

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1540
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1541

---

### Documentation
**Database changes (Liquibase migration `changelog_2026-05-06__09-46-34.xml`):**
- `declared_experience.description`: `varchar(255)` → `varchar(400)`
- `declared_experience.summary`: `varchar(255)` → `varchar(400)`

**Modified files:**
- `src/main/java/.../DeclaredExperienceEntity.java` - Add `@Column(length)` on `description` and `summary`
- `src/main/resources/db/changelog/generated/changelog_2026-05-06__09-46-34.xml` - Liquibase changesets to resize columns

---

### Target Branch
`develop`

---

### Additional Notes
The root cause was a mismatch between the Bean Validation constraint (`@Size(max = 400)`) and the actual DDL column type (`varchar(255)` by default when `@Column(length)` is absent). The fix aligns the database schema with the domain validation rules already in place.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process