### PR TITLE
feat(notification): added endpoint to write feedback

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityController.java
@@ -287,6 +287,17 @@ public class DeclaredActivityController {
         feedbackDetailsDTOMapper.toDTO(declaredActivityService.getFeedbackDetails(feedbackId)));
   }
 
+  @PutMapping("/feedbacks/{feedbackId}")
+  public ResponseEntity<Void> updateFeedback(
+      Principal principal,
+      @Valid @PathVariable UUID feedbackId,
+      @Valid @RequestBody UpdateFeedbackRequest request) {
+    log.debug(
+        "Received request to update feedback [{}] by user [{}]", feedbackId, principal.getName());
+    declaredActivityService.updateFeedback(feedbackId, request.feedback());
+    return ResponseEntity.noContent().build();
+  }
+
   @PostMapping("/{declaredActivityId}/ask-for-feedback")
   public ResponseEntity<FeedbackDetailsDTO> askForFeedback(
       Principal principal, @Valid @PathVariable UUID declaredActivityId) {

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/UpdateFeedbackRequest.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/UpdateFeedbackRequest.java
@@ -1,0 +1,11 @@
+package fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto;
+
+import static fr.avenirsesr.portfolio.common.validation.domain.constraints.FieldMaxLengths.RICH_TEXT_LENGTH;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(requiredProperties = {"feedback"})
+public record UpdateFeedbackRequest(
+    @Size(max = RICH_TEXT_LENGTH, message = "Feedback can not exceed {max} characters")
+        String feedback) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
@@ -69,6 +69,8 @@ public interface DeclaredActivityService {
 
   Feedback getFeedbackDetails(UUID feedbackId);
 
+  void updateFeedback(UUID feedbackId, String feedback);
+
   PagedResult<Feedback> getStaffFeedbacks(
       EFeedbackStatus statusFilter, UUID activityId, PageCriteria pageCriteria);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -19,6 +19,7 @@ import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.common.data.domain.model.AvenirsBaseModel;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
+import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.notification.domain.model.notification.AskForFeedbackNotification;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
@@ -43,6 +44,7 @@ import fr.avenirsesr.portfolio.trace.domain.exception.TraceNotFoundException;
 import fr.avenirsesr.portfolio.trace.domain.filter.TraceFilter;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.trace.domain.port.input.TraceService;
+import fr.avenirsesr.portfolio.user.domain.model.Staff;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -548,6 +550,24 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
       EFeedbackStatus statusFilter, UUID activityId, PageCriteria pageCriteria) {
     var staff = loggedInUserService.getLoggedInStaff();
     return feedbackRepository.findByStaff(staff.getId(), statusFilter, activityId, pageCriteria);
+  }
+
+  @Override
+  public void updateFeedback(UUID feedbackId, String feedback) {
+    Feedback feedbackToUpdate =
+        feedbackRepository.findById(feedbackId).orElseThrow(FeedbackNotFoundException::new);
+
+    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Staff author = feedbackToUpdate.getDeclaredActivity().getActivity().getAuthor();
+
+    if (!loggedInUser.equals(author.getUser())) {
+      throw new UserNotAuthorizedException();
+    }
+
+    validateOptionalTextMaxLength("feedback", feedback, RICH_TEXT_LENGTH);
+
+    feedbackToUpdate.setFeedback(feedback);
+    feedbackRepository.save(feedbackToUpdate);
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityControllerTest.java
@@ -17,6 +17,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.activity.application.ad
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.SubscribeDeclaredActivityRequest;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.UpdateFeedbackRequest;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.DeclaredActivityAssociationsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.DeclaredActivityDetailsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.DeclaredActivityViewDTOMapper;
@@ -378,5 +379,40 @@ class DeclaredActivityControllerTest {
     assertThat(response.getBody().page().totalElements()).isZero();
 
     verifyNoInteractions(feedbackStaffListItemDTOMapper);
+  }
+
+  @Test
+  void updateFeedback_should_return_204_no_content() {
+    BddLogger.given("A valid feedback ID and a staff writing their feedback text");
+
+    UUID feedbackId = UUID.randomUUID();
+    UpdateFeedbackRequest request = new UpdateFeedbackRequest("Excellent travail, bravo !");
+
+    doNothing().when(declaredActivityService).updateFeedback(feedbackId, request.feedback());
+
+    BddLogger.when("updateFeedback is called");
+    ResponseEntity<Void> response = controller.updateFeedback(principal, feedbackId, request);
+
+    BddLogger.then("204 No Content is returned with no body");
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(response.getBody()).isNull();
+
+    verify(declaredActivityService).updateFeedback(feedbackId, request.feedback());
+  }
+
+  @Test
+  void updateFeedback_should_delegate_to_service_with_correct_feedback_id_and_text() {
+    BddLogger.given("A feedback ID and a request with a specific feedback text");
+
+    UUID feedbackId = UUID.randomUUID();
+    String feedbackText = "Très bon travail sur cette activité.";
+    UpdateFeedbackRequest request = new UpdateFeedbackRequest(feedbackText);
+
+    BddLogger.when("updateFeedback is called");
+    controller.updateFeedback(principal, feedbackId, request);
+
+    BddLogger.then("The service is called exactly once with the correct feedback ID and text");
+    verify(declaredActivityService, times(1)).updateFeedback(feedbackId, feedbackText);
+    verifyNoMoreInteractions(declaredActivityService);
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -22,6 +22,7 @@ import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
+import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.error.domain.exception.BusinessException;
 import fr.avenirsesr.portfolio.common.error.domain.exception.FieldValidationException;
 import fr.avenirsesr.portfolio.common.error.domain.model.enums.EErrorCode;
@@ -52,6 +53,7 @@ import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.trace.domain.port.input.TraceService;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -2014,5 +2016,126 @@ class DeclaredActivityServiceImplTest {
     BddLogger.then("it should not throw");
     assertThatCode(() -> service.checkDeclaredActivitiesUnlocked(List.of(declaredActivityId)))
         .doesNotThrowAnyException();
+  }
+
+  // ── updateFeedback ────────────────────────────────────────────────────────
+
+  @Test
+  void updateFeedback_should_save_feedback_with_updated_text_when_user_is_author() {
+    BddLogger.given("A logged-in staff who is the author of the activity and a valid feedback");
+    UUID feedbackId = UUID.randomUUID();
+    Activity activity = ActivityFixture.create().toModel();
+    DeclaredActivity declaredActivity =
+        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
+    Feedback feedback =
+        Feedback.toDomain(
+            feedbackId,
+            Instant.now(),
+            Instant.now(),
+            declaredActivity,
+            null,
+            null,
+            EFeedbackStatus.IN_PROCESS,
+            1,
+            List.of(),
+            List.of());
+    String feedbackText = "Excellent travail, bravo !";
+    User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
+
+    when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+    when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+    when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+
+    BddLogger.when("updateFeedback is called with the new feedback text");
+    service.updateFeedback(feedbackId, feedbackText);
+
+    BddLogger.then("The feedback is saved with the updated text");
+    verify(feedbackRepository).save(feedbackCaptor.capture());
+    Feedback saved = feedbackCaptor.getValue();
+    assertThat(saved.getFeedback()).contains(feedbackText);
+  }
+
+  @Test
+  void updateFeedback_should_throw_FeedbackNotFoundException_when_feedback_does_not_exist() {
+    BddLogger.given("A non-existent feedback ID");
+    UUID feedbackId = UUID.randomUUID();
+
+    when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.empty());
+
+    BddLogger.when("updateFeedback is called");
+
+    BddLogger.then("A FeedbackNotFoundException is thrown and nothing is saved");
+    assertThatThrownBy(() -> service.updateFeedback(feedbackId, "some text"))
+        .isInstanceOf(FeedbackNotFoundException.class);
+
+    verify(feedbackRepository, never()).save(any());
+  }
+
+  @Test
+  void updateFeedback_should_throw_UserNotAuthorizedException_when_user_is_not_the_author() {
+    BddLogger.given("A logged-in user who is NOT the author of the activity");
+    UUID feedbackId = UUID.randomUUID();
+    Activity activity = ActivityFixture.create().toModel();
+    DeclaredActivity declaredActivity =
+        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
+    Feedback feedback =
+        Feedback.toDomain(
+            feedbackId,
+            Instant.now(),
+            Instant.now(),
+            declaredActivity,
+            null,
+            null,
+            EFeedbackStatus.IN_PROCESS,
+            1,
+            List.of(),
+            List.of());
+    User differentUser = UserFixture.create().toModel();
+
+    when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+    when(loggedInUserService.getLoggedInUser()).thenReturn(differentUser);
+
+    BddLogger.when("updateFeedback is called");
+
+    BddLogger.then("A UserNotAuthorizedException is thrown and nothing is saved");
+    assertThatThrownBy(() -> service.updateFeedback(feedbackId, "some text"))
+        .isInstanceOf(UserNotAuthorizedException.class);
+
+    verify(feedbackRepository, never()).save(any());
+  }
+
+  @Test
+  void
+      updateFeedback_should_throw_FieldValidationException_when_feedback_text_exceeds_max_length() {
+    BddLogger.given("A valid feedback and a feedback text exceeding RICH_TEXT_LENGTH");
+    UUID feedbackId = UUID.randomUUID();
+    Activity activity = ActivityFixture.create().toModel();
+    DeclaredActivity declaredActivity =
+        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
+    Feedback feedback =
+        Feedback.toDomain(
+            feedbackId,
+            Instant.now(),
+            Instant.now(),
+            declaredActivity,
+            null,
+            null,
+            EFeedbackStatus.IN_PROCESS,
+            1,
+            List.of(),
+            List.of());
+    String tooLongFeedback = "a".repeat(RICH_TEXT_LENGTH + 1);
+    User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
+
+    when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+    when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+
+    BddLogger.when("updateFeedback is called with a text that is too long");
+
+    BddLogger.then("A FieldValidationException is thrown and nothing is saved");
+    assertThatThrownBy(() -> service.updateFeedback(feedbackId, tooLongFeedback))
+        .isInstanceOf(FieldValidationException.class);
+
+    verify(feedbackRepository, never()).save(any());
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajout d'un endpoint `PUT /me/activity-progress/feedbacks/{feedbackId}` dans `DeclaredActivityController` permettant à un formateur (staff/auteur de l'activité) de rédiger ou mettre à jour le champ `feedback` d'un feedback existant. Le body attend un objet `UpdateFeedbackRequest` contenant le texte du feedback (limité à `RICH_TEXT_LENGTH` caractères).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1756

---

### Documentation
> Aucune mise à jour documentaire nécessaire. L'endpoint est exposé via Swagger/OpenAPI automatiquement.

---

### Target Branch
> `develop`

---

### Additional Notes
> - La vérification d'autorisation s'assure que seul l'auteur de l'activité (staff) peut écrire le feedback.
> - Une `FeedbackNotFoundException` est levée si le feedback n'existe pas, une `UserNotAuthorizedException` si l'utilisateur connecté n'est pas l'auteur.
> - La validation de longueur (`RICH_TEXT_LENGTH`) est appliquée côté service via `validateOptionalTextMaxLength`.

---

### Known Limitations or Side Effects
> Aucun.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process