### PR TITLE
feat(staff-activity): implement delete draft endpoint

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
@@ -198,6 +198,19 @@ public class ActivityController {
     return ResponseEntity.ok(new CreationResponse(activity.getId()));
   }
 
+  @DeleteMapping("/draft/{activityDraftId}")
+  public ResponseEntity<String> deleteActivityDraft(
+      Principal principal, @PathVariable UUID activityDraftId) {
+    log.debug(
+        "Received request to delete activity draft {} by user [{}]",
+        activityDraftId,
+        principal.getName());
+
+    activityService.deleteDraft(activityDraftId);
+
+    return ResponseEntity.ok("Activity draft successfully deleted");
+  }
+
   @PatchMapping("/{activityStatus}/{activityId}")
   public ResponseEntity<ActivityDraftUpdateResponse> updateActivity(
       Principal principal,

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
@@ -31,6 +31,8 @@ public interface ActivityService {
 
   Activity publish(UUID activityDraftId);
 
+  void deleteDraft(UUID activityDraftId);
+
   FileData getActivityBanner(Activity activity);
 
   FileData getActivityBanner(ActivityDraft activity);

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -124,14 +124,30 @@ public class ActivityServiceImpl implements ActivityService {
   }
 
   @Override
+  public void deleteDraft(UUID activityDraftId) {
+    var staff = loggedInUserService.getLoggedInStaff();
+    var draft =
+        activityDraftRepository
+            .findById(activityDraftId)
+            .orElseThrow(ActivityDraftNotFoundException::new);
+    if (!draft.getAuthor().equals(staff)) {
+      throw new UserNotAuthorizedException();
+    }
+
+    activityDraftRepository.removeFromDatabase(draft);
+    log.info("Deleted activity draft with id: {}", activityDraftId);
+  }
+
+  @Override
   public Activity getActivityById(UUID id) {
-    return activityRepository.findById(id).orElseThrow(ActivityNotFoundException::new);
+    return activityRepository.findById(id).orElseThrow(ActivityDraftNotFoundException::new);
   }
 
   @Override
   public ActivityDraft getActivityDraftById(UUID id) {
     var staff = loggedInUserService.getLoggedInStaff();
-    var draft = activityDraftRepository.findById(id).orElseThrow(ActivityNotFoundException::new);
+    var draft =
+        activityDraftRepository.findById(id).orElseThrow(ActivityDraftNotFoundException::new);
     if (!draft.getAuthor().equals(staff)) {
       throw new UserNotAuthorizedException();
     }

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -1,6 +1,9 @@
 package fr.avenirsesr.portfolio.activity.domain.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -34,6 +37,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
@@ -1141,5 +1145,98 @@ class ActivityServiceImplTest {
     assertFalse(result.isEnableReflection());
     assertEquals(3, result.getTraceAllowedAssociations());
     assertEquals(5, result.getFeedbackAllowedIterations());
+  }
+
+  @Nested
+  class GivenAnActivityService {
+
+    @BeforeEach
+    void setupGiven() {
+      BddLogger.given("an activity service");
+    }
+
+    @Nested
+    class WhenDeletingAnActivityDraft {
+
+      @BeforeEach
+      void setupWhen() {
+        BddLogger.when("deleting an activity draft");
+      }
+
+      @Nested
+      class AndTheDraftExists {
+
+        ActivityDraft draft = mock(ActivityDraft.class);
+        UUID draftId = UUID.randomUUID();
+
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the draft exists");
+          when(activityDraftRepository.findById(draftId)).thenReturn(Optional.of(draft));
+        }
+
+        @Nested
+        class AndTheLoggedInStaffIsTheAuthor {
+
+          Staff staff = mock(Staff.class);
+
+          @BeforeEach
+          void setupAnd() {
+            BddLogger.and("the logged-in staff is the author of the draft");
+            when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+            when(draft.getAuthor()).thenReturn(staff);
+          }
+
+          @Test
+          void thenItShouldBeDeleted() {
+
+            BddLogger.then("the draft should be deleted");
+            activityService.deleteDraft(draftId);
+            verify(activityDraftRepository).removeFromDatabase(draft);
+          }
+        }
+
+        @Nested
+        class AndTheLoggedInStaffIsNotTheAuthor {
+
+          Staff staff = mock(Staff.class);
+          Staff author = mock(Staff.class);
+
+          @BeforeEach
+          void setupAnd() {
+            BddLogger.and("the logged-in staff is not the author of the draft");
+            when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+            when(draft.getAuthor()).thenReturn(author);
+          }
+
+          @Test
+          void thenItShouldThrowUserNotAuthorizedException() {
+            BddLogger.then("the service should throw UserNotAuthorizedException");
+            assertThrows(
+                UserNotAuthorizedException.class, () -> activityService.deleteDraft(draftId));
+            verify(activityDraftRepository, never()).removeFromDatabase(any());
+          }
+        }
+      }
+
+      @Nested
+      class AndTheDraftDoesNotExist {
+        UUID unknownId = UUID.randomUUID();
+
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the draft does not exist");
+          when(activityDraftRepository.findById(unknownId)).thenReturn(Optional.empty());
+        }
+
+        @Test
+        void thenItShouldThrowActivityDraftNotFoundException() {
+          BddLogger.then("the service should throw ActivityDraftNotFoundException");
+          assertThrows(
+              ActivityDraftNotFoundException.class, () -> activityService.deleteDraft(unknownId));
+          verify(activityDraftRepository, never()).removeFromDatabase(any());
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR implements the delete endpoint for staff activity drafts, allowing users to remove draft progress. 

Main changes:
- ✨ Added DELETE endpoint in `ActivityController`.
- ⚙️ Updated `ActivityService` and `ActivityServiceImpl` to handle draft deletion.
- ✅ Added comprehensive unit tests in `ActivityServiceImplTest`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1509

---

### Documentation
- Updated API services to include delete functionality.
- Modified files:
  - `ActivityController.java`
  - `ActivityService.java`
  - `ActivityServiceImpl.java`
  - `ActivityServiceImplTest.java`

---

### Target Branch
`develop`

---

### Additional Notes
Implementation ensures that only drafts associated with the user/context can be deleted, following existing service patterns.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process
