### PR TITLE
feat(1653): add staff library endpoint

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
@@ -121,6 +121,30 @@ public class ActivityController {
     return ResponseEntity.ok(viewResponse);
   }
 
+  @GetMapping("/staff/library")
+  public ResponseEntity<PagedResponse<ActivityStaffOverviewDTO>> getStaffActivityLibrary(
+      Principal principal,
+      @RequestParam(required = false) Integer page,
+      @RequestParam(required = false) Integer pageSize,
+      @RequestParam(required = false) EActivityThematic thematic) {
+    var pageCriteria = new PageCriteria(page, pageSize);
+    log.debug(
+        "Received request to get activity library view of user [{}] (page= {}, fileSize= {})",
+        principal.getName(),
+        pageCriteria.page(),
+        pageCriteria.pageSize());
+
+    PagedResult<ActivityStaffOverviewData> pagedResult =
+        activityService.staffActivityLibrary(thematic, pageCriteria);
+
+    var viewResponse =
+        new PagedResponse<>(
+            pagedResult.content().stream().map(activityStaffOverviewDtoMapper::toDTO).toList(),
+            PageInfoDTO.fromDomain(pagedResult.pageInfo()));
+
+    return ResponseEntity.ok(viewResponse);
+  }
+
   @GetMapping
   public ResponseEntity<PagedResponse<ActivityOverviewDTO>> getActivitiesView(
       Principal principal,

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
@@ -48,6 +48,9 @@ public interface ActivityService {
 
   PagedResult<ActivityStaffOverviewData> staffActivityWorkingSpace(PageCriteria pageCriteria);
 
+  PagedResult<ActivityStaffOverviewData> staffActivityLibrary(
+      EActivityThematic thematic, PageCriteria pageCriteria);
+
   PagedResult<ActivityWithStudentStatusData> latestActivitiesView(PageCriteria pageCriteria);
 
   ActivityDraft createActivityDraft(String title);

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/output/repository/ActivityRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/output/repository/ActivityRepository.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.activity.domain.port.output.repository;
 
+import fr.avenirsesr.portfolio.activity.domain.data.ActivityStaffOverviewData;
 import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityThematic;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
@@ -10,6 +11,9 @@ import java.util.List;
 
 public interface ActivityRepository extends GenericRepositoryPort<Activity> {
   PagedResult<Activity> findAll(EActivityThematic thematic, PageCriteria pageCriteria);
+
+  PagedResult<ActivityStaffOverviewData> findAllStaffOverview(
+      EActivityThematic thematic, PageCriteria pageCriteria);
 
   PagedResult<Activity> findLatest(
       Duration durationForLate, List<Activity> activityToExclude, PageCriteria pageCriteria);

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -194,6 +194,13 @@ public class ActivityServiceImpl implements ActivityService {
   }
 
   @Override
+  public PagedResult<ActivityStaffOverviewData> staffActivityLibrary(
+      EActivityThematic thematic, PageCriteria pageCriteria) {
+    loggedInUserService.getLoggedInStaff();
+    return activityRepository.findAllStaffOverview(thematic, pageCriteria);
+  }
+
+  @Override
   public PagedResult<ActivityWithStudentStatusData> activitiesView(
       EActivityThematic thematic, PageCriteria pageCriteria) {
     var pagedActivities = activityRepository.findAll(thematic, pageCriteria);

--- a/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/repository/ActivityDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/repository/ActivityDatabaseRepository.java
@@ -1,6 +1,8 @@
 package fr.avenirsesr.portfolio.activity.infrastructure.adapter.repository;
 
+import fr.avenirsesr.portfolio.activity.domain.data.ActivityStaffOverviewData;
 import fr.avenirsesr.portfolio.activity.domain.model.Activity;
+import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityStatus;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityThematic;
 import fr.avenirsesr.portfolio.activity.domain.port.output.repository.ActivityRepository;
 import fr.avenirsesr.portfolio.activity.infrastructure.adapter.mapper.ActivityMapper;
@@ -30,6 +32,25 @@ public class ActivityDatabaseRepository
 
     return findAll(
         specification, PageRequest.of(pageCriteria.page(), pageCriteria.pageSize(), sort));
+  }
+
+  @Override
+  public PagedResult<ActivityStaffOverviewData> findAllStaffOverview(
+      EActivityThematic thematic, PageCriteria pageCriteria) {
+    var pagedActivities = findAll(thematic, pageCriteria);
+    return new PagedResult<>(
+        pagedActivities.content().stream()
+            .map(
+                a ->
+                    new ActivityStaffOverviewData(
+                        a.getId(),
+                        a.getTitle(),
+                        a.getThematic(),
+                        a.getAuthor(),
+                        EActivityStatus.PUBLISHED,
+                        a.getUpdatedAt()))
+            .toList(),
+        pagedActivities.pageInfo());
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java
@@ -29,6 +29,7 @@ class ActivityControllerIT extends ContainerConfigurationTest {
   private static final String DRAFT_BASE_PATH = BASE_PATH + "/draft";
   private static final String DRAFT_UPDATE_PATH = BASE_PATH + "/DRAFT/{draftId}";
   private static final String WORKING_SPACE_PATH = BASE_PATH + "/staff/working-space";
+  private static final String LIBRARY_PATH = BASE_PATH + "/staff/library";
   private static final String PUBLISH_PATH = BASE_PATH + "/publish/{draftId}";
 
   @Autowired private WebTestClient webTestClient;
@@ -783,6 +784,100 @@ class ActivityControllerIT extends ContainerConfigurationTest {
   }
 
   @Test
+  void shouldReturnStaffActivityLibrary() {
+    BddLogger.given("the " + LIBRARY_PATH + " endpoint");
+    BddLogger.when("performing a GET as a staff user");
+    BddLogger.then("it should return paged activities with data and page info");
+
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path(LIBRARY_PATH)
+                    .queryParam("page", "0")
+                    .queryParam("pageSize", "8")
+                    .build())
+        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+        .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.data")
+        .isArray()
+        .jsonPath("$.page.page")
+        .isEqualTo(0)
+        .jsonPath("$.page.pageSize")
+        .isEqualTo(8)
+        .jsonPath("$.page.totalElements")
+        .exists();
+  }
+
+  @Test
+  void shouldReturnStaffActivityLibraryFilteredByThematic() {
+    BddLogger.given("the " + LIBRARY_PATH + " endpoint with thematic filter");
+    BddLogger.when("performing a GET with thematic filter");
+    BddLogger.then("it should return filtered paged activities");
+
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path(LIBRARY_PATH)
+                    .queryParam("thematic", EActivityThematic.SELF_KNOWLEDGE.name())
+                    .queryParam("page", "0")
+                    .queryParam("pageSize", "8")
+                    .build())
+        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+        .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.data")
+        .isArray()
+        .jsonPath("$.page.page")
+        .isEqualTo(0)
+        .jsonPath("$.page.pageSize")
+        .isEqualTo(8)
+        .jsonPath("$.page.totalElements")
+        .exists();
+  }
+
+  @Test
+  void shouldReturnStaffActivityLibraryWithDefaultPaginationWhenNoParamsProvided() {
+    BddLogger.given("the " + LIBRARY_PATH + " endpoint");
+    BddLogger.when("performing a GET without pagination params");
+    BddLogger.then("it should return 200 with default pagination applied");
+
+    webTestClient
+        .get()
+        .uri(LIBRARY_PATH)
+        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+        .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.data")
+        .isArray()
+        .jsonPath("$.page.page")
+        .isEqualTo(0)
+        .jsonPath("$.page.pageSize")
+        .isEqualTo(8)
+        .jsonPath("$.page.totalElements")
+        .exists();
+  }
+
+  @Test
   void shouldReturnOnlyStaffOwnActivities() throws Exception {
     BddLogger.given("a staff user with created drafts");
     createDraftAndGetId("Mon brouillon working space");
@@ -918,6 +1013,42 @@ class ActivityControllerIT extends ContainerConfigurationTest {
     webTestClient
         .get()
         .uri(WORKING_SPACE_PATH)
+        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, secondStudentPayload)
+        .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, secondStudentSignature)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .jsonPath("$.code")
+        .isEqualTo("USER_IS_NOT_STAFF_EXCEPTION");
+  }
+
+  @Test
+  void shouldReturn401WhenNotAuthenticatedOnLibrary() {
+    BddLogger.given("the " + LIBRARY_PATH + " endpoint");
+    BddLogger.when("performing a GET without authentication headers");
+    BddLogger.then("it should return 401");
+
+    webTestClient
+        .get()
+        .uri(LIBRARY_PATH)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+  }
+
+  @Test
+  void shouldReturn403WhenUserIsNotStaffOnLibrary() {
+    BddLogger.given("the " + LIBRARY_PATH + " endpoint");
+    BddLogger.when("performing a GET with a student account");
+    BddLogger.then("it should return 403 with USER_IS_NOT_STAFF error code");
+
+    webTestClient
+        .get()
+        .uri(LIBRARY_PATH)
         .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, secondStudentPayload)
         .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
         .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, secondStudentSignature)

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerTest.java
@@ -441,6 +441,141 @@ class ActivityControllerTest {
   }
 
   @Test
+  void shouldReturnStaffActivityLibrary() {
+    BddLogger.given("an ActivityController for staff library");
+
+    PageInfo pageInfo = new PageInfo(0, 8, 1);
+    var staff = mock(Staff.class);
+
+    var overviewData =
+        new ActivityStaffOverviewData(
+            UUID.randomUUID(),
+            "Mon activité",
+            EActivityThematic.EXPERIENCES,
+            staff,
+            EActivityStatus.PUBLISHED,
+            Instant.now());
+
+    var pagedResult = new PagedResult<>(List.of(overviewData), pageInfo);
+
+    when(activityService.staffActivityLibrary(eq(null), any(PageCriteria.class)))
+        .thenReturn(pagedResult);
+
+    var expectedDto =
+        new ActivityStaffOverviewDTO(
+            overviewData.activityId(),
+            AUTHOR,
+            "title",
+            EActivityThematic.EXPERIENCES,
+            EActivityStatus.PUBLISHED,
+            Instant.now());
+    when(activityStaffOverviewDtoMapper.toDTO(overviewData)).thenReturn(expectedDto);
+
+    BddLogger.when("getting staff activity library");
+    var response = controller.getStaffActivityLibrary(principal, 0, 8, null);
+
+    BddLogger.then("it should return the library with correct data");
+
+    assertEquals(200, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+    assertEquals(1, response.getBody().data().size());
+
+    var dto = response.getBody().data().getFirst();
+    assertEquals(overviewData.activityId(), dto.activityId());
+    assertEquals(EActivityStatus.PUBLISHED, dto.activityStatus());
+
+    verify(activityService).staffActivityLibrary(eq(null), any(PageCriteria.class));
+    verify(activityStaffOverviewDtoMapper).toDTO(overviewData);
+  }
+
+  @Test
+  void shouldReturnStaffActivityLibraryWithThematic() {
+    BddLogger.given("an ActivityController for staff library with thematic filter");
+
+    PageInfo pageInfo = new PageInfo(0, 8, 1);
+    var staff = mock(Staff.class);
+
+    var overviewData =
+        new ActivityStaffOverviewData(
+            UUID.randomUUID(),
+            "Mon activité",
+            EActivityThematic.EXPERIENCES,
+            staff,
+            EActivityStatus.PUBLISHED,
+            Instant.now());
+
+    var pagedResult = new PagedResult<>(List.of(overviewData), pageInfo);
+
+    when(activityService.staffActivityLibrary(
+            eq(EActivityThematic.EXPERIENCES), any(PageCriteria.class)))
+        .thenReturn(pagedResult);
+
+    when(activityStaffOverviewDtoMapper.toDTO(overviewData))
+        .thenReturn(
+            new ActivityStaffOverviewDTO(
+                overviewData.activityId(),
+                AUTHOR,
+                "title",
+                EActivityThematic.EXPERIENCES,
+                EActivityStatus.PUBLISHED,
+                Instant.now()));
+
+    BddLogger.when("getting staff activity library with thematic");
+    var response =
+        controller.getStaffActivityLibrary(principal, 0, 8, EActivityThematic.EXPERIENCES);
+
+    BddLogger.then("it should return filtered activities");
+
+    assertEquals(200, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+    assertEquals(1, response.getBody().data().size());
+
+    verify(activityService)
+        .staffActivityLibrary(eq(EActivityThematic.EXPERIENCES), any(PageCriteria.class));
+  }
+
+  @Test
+  void shouldReturnEmptyStaffActivityLibrary() {
+    BddLogger.given("an ActivityController with no activities in library");
+
+    PageInfo pageInfo = new PageInfo(0, 8, 0);
+
+    when(activityService.staffActivityLibrary(any(), any(PageCriteria.class)))
+        .thenReturn(new PagedResult<>(List.of(), pageInfo));
+
+    BddLogger.when("getting staff activity library with no results");
+    var response = controller.getStaffActivityLibrary(principal, 0, 8, null);
+
+    BddLogger.then("it should return empty content");
+
+    assertEquals(200, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().data().isEmpty());
+
+    verify(activityService).staffActivityLibrary(any(), any(PageCriteria.class));
+    verifyNoInteractions(activityStaffOverviewDtoMapper);
+  }
+
+  @Test
+  void shouldForwardPageCriteriaToLibraryService() {
+    BddLogger.given("an ActivityController receiving specific pagination params");
+
+    PageInfo pageInfo = new PageInfo(2, 5, 0);
+
+    when(activityService.staffActivityLibrary(any(), any(PageCriteria.class)))
+        .thenReturn(new PagedResult<>(List.of(), pageInfo));
+
+    BddLogger.when("getting staff activity library with page=2 and pageSize=5");
+    controller.getStaffActivityLibrary(principal, 2, 5, null);
+
+    BddLogger.then("it should forward the pagination params to the service");
+
+    verify(activityService)
+        .staffActivityLibrary(
+            any(), argThat(criteria -> criteria.page() == 2 && criteria.pageSize() == 5));
+  }
+
+  @Test
   void shouldApplyMapperToEachItem() {
     BddLogger.given("an ActivityController with multiple activities to map");
 

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -1,6 +1,9 @@
 package fr.avenirsesr.portfolio.activity.domain.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -943,6 +946,84 @@ class ActivityServiceImplTest {
     assertEquals(staff, data.author());
     assertEquals(EActivityStatus.DRAFT, data.activityStatus());
     assertEquals(expectedUpdatedAt, data.updatedAt());
+  }
+
+  @Test
+  void staffActivityLibrary_shouldReturnPagedResult() {
+    // Given
+    var pageCriteria = mock(PageCriteria.class);
+    var pageInfo = new PageInfo(0, 8, 1);
+    var staff = mock(Staff.class);
+
+    var overviewData =
+        new ActivityStaffOverviewData(
+            UUID.randomUUID(),
+            "Mon activité",
+            EActivityThematic.EXPERIENCES,
+            staff,
+            EActivityStatus.PUBLISHED,
+            Instant.now());
+
+    var pagedActivities = new PagedResult<>(List.of(overviewData), pageInfo);
+
+    when(activityRepository.findAllStaffOverview(null, pageCriteria)).thenReturn(pagedActivities);
+
+    // When
+    var result = activityService.staffActivityLibrary(null, pageCriteria);
+
+    // Then
+    assertNotNull(result);
+    assertEquals(1, result.content().size());
+    assertEquals(pageInfo, result.pageInfo());
+
+    var data = result.content().getFirst();
+    assertEquals(overviewData.activityId(), data.activityId());
+    assertEquals(overviewData.title(), data.title());
+    assertEquals(overviewData.thematic(), data.thematic());
+    assertEquals(overviewData.author(), data.author());
+    assertEquals(overviewData.activityStatus(), data.activityStatus());
+    assertEquals(overviewData.updatedAt(), data.updatedAt());
+
+    verify(loggedInUserService).getLoggedInStaff();
+    verify(activityRepository).findAllStaffOverview(null, pageCriteria);
+  }
+
+  @Test
+  void staffActivityLibrary_shouldReturnEmpty_whenNoActivities() {
+    // Given
+    var pageCriteria = mock(PageCriteria.class);
+    var pageInfo = new PageInfo(0, 8, 0);
+
+    when(activityRepository.findAllStaffOverview(null, pageCriteria))
+        .thenReturn(new PagedResult<>(List.of(), pageInfo));
+
+    // When
+    var result = activityService.staffActivityLibrary(null, pageCriteria);
+
+    // Then
+    assertNotNull(result);
+    assertTrue(result.content().isEmpty());
+    assertEquals(pageInfo, result.pageInfo());
+
+    verify(loggedInUserService).getLoggedInStaff();
+    verify(activityRepository).findAllStaffOverview(null, pageCriteria);
+  }
+
+  @Test
+  void staffActivityLibrary_shouldForwardThematicToRepository() {
+    // Given
+    var pageCriteria = mock(PageCriteria.class);
+    var pageInfo = new PageInfo(0, 8, 0);
+
+    when(activityRepository.findAllStaffOverview(EActivityThematic.EXPERIENCES, pageCriteria))
+        .thenReturn(new PagedResult<>(List.of(), pageInfo));
+
+    // When
+    activityService.staffActivityLibrary(EActivityThematic.EXPERIENCES, pageCriteria);
+
+    // Then
+    verify(loggedInUserService).getLoggedInStaff();
+    verify(activityRepository).findAllStaffOverview(EActivityThematic.EXPERIENCES, pageCriteria);
   }
 
   @Test


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- Add the `/me/activities/staff/library` endpoint to retrieve a paginated list of published activities

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1653

---

**Modified areas:**
- `src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java`
- `src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java`
- `src/main/java/fr/avenirsesr/portfolio/activity/domain/port/output/repository/ActivityRepository.java`
- `src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java`
- `src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/repository/ActivityDatabaseRepository.java`
- `src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java`
- `src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerTest.java`
- `src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java`

---

### Target Branch
`develop`

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process