### PR TITLE
feat(notification): added notification enabled into ProfileOverviewDTO

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/dto/ProfileOverviewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/dto/ProfileOverviewDTO.java
@@ -12,6 +12,7 @@ import java.util.UUID;
       "bio",
       "email",
       "hasUnseenNotification",
+      "notificationEnabled",
       "profilePicture",
       "coverPicture"
     })
@@ -22,5 +23,6 @@ public record ProfileOverviewDTO(
     String bio,
     String email,
     boolean hasUnseenNotification,
+    boolean notificationEnabled,
     FileDTO profilePicture,
     FileDTO coverPicture) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/mapper/ProfileOverviewMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/mapper/ProfileOverviewMapper.java
@@ -16,6 +16,7 @@ public interface ProfileOverviewMapper {
         overview.bio(),
         overview.email(),
         overview.hasUnseenNotification(),
+        overview.notificationEnabled(),
         new FileDTO(
             overview.profilePhoto().id().orElse(null),
             overview.profilePhoto().name().orElse(null),

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/data/UserProfileOverviewData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/data/UserProfileOverviewData.java
@@ -10,5 +10,6 @@ public record UserProfileOverviewData(
     String email,
     String bio,
     boolean hasUnseenNotification,
+    boolean notificationEnabled,
     FileData coverPhoto,
     FileData profilePhoto) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImpl.java
@@ -44,6 +44,7 @@ public class StaffServiceImpl implements StaffService {
         staff.getInstitutionEmail(),
         staff.getBio(),
         staff.isHasUnseenNotification(),
+        staff.getUser().isNotificationEnabled(),
         FileDataMapper.mapFileData(
             staff.getCoverPicture().orElse(null), FileStorageConstants.DEFAULT_COVER_FILE_URL),
         FileDataMapper.mapFileData(

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StudentServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StudentServiceImpl.java
@@ -48,6 +48,7 @@ public class StudentServiceImpl implements StudentService {
         student.getUser().getEmail(),
         student.getBio(),
         student.isHasUnseenNotification(),
+        student.getUser().isNotificationEnabled(),
         FileDataMapper.mapFileData(
             student.getCoverPicture().orElse(null), FileStorageConstants.DEFAULT_COVER_FILE_URL),
         FileDataMapper.mapFileData(

--- a/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/mapper/ProfileOverviewMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/mapper/ProfileOverviewMapperTest.java
@@ -26,7 +26,15 @@ class ProfileOverviewMapperTest {
     var cover = new FileData(Optional.of(coverFileId), Optional.of("cover.jpg"), "cover.jpg");
     UserProfileOverviewData overview =
         new UserProfileOverviewData(
-            UUID.randomUUID(), "Jane", "Doe", "jane@example.com", "My bio", false, cover, profile);
+            UUID.randomUUID(),
+            "Jane",
+            "Doe",
+            "jane@example.com",
+            "My bio",
+            false,
+            true,
+            cover,
+            profile);
 
     BddLogger.when("mapping to ProfileOverviewDTO");
     ProfileOverviewDTO dto = mapper.userDomainToDto(overview, "https://cdn.example.com/");
@@ -38,6 +46,7 @@ class ProfileOverviewMapperTest {
     assertEquals("jane@example.com", dto.email());
     assertEquals("My bio", dto.bio());
     assertFalse(dto.hasUnseenNotification());
+    assertTrue(dto.notificationEnabled());
     assertNotNull(dto.profilePicture());
     assertEquals(profileFileId, dto.profilePicture().id());
     assertEquals("profile.jpg", dto.profilePicture().fileName());
@@ -52,7 +61,15 @@ class ProfileOverviewMapperTest {
     var cover = new FileData(Optional.empty(), Optional.empty(), "default-cover.jpg");
     UserProfileOverviewData overview =
         new UserProfileOverviewData(
-            UUID.randomUUID(), "Jane", "Doe", "jane@example.com", "My bio", true, cover, profile);
+            UUID.randomUUID(),
+            "Jane",
+            "Doe",
+            "jane@example.com",
+            "My bio",
+            true,
+            false,
+            cover,
+            profile);
 
     BddLogger.when("mapping to ProfileOverviewDTO");
     ProfileOverviewDTO dto = mapper.userDomainToDto(overview, "https://cdn.example.com/");
@@ -60,6 +77,7 @@ class ProfileOverviewMapperTest {
     BddLogger.then("it should map hasUnseenNotification as true");
     assertNotNull(dto);
     assertTrue(dto.hasUnseenNotification());
+    assertFalse(dto.notificationEnabled());
   }
 
   @Test
@@ -70,7 +88,15 @@ class ProfileOverviewMapperTest {
     var cover = new FileData(Optional.empty(), Optional.empty(), "default-cover.jpg");
     UserProfileOverviewData overview =
         new UserProfileOverviewData(
-            UUID.randomUUID(), "John", "Smith", "john@example.com", null, false, cover, profile);
+            UUID.randomUUID(),
+            "John",
+            "Smith",
+            "john@example.com",
+            null,
+            false,
+            false,
+            cover,
+            profile);
 
     BddLogger.when("mapping to ProfileOverviewDTO");
     ProfileOverviewDTO dto = mapper.userDomainToDto(overview, "https://cdn.example.com/");


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout du champ `notificationEnabled` (booléen issu du modèle `User`) dans le `ProfileOverviewDTO`, propagé depuis `UserProfileOverviewData` via le mapper et les services `StaffServiceImpl` et `StudentServiceImpl`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1854

---

### Documentation
> Aucune mise à jour documentaire requise. Le champ est ajouté dans la liste `requiredProperties` du `@Schema` Swagger.

---

### Target Branch
> `develop`

---

### Additional Notes
> Le champ `notificationEnabled` est lu directement depuis `User.isNotificationEnabled()` dans les deux services (staff et student). Les tests du mapper ont été mis à jour en conséquence.

---

### Known Limitations or Side Effects
> Aucune.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process