### PR TITLE
fix(user-student): get email instead of institutionEmail on profileOverview

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
@@ -55,14 +55,13 @@ public class UserServiceImpl implements UserService {
           case STUDENT -> studentService.getBio(user);
           case STAFF -> staffService.getBio(user);
         };
-    var institutionEmail =
+    var email =
         switch (userCategory) {
-          case STUDENT -> studentService.getInstitutionEmail(user);
+          case STUDENT -> user.getEmail();
           case STAFF -> staffService.getInstitutionEmail(user);
         };
 
-    return new UserProfileOverviewData(
-        user.getFirstName(), user.getLastName(), institutionEmail, bio);
+    return new UserProfileOverviewData(user.getFirstName(), user.getLastName(), email, bio);
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java
@@ -150,7 +150,7 @@ public class UserControllerIT extends ContainerConfigurationTest {
         .isOk()
         .expectBody()
         .jsonPath("$.email")
-        .isEqualTo("lucas.tessier@email.com")
+        .isEqualTo("lucas.tessier@university.com")
         .jsonPath("$.bio")
         .exists();
   }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR fixes the student profile overview email source by returning the account email instead of the institution email for student users.

Main changes:
- 🐛 Use student account email in user profile overview response
- ✅ Update integration test expectation for student email in profile overview

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1551

---

### Documentation
- Updated integration test to validate the corrected student email value in the overview endpoint response

Modified files:
- src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
- src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java

---

### Target Branch
`develop`

---

### Additional Notes
For staff users, the existing behavior is preserved and still uses institution email. The fix only changes the student branch logic.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to CHANGELOG.md file all properties and database change and details for the update process
