### PR TITLE
feat(notification): introduce user notification preferences

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImpl.java
@@ -26,8 +26,16 @@ public class NotificationServiceImpl implements NotificationService {
 
   @Override
   public void notify(BaseNotification notification) {
-    // Todo: check if user has enabled notifications
-    var savedNotification = notificationRepository.save(notification.build());
+    var builtNotification = notification.build();
+
+    if (!builtNotification.getUser().isNotificationEnabled()) {
+      log.debug(
+          "Notifications disabled for user [{}], skipping notification",
+          builtNotification.getUser().getId());
+      return;
+    }
+
+    var savedNotification = notificationRepository.save(builtNotification);
 
     var userId = savedNotification.getUser().getId();
     switch (savedNotification.getUserCategory()) {

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/UserMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/UserMapper.java
@@ -15,6 +15,7 @@ public class UserMapper implements Mapper<UserEntity, User> {
             user.getFirstName(),
             user.getLastName(),
             user.getEmail(),
+            user.isNotificationEnabled(),
             user.getCreatedAt(),
             user.getUpdatedAt())
         : null;
@@ -28,6 +29,7 @@ public class UserMapper implements Mapper<UserEntity, User> {
             userEntity.getFirstName(),
             userEntity.getLastName(),
             userEntity.getEmail(),
+            userEntity.isNotificationEnabled(),
             userEntity.getCreatedAt(),
             userEntity.getUpdatedAt())
         : null;

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/model/UserEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/model/UserEntity.java
@@ -25,17 +25,22 @@ public class UserEntity extends AvenirsBaseEntity {
 
   @Email @Column private String email;
 
+  @Column(name = "notification_enabled", nullable = false)
+  private boolean notificationEnabled;
+
   private UserEntity(
       UUID id,
       String firstName,
       String lastName,
       String email,
+      boolean notificationEnabled,
       Instant createdAt,
       Instant updatedAt) {
     this.setId(id);
     this.firstName = firstName;
     this.lastName = lastName;
     this.email = email;
+    this.notificationEnabled = notificationEnabled;
     this.setCreatedAt(createdAt);
     this.setUpdatedAt(updatedAt);
   }
@@ -45,8 +50,10 @@ public class UserEntity extends AvenirsBaseEntity {
       String firstName,
       String lastName,
       String email,
+      boolean notificationEnabled,
       Instant createdAt,
       Instant updatedAt) {
-    return new UserEntity(id, firstName, lastName, email, createdAt, updatedAt);
+    return new UserEntity(
+        id, firstName, lastName, email, notificationEnabled, createdAt, updatedAt);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/fake/FakeUser.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/fake/FakeUser.java
@@ -26,6 +26,7 @@ public class FakeUser {
             userDataGenerator.with("firstName").firstName(),
             userDataGenerator.with("lastName").lastName(),
             userDataGenerator.with("email").email(),
+            false,
             Instant.now(),
             Instant.now()));
   }

--- a/src/main/resources/db/changelog/generated/changelog_2026-06-12__add-notification-enabled-to-student-and-staff.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-06-12__add-notification-enabled-to-student-and-staff.xml
@@ -1,0 +1,10 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="bilelbanelhaq" id="add-notification-enabled-to-user">
+        <addColumn tableName="user">
+            <column name="notification_enabled" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImplTest.java
@@ -20,6 +20,7 @@ import fr.avenirsesr.portfolio.user.domain.model.Staff;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.StaffRepository;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.StudentRepository;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.StaffFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.time.Instant;
@@ -70,7 +71,7 @@ class NotificationServiceImplTest {
     @Test
     void should_save_the_notification_built_from_the_base_notification() {
       BddLogger.given("A BaseNotification that builds a specific Notification");
-      User user = UserFixture.create().toModel();
+      User user = UserFixture.create().withNotificationEnabled(true).toModel();
       Notification expectedNotification = buildNotification(user, EUserCategory.STUDENT);
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(expectedNotification);
@@ -88,7 +89,7 @@ class NotificationServiceImplTest {
     @Test
     void should_call_build_exactly_once() {
       BddLogger.given("A BaseNotification mock");
-      User user = UserFixture.create().toModel();
+      User user = UserFixture.create().withNotificationEnabled(true).toModel();
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(buildNotification(user, EUserCategory.STUDENT));
       when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -167,8 +168,8 @@ class NotificationServiceImplTest {
 
     @Test
     void should_set_hasUnseenNotification_true_on_student_when_userCategory_is_STUDENT() {
-      BddLogger.given("A notification targeting a STUDENT");
-      User user = UserFixture.create().toModel();
+      BddLogger.given("A notification targeting a STUDENT whose user has notifications enabled");
+      User user = UserFixture.create().withNotificationEnabled(true).toModel();
       Student student =
           StudentFixture.create().withUser(user).withHasUnseenNotification(false).toModel();
       Notification notification = buildNotification(user, EUserCategory.STUDENT);
@@ -188,10 +189,12 @@ class NotificationServiceImplTest {
 
     @Test
     void should_not_update_staff_when_userCategory_is_STUDENT() {
-      BddLogger.given("A notification targeting a STUDENT");
-      User user = UserFixture.create().toModel();
+      BddLogger.given("A notification targeting a STUDENT whose user has notifications enabled");
+      User user = UserFixture.create().withNotificationEnabled(true).toModel();
+      Student student = StudentFixture.create().withUser(user).toModel();
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(buildNotification(user, EUserCategory.STUDENT));
+      when(studentRepository.findById(user.getId())).thenReturn(Optional.of(student));
       when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
@@ -203,11 +206,9 @@ class NotificationServiceImplTest {
 
     @Test
     void should_set_hasUnseenNotification_true_on_staff_when_userCategory_is_STAFF() {
-      BddLogger.given("A notification targeting a STAFF");
-      User user = UserFixture.create().toModel();
-      Staff staff =
-          Staff.toDomain(
-              user, user.getEmail(), "bio", false, null, null, Instant.now(), Instant.now());
+      BddLogger.given("A notification targeting a STAFF whose user has notifications enabled");
+      User user = UserFixture.create().withNotificationEnabled(true).toModel();
+      Staff staff = StaffFixture.create().withUser(user).withHasUnseenNotification(false).toModel();
       Notification notification = buildNotification(user, EUserCategory.STAFF);
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(notification);
@@ -225,10 +226,12 @@ class NotificationServiceImplTest {
 
     @Test
     void should_not_update_student_when_userCategory_is_STAFF() {
-      BddLogger.given("A notification targeting a STAFF");
-      User user = UserFixture.create().toModel();
+      BddLogger.given("A notification targeting a STAFF whose user has notifications enabled");
+      User user = UserFixture.create().withNotificationEnabled(true).toModel();
+      Staff staff = StaffFixture.create().withUser(user).toModel();
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(buildNotification(user, EUserCategory.STAFF));
+      when(staffRepository.findById(user.getId())).thenReturn(Optional.of(staff));
       when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
@@ -240,13 +243,11 @@ class NotificationServiceImplTest {
 
     @Test
     void should_set_hasUnseenNotification_true_on_both_when_userCategory_is_null() {
-      BddLogger.given("A notification with no specific user category (null)");
-      User user = UserFixture.create().toModel();
+      BddLogger.given("A notification with null category whose user has notifications enabled");
+      User user = UserFixture.create().withNotificationEnabled(true).toModel();
       Student student =
           StudentFixture.create().withUser(user).withHasUnseenNotification(false).toModel();
-      Staff staff =
-          Staff.toDomain(
-              user, user.getEmail(), "bio", false, null, null, Instant.now(), Instant.now());
+      Staff staff = StaffFixture.create().withUser(user).withHasUnseenNotification(false).toModel();
       Notification notification = buildNotification(user, null);
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(notification);
@@ -265,6 +266,55 @@ class NotificationServiceImplTest {
       ArgumentCaptor<Staff> staffCaptor = ArgumentCaptor.forClass(Staff.class);
       verify(staffRepository).save(staffCaptor.capture());
       assertTrue(staffCaptor.getValue().isHasUnseenNotification());
+    }
+  }
+
+  @Nested
+  class NotificationEnabledCheck {
+
+    @Test
+    void should_not_save_notification_when_user_has_notifications_disabled() {
+      BddLogger.given("A notification whose user has notifications disabled");
+      User user = UserFixture.create().withNotificationEnabled(false).toModel();
+      BaseNotification baseNotification = mock(BaseNotification.class);
+      when(baseNotification.build()).thenReturn(buildNotification(user, EUserCategory.STUDENT));
+
+      BddLogger.when("notify is called");
+      service.notify(baseNotification);
+
+      BddLogger.then("the notification is not saved and no unseen flag is updated");
+      verify(notificationRepository, never()).save(any());
+      verify(studentRepository, never()).findById(any());
+      verify(staffRepository, never()).findById(any());
+    }
+
+    @Test
+    void should_not_save_notification_for_staff_when_user_has_notifications_disabled() {
+      BddLogger.given("A STAFF notification whose user has notifications disabled");
+      User user = UserFixture.create().withNotificationEnabled(false).toModel();
+      BaseNotification baseNotification = mock(BaseNotification.class);
+      when(baseNotification.build()).thenReturn(buildNotification(user, EUserCategory.STAFF));
+
+      BddLogger.when("notify is called");
+      service.notify(baseNotification);
+
+      BddLogger.then("the notification is not saved");
+      verify(notificationRepository, never()).save(any());
+      verify(staffRepository, never()).findById(any());
+    }
+
+    @Test
+    void should_not_save_notification_for_null_category_when_user_has_notifications_disabled() {
+      BddLogger.given("A null-category notification whose user has notifications disabled");
+      User user = UserFixture.create().withNotificationEnabled(false).toModel();
+      BaseNotification baseNotification = mock(BaseNotification.class);
+      when(baseNotification.build()).thenReturn(buildNotification(user, null));
+
+      BddLogger.when("notify is called");
+      service.notify(baseNotification);
+
+      BddLogger.then("the notification is not saved");
+      verify(notificationRepository, never()).save(any());
     }
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/specification/NotificationSpecificationIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/specification/NotificationSpecificationIT.java
@@ -147,7 +147,7 @@ class NotificationSpecificationIT extends ContainerConfigurationTest {
   private UserEntity persistUser(String email) {
     UserEntity u =
         UserEntity.of(
-            UUID.randomUUID(), "Firstname", "Lastname", email, Instant.now(), Instant.now());
+            UUID.randomUUID(), "Firstname", "Lastname", email, false, Instant.now(), Instant.now());
     entityManager.persist(u);
     return u;
   }

--- a/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
@@ -168,6 +168,7 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
             "firstname",
             "lastname",
             "test@gmail.com",
+            false,
             Instant.now(),
             Instant.now());
     entityManager.persist(u);

--- a/src/test/java/fr/avenirsesr/portfolio/user/infrastructure/fixture/StaffFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/infrastructure/fixture/StaffFixture.java
@@ -1,0 +1,74 @@
+package fr.avenirsesr.portfolio.user.infrastructure.fixture;
+
+import fr.avenirsesr.portfolio.common.data.domain.model.User;
+import fr.avenirsesr.portfolio.file.domain.model.File;
+import fr.avenirsesr.portfolio.user.domain.model.Staff;
+import java.time.Instant;
+import java.util.UUID;
+
+public class StaffFixture {
+  private UUID id;
+  private String bio;
+  private User user;
+  private File profilePicture;
+  private File coverPicture;
+  private boolean hasUnseenNotification;
+  private Instant createdAt;
+  private Instant updatedAt;
+
+  private StaffFixture() {
+    this.user = UserFixture.create().toModel();
+    this.id = user.getId();
+    this.bio = "this is my staff bio";
+    this.hasUnseenNotification = false;
+    this.createdAt = Instant.now();
+    this.updatedAt = Instant.now();
+  }
+
+  public static StaffFixture create() {
+    return new StaffFixture();
+  }
+
+  public StaffFixture withId(UUID id) {
+    this.id = id;
+    this.user = UserFixture.create().withId(id).toModel();
+    return this;
+  }
+
+  public StaffFixture withBio(String bio) {
+    this.bio = bio;
+    return this;
+  }
+
+  public StaffFixture withUser(User user) {
+    this.user = user;
+    return this;
+  }
+
+  public StaffFixture withCreatedAt(Instant createdAt) {
+    this.createdAt = createdAt;
+    return this;
+  }
+
+  public StaffFixture withUpdatedAt(Instant updatedAt) {
+    this.updatedAt = updatedAt;
+    return this;
+  }
+
+  public StaffFixture withHasUnseenNotification(boolean hasUnseenNotification) {
+    this.hasUnseenNotification = hasUnseenNotification;
+    return this;
+  }
+
+  public Staff toModel() {
+    return Staff.toDomain(
+        user,
+        user.getEmail(),
+        bio,
+        hasUnseenNotification,
+        coverPicture,
+        profilePicture,
+        createdAt,
+        updatedAt);
+  }
+}

--- a/src/test/java/fr/avenirsesr/portfolio/user/infrastructure/fixture/UserFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/infrastructure/fixture/UserFixture.java
@@ -10,6 +10,7 @@ public class UserFixture {
   private String firstName;
   private String lastName;
   private String email;
+  private boolean notificationEnabled;
   private Instant createdAt;
   private Instant updatedAt;
 
@@ -18,6 +19,7 @@ public class UserFixture {
     this.firstName = "firstName";
     this.lastName = "lastName";
     this.email = "user@email.com";
+    this.notificationEnabled = false;
     this.createdAt = Instant.now();
     this.updatedAt = Instant.now();
   }
@@ -56,7 +58,12 @@ public class UserFixture {
     return this;
   }
 
+  public UserFixture withNotificationEnabled(boolean notificationEnabled) {
+    this.notificationEnabled = notificationEnabled;
+    return this;
+  }
+
   public User toModel() {
-    return User.toDomain(id, firstName, lastName, email, createdAt, updatedAt);
+    return User.toDomain(id, firstName, lastName, email, notificationEnabled, createdAt, updatedAt);
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a `notificationEnabled` boolean field (default `false`) on the `User` model to let users opt-in to notifications. The `NotificationService.notify()` method now checks this flag before persisting a notification — if disabled it simply logs a debug message and returns early. Includes the Liquibase migration, mapper updates, fake seeders, test fixtures (`UserFixture`, new `StaffFixture`), and full unit-test coverage of the new behaviour.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1747

linked with https://github.com/avenirs-esr/avenirs-portfolio-common/pull/70

---

### Documentation
> No documentation update required. The preference flag is self-describing and will be exposed via the existing user profile endpoints.

---

### Target Branch
> `develop`

---

### Additional Notes
> The field lives on `User` rather than on `Student`/`Staff` to avoid duplicating the preference across role tables — a user can only have one notification preference regardless of their role(s).
>
> The Liquibase changeset (`changelog_2026-06-12__add-notification-enabled-to-student-and-staff.xml`) adds `notification_enabled BOOLEAN NOT NULL DEFAULT FALSE` to the `user` table.

---

### Known Limitations or Side Effects
> - All existing users will have `notificationEnabled = false` after migration. A follow-up story should expose a settings endpoint so users can opt in.
> - No existing notifications are retroactively affected.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process