### PR TITLE
fix(1602): sort declared experiences by end date instead of start date

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/specification/DeclaredExperienceSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/specification/DeclaredExperienceSpecification.java
@@ -20,7 +20,7 @@ public class DeclaredExperienceSpecification {
           cb.<Integer>selectCase().when(cb.isNull(root.get("endDate")), 1).otherwise(0);
 
       orders.add(cb.desc(endDateOrder));
-      orders.add(cb.desc(root.get("startDate")));
+      orders.add(cb.desc(root.get("endDate")));
       orders.add(cb.asc(cb.lower(root.get("title"))));
 
       query.orderBy(orders);


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Sort declared experiences by `endDate` instead of `startDate`

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1602

---

**Modified areas:**
- `src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/specification/DeclaredExperienceSpecification.java`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process