### PR TITLE
fix(feedback): set right dto into FeedbackStaffListItemDTO

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/FeedbackStaffListItemDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/FeedbackStaffListItemDTO.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public record FeedbackStaffListItemDTO(
     UUID id,
     UserInfoDTO student,
-    DeclaredActivityViewDTO activity,
+    DeclaredActivityDetailsDTO activity,
     @Schema(ref = "#/components/schemas/EFeedbackStatus") EFeedbackStatus status,
     int iteration,
     Instant createdAt,

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityDetailsDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityDetailsDTOMapper.java
@@ -3,6 +3,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.application.a
 import fr.avenirsesr.portfolio.activity.application.adapter.mapper.ActivityContentDtoMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.DeclaredActivityDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.DeclaredActivityDetailsData;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EDeclaredActivityStatus;
 import java.time.Instant;
 import java.util.Optional;
@@ -25,6 +26,11 @@ public interface DeclaredActivityDetailsDTOMapper {
   @Mapping(source = "data.declaredActivity.updatedAt", target = "updatedAt")
   DeclaredActivityDetailsDTO toDTO(
       DeclaredActivityDetailsData data, EDeclaredActivityStatus status);
+
+  @Mapping(source = "activity", target = "activity")
+  @Mapping(target = "status", ignore = true)
+  @Mapping(target = "feedbacks", ignore = true)
+  DeclaredActivityDetailsDTO toDTO(DeclaredActivity declaredActivity);
 
   default Instant unwrap(Optional<Instant> value) {
     return value == null ? null : value.orElse(null);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/FeedbackStaffListItemDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/FeedbackStaffListItemDTOMapper.java
@@ -9,7 +9,7 @@ import org.mapstruct.Mapping;
 
 @Mapper(
     componentModel = "spring",
-    uses = {DeclaredActivityViewDTOMapper.class})
+    uses = {DeclaredActivityDetailsDTOMapper.class})
 public interface FeedbackStaffListItemDTOMapper {
 
   @Mapping(source = "declaredActivity.student.user", target = "student")


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Correction du mapping MapStruct dans `FeedbackStaffListItemDTOMapper` : le champ `activity` était toujours `null` car MapStruct ne pouvait pas faire correspondre automatiquement `declaredActivity` (source) vers `activity` (cible). Ajout d'un `@Mapping` explicite et d'une surcharge `toDTO(DeclaredActivity)` dans `DeclaredActivityDetailsDTOMapper` pour résoudre le problème.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1709

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `DeclaredActivityDetailsDTOMapper.toDTO(DeclaredActivity)` mappe sans `status` ni `feedbacks` (ignorés), adapté au contexte de liste staff.
> - `finishedAt` (`Optional<Instant>`) est géré par le helper `unwrap` existant.

---

### Known Limitations or Side Effects
> `status` et `feedbacks` seront `null` dans le champ `activity` de `FeedbackStaffListItemDTO`, ce qui est attendu pour une vue liste.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process