### PR TITLE
feat(notification): added endpoint update notification preferences

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserController.java
@@ -5,6 +5,7 @@ import static fr.avenirsesr.portfolio.shared.application.adapter.Utils.extractOr
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.user.application.adapter.dto.ProfileOverviewDTO;
 import fr.avenirsesr.portfolio.user.application.adapter.mapper.ProfileOverviewMapper;
+import fr.avenirsesr.portfolio.user.application.adapter.request.NotificationPreferencesRequest;
 import fr.avenirsesr.portfolio.user.application.adapter.request.ProfileUpdateRequest;
 import fr.avenirsesr.portfolio.user.domain.data.UserProfileOverviewData;
 import fr.avenirsesr.portfolio.user.domain.port.input.StaffService;
@@ -20,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -71,6 +73,15 @@ public class UserController {
       @RequestBody ProfileUpdateRequest request) {
     log.debug("Received request to update profile of user [{}]", principal.getName());
     userService.updateProfile(userCategory, request.getEmail(), request.getBio());
-    return ResponseEntity.ok("Mise à jour faite.");
+    return ResponseEntity.noContent().build();
+  }
+
+  @PatchMapping("/preferences/notification")
+  public ResponseEntity<String> updateNotificationPreferences(
+      Principal principal, @RequestBody NotificationPreferencesRequest request) {
+    log.debug(
+        "Received request to update notification preferences of user [{}]", principal.getName());
+    userService.updateNotificationPreferences(request.notificationEnabled());
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/request/NotificationPreferencesRequest.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/request/NotificationPreferencesRequest.java
@@ -1,0 +1,3 @@
+package fr.avenirsesr.portfolio.user.application.adapter.request;
+
+public record NotificationPreferencesRequest(boolean notificationEnabled) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/port/input/UserService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/port/input/UserService.java
@@ -11,5 +11,7 @@ public interface UserService extends BaseUserService {
 
   void updateProfile(EUserCategory userCategory, String email, String bio);
 
+  void updateNotificationPreferences(boolean notificationEnabled);
+
   User createUser(UUID id, String firstname, String lastname, String email, String eppn);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
@@ -7,7 +7,7 @@ import fr.avenirsesr.portfolio.common.error.domain.model.enums.EErrorCode;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.common.user.domain.exceptions.ExternalUserNotFoundException;
 import fr.avenirsesr.portfolio.common.user.domain.model.enums.EUserStatus;
-import fr.avenirsesr.portfolio.common.web.infrastructure.context.RequestContext;
+import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StaffService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
 import fr.avenirsesr.portfolio.user.domain.port.input.UserService;
@@ -26,6 +26,7 @@ public class UserServiceImpl implements UserService {
   private final StaffService staffService;
   private final StudentService studentService;
   private final ExternalUserClient externalUserClient;
+  private final LoggedInUserService loggedInUserService;
 
   @Override
   public User getUser(UUID id) {
@@ -47,7 +48,7 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public void updateProfile(EUserCategory userCategory, String email, String bio) {
-    var user = RequestContext.get().userLoggedIn().orElseThrow(IllegalStateException::new);
+    var user = loggedInUserService.getLoggedInUser();
     if (email != null) {
       switch (userCategory) {
         case STUDENT -> user.setEmail(email);
@@ -61,6 +62,13 @@ public class UserServiceImpl implements UserService {
       case STAFF -> staffService.updateProfile(user, bio);
       default -> throw new UserNotAuthorizedException();
     }
+  }
+
+  @Override
+  public void updateNotificationPreferences(boolean notificationEnabled) {
+    var user = loggedInUserService.getLoggedInUser();
+    user.setNotificationEnabled(notificationEnabled);
+    userRepository.save(user);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/service/TransactionalUserService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/service/TransactionalUserService.java
@@ -30,6 +30,11 @@ public class TransactionalUserService implements UserService {
   }
 
   @Override
+  public void updateNotificationPreferences(boolean notificationEnabled) {
+    delegate.updateNotificationPreferences(notificationEnabled);
+  }
+
+  @Override
   @Transactional
   public User createUser(UUID id, String firstname, String lastname, String email, String eppn) {
     return delegate.createUser(id, firstname, lastname, email, eppn);

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/service/UserServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/service/UserServiceConfig.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.user.infrastructure.adapter.service;
 
+import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StaffService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
 import fr.avenirsesr.portfolio.user.domain.port.input.UserService;
@@ -20,6 +21,7 @@ public class UserServiceConfig {
   private final StaffService staffService;
   private final StudentService studentService;
   private final ExternalUserClient externalUserClient;
+  private final LoggedInUserService loggedInUserService;
 
   @Bean
   public UserService userService() {
@@ -29,6 +31,7 @@ public class UserServiceConfig {
             userPrincipalRepository,
             staffService,
             studentService,
-            externalUserClient));
+            externalUserClient,
+            loggedInUserService));
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java
@@ -8,6 +8,7 @@ import fr.avenirsesr.portfolio.shared.application.adapter.Utils;
 import fr.avenirsesr.portfolio.shared.infrastructure.ContainerConfigurationTest;
 import fr.avenirsesr.portfolio.shared.infrastructure.adapter.seeder.SeederRunner;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -64,9 +65,7 @@ public class UserControllerIT extends ContainerConfigurationTest {
         .bodyValue(payloadJson)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectBody(String.class)
-        .isEqualTo("Mise à jour faite.");
+        .isNoContent();
   }
 
   @Test
@@ -87,9 +86,7 @@ public class UserControllerIT extends ContainerConfigurationTest {
         .bodyValue(payloadJson)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectBody(String.class)
-        .isEqualTo("Mise à jour faite.");
+        .isNoContent();
   }
 
   @Test
@@ -230,6 +227,76 @@ public class UserControllerIT extends ContainerConfigurationTest {
     String origin = ReflectionTestUtils.invokeMethod(Utils.class, "extractOrigin", request);
 
     assertThat(origin).isNull();
+  }
+
+  @Nested
+  class UpdateNotificationPreferences {
+
+    @Test
+    void shouldUpdateNotificationPreferencesForStudent() throws Exception {
+      BddLogger.given("the /me/users/preferences/notification endpoint");
+      String payloadJson = loadJson("user/mock-update-notification-preferences.json");
+
+      BddLogger.when("performing a PATCH as a student");
+      BddLogger.then("it should update the notification preferences successfully");
+
+      webTestClient
+          .patch()
+          .uri("/me/users/preferences/notification")
+          .header("X-Signed-Context", studentPayload)
+          .header("X-Context-Kid", secretKey)
+          .header("X-Context-Signature", studentSignature)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(payloadJson)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+    }
+
+    @Test
+    void shouldUpdateNotificationPreferencesForStaff() throws Exception {
+      BddLogger.given("the /me/users/preferences/notification endpoint");
+      String payloadJson = loadJson("user/mock-update-notification-preferences.json");
+
+      BddLogger.when("performing a PATCH as a staff member");
+      BddLogger.then("it should update the notification preferences successfully");
+
+      webTestClient
+          .patch()
+          .uri("/me/users/preferences/notification")
+          .header("X-Signed-Context", staffPayload)
+          .header("X-Context-Kid", secretKey)
+          .header("X-Context-Signature", staffSignature)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(payloadJson)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+    }
+
+    @Test
+    void shouldReturnUnauthorizedForUnknownUser() throws Exception {
+      BddLogger.given("the /me/users/preferences/notification endpoint");
+      String payloadJson = loadJson("user/mock-update-notification-preferences.json");
+
+      BddLogger.when("performing a PATCH with an unknown user");
+      BddLogger.then("it should return 401");
+
+      webTestClient
+          .patch()
+          .uri("/me/users/preferences/notification")
+          .header("X-Signed-Context", unknownPayload)
+          .header("X-Context-Kid", secretKey)
+          .header("X-Context-Signature", unknownSignature)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(payloadJson)
+          .exchange()
+          .expectStatus()
+          .isUnauthorized()
+          .expectBody()
+          .jsonPath("$.code")
+          .isEqualTo("USER_NOT_AUTHORIZED");
+    }
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImplTest.java
@@ -7,20 +7,19 @@ import static org.mockito.Mockito.*;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.error.domain.exception.UserNotFoundException;
-import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.common.user.application.adapter.dto.ExternalUserDTO;
 import fr.avenirsesr.portfolio.common.user.domain.exceptions.ExternalUserNotFoundException;
 import fr.avenirsesr.portfolio.common.user.domain.model.enums.EUserStatus;
-import fr.avenirsesr.portfolio.common.web.infrastructure.context.RequestContext;
-import fr.avenirsesr.portfolio.common.web.infrastructure.context.RequestData;
+import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StaffService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
 import fr.avenirsesr.portfolio.user.domain.port.output.client.ExternalUserClient;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.UserPrincipalRepository;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.UserRepository;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.*;
@@ -36,10 +35,10 @@ class UserServiceImplTest {
   @Mock private StaffService staffService;
   @Mock private StudentService studentService;
   @Mock private ExternalUserClient externalUserClient;
+  @Mock private LoggedInUserService loggedInUserService;
 
   private UserServiceImpl userService;
   private User loggedUser;
-  private MockedStatic<RequestContext> mockedRequestContext;
 
   @BeforeEach
   void setUp() {
@@ -51,17 +50,8 @@ class UserServiceImplTest {
             userPrincipalRepository,
             staffService,
             studentService,
-            externalUserClient);
-
-    mockedRequestContext = mockStatic(RequestContext.class);
-    mockedRequestContext
-        .when(RequestContext::get)
-        .thenReturn(new RequestData(Optional.of(loggedUser), ELanguage.FRENCH));
-  }
-
-  @AfterEach
-  void tearDown() {
-    mockedRequestContext.close();
+            externalUserClient,
+            loggedInUserService);
   }
 
   @Nested
@@ -280,6 +270,11 @@ class UserServiceImplTest {
   @Nested
   class UpdateProfile {
 
+    @BeforeEach
+    void setUp() {
+      when(loggedInUserService.getLoggedInUser()).thenReturn(loggedUser);
+    }
+
     @Test
     void shouldUpdateStudentEmailAndBio() {
       BddLogger.given("a logged student user");
@@ -332,6 +327,49 @@ class UserServiceImplTest {
 
       verify(userRepository, never()).save(any());
       verifyNoInteractions(staffService, studentService);
+    }
+  }
+
+  @Nested
+  class UpdateNotificationPreferences {
+
+    @BeforeEach
+    void setUp() {
+      when(loggedInUserService.getLoggedInUser()).thenReturn(loggedUser);
+    }
+
+    @Test
+    void shouldEnableNotificationsForLoggedInUser() {
+      loggedUser = UserFixture.create().withNotificationEnabled(false).toModel();
+      when(loggedInUserService.getLoggedInUser()).thenReturn(loggedUser);
+
+      BddLogger.given("a logged user with notifications disabled");
+
+      BddLogger.when("enabling notifications");
+      userService.updateNotificationPreferences(true);
+
+      BddLogger.then("it should save the user with notifications enabled");
+      ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+      verify(userRepository).save(userCaptor.capture());
+
+      assertTrue(userCaptor.getValue().isNotificationEnabled());
+    }
+
+    @Test
+    void shouldDisableNotificationsForLoggedInUser() {
+      loggedUser = UserFixture.create().withNotificationEnabled(true).toModel();
+      when(loggedInUserService.getLoggedInUser()).thenReturn(loggedUser);
+
+      BddLogger.given("a logged user with notifications enabled");
+
+      BddLogger.when("disabling notifications");
+      userService.updateNotificationPreferences(false);
+
+      BddLogger.then("it should save the user with notifications disabled");
+      ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+      verify(userRepository).save(userCaptor.capture());
+
+      assertFalse(userCaptor.getValue().isNotificationEnabled());
     }
   }
 

--- a/src/test/resources/mock/user/mock-update-notification-preferences.json
+++ b/src/test/resources/mock/user/mock-update-notification-preferences.json
@@ -1,0 +1,1 @@
+{"notificationEnabled": true}


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout d'un nouvel endpoint `PATCH /me/users/notification-preferences` permettant à un utilisateur connecté de mettre à jour sa préférence de notifications (`notificationEnabled`). Refactorisation de `UserServiceImpl` pour utiliser `LoggedInUserService` à la place de `RequestContext` afin d'obtenir l'utilisateur courant. Tests unitaires et d'intégration ajoutés en conséquence.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1748

---

### Documentation
> Aucune mise à jour de documentation nécessaire. L'endpoint est exposé via Swagger/OpenAPI automatiquement.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `NotificationPreferencesRequest` est implémenté en tant que Java record, conformément aux conventions du projet.
> - Le remplacement de `RequestContext` par `LoggedInUserService` dans `UserServiceImpl` entraîne la mise à jour des tests unitaires existants (`UpdateProfile`) : suppression du `MockedStatic<RequestContext>` au profit d'un mock de `LoggedInUserService`.

---

### Known Limitations or Side Effects
> Aucun.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process