### PR TITLE
refactor(1862):  fix null feedback visibility

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
@@ -3,6 +3,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.application.a
 import fr.avenirsesr.portfolio.common.data.application.adapter.dto.PageInfoDTO;
 import fr.avenirsesr.portfolio.common.data.application.adapter.response.PagedResponse;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
+import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.UpdateFeedbackRequest;
@@ -62,15 +63,19 @@ public class FeedbackController {
             PageInfoDTO.fromDomain(result.pageInfo())));
   }
 
-  @GetMapping("/{feedbackId}")
+  @GetMapping("/{userCategory}/{feedbackId}")
   public ResponseEntity<FeedbackDetailsDTO> getFeedbackDetails(
-      Principal principal, @Valid @PathVariable UUID feedbackId) {
+      Principal principal,
+      @Valid @PathVariable UUID feedbackId,
+      @PathVariable EUserCategory userCategory) {
     log.debug(
-        "Received request to get feedback details [{}] by user [{}]",
+        "Received request to get feedback details [{}] by user [{}] (userCategory={})",
         feedbackId,
-        principal.getName());
+        principal.getName(),
+        userCategory);
     return ResponseEntity.ok(
-        feedbackDetailsDTOMapper.toDTO(feedbackService.getFeedbackDetails(feedbackId)));
+        feedbackDetailsDTOMapper.toDTO(
+            feedbackService.getFeedbackDetails(feedbackId, userCategory)));
   }
 
   @PutMapping("/{feedbackId}")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/FeedbackDetailsDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/FeedbackDetailsDTOMapper.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.application.a
 
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.application.adapter.mapper.DeclaredSkillProgressMapper;
 import fr.avenirsesr.portfolio.trace.application.adapter.mapper.TraceDetailMapper;
@@ -17,6 +18,10 @@ public interface FeedbackDetailsDTOMapper {
   @Mapping(source = "declaredActivity.id", target = "declaredActivityId")
   @Mapping(source = "declaredActivity.student.user", target = "student")
   FeedbackDetailsDTO toDTO(Feedback feedback);
+
+  @Mapping(source = "declaredActivity.id", target = "declaredActivityId")
+  @Mapping(source = "declaredActivity.student.user", target = "student")
+  FeedbackDetailsDTO toDTO(FeedbackData feedbackData);
 
   UserInfoDTO toUserInfoDTO(User user);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/FeedbackOverviewDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/FeedbackOverviewDTOMapper.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.application.a
 
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackOverviewDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.user.application.adapter.dto.UserInfoDTO;
 import java.util.Optional;
@@ -14,6 +15,10 @@ public interface FeedbackOverviewDTOMapper {
   @Mapping(source = "declaredActivity.student.user", target = "student")
   @Mapping(source = "declaredActivity.activity.author.user", target = "staff")
   FeedbackOverviewDTO toDTO(Feedback feedback);
+
+  @Mapping(source = "declaredActivity.student.user", target = "student")
+  @Mapping(source = "declaredActivity.activity.author.user", target = "staff")
+  FeedbackOverviewDTO toDTO(FeedbackData feedbackData);
 
   UserInfoDTO toUserInfoDTO(User user);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/data/DeclaredActivityDetailsData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/data/DeclaredActivityDetailsData.java
@@ -1,8 +1,7 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data;
 
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import java.util.List;
 
 public record DeclaredActivityDetailsData(
-    DeclaredActivity declaredActivity, List<Feedback> feedbacks) {}
+    DeclaredActivity declaredActivity, List<FeedbackData> feedbacks) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/data/FeedbackData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/data/FeedbackData.java
@@ -1,0 +1,26 @@
+package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data;
+
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
+import fr.avenirsesr.portfolio.trace.domain.model.Trace;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Represents the details of a feedback. The {@code feedback} field may be {@code null} when the
+ * feedback has not yet been submitted (status other than {@link EFeedbackStatus#SUBMITTED}), in
+ * order to hide the staff comment from the student until the review is finalised.
+ */
+public record FeedbackData(
+    UUID id,
+    Instant createdAt,
+    Instant updatedAt,
+    DeclaredActivity declaredActivity,
+    String reflexion,
+    String feedback,
+    EFeedbackStatus status,
+    int iteration,
+    List<Trace> associatedTraces,
+    List<DeclaredSkillProgress> associatedDeclaredSkills) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
@@ -71,4 +71,6 @@ public interface DeclaredActivityService {
       List<DeclaredActivity> declaredActivities);
 
   EDeclaredActivityStatus getDeclaredActivityStatus(DeclaredActivity declaredActivity);
+
+  DeclaredActivity fetchActivityAndCheckLoggedInStudentAuthorization(UUID declaredActivityId);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
@@ -2,6 +2,9 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.i
 
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
+import fr.avenirsesr.portfolio.common.data.domain.model.User;
+import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import java.util.UUID;
@@ -9,7 +12,9 @@ import java.util.UUID;
 public interface FeedbackService {
   Feedback createFeedback(UUID declaredActivityId);
 
-  Feedback getFeedbackDetails(UUID feedbackId);
+  FeedbackData getFeedbackDetails(UUID feedbackId, EUserCategory userCategory);
+
+  FeedbackData getStudentFeedbackDetails(User loggedInUser, Feedback feedback);
 
   void updateFeedback(UUID feedbackId, String feedback);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -23,11 +23,12 @@ import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorize
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.DeclaredActivityAssociationsData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.DeclaredActivityDetailsData;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.*;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EDeclaredActivityStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillAssociationData;
@@ -61,6 +62,7 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
   private final AssociationSearchHelper associationSearchHelper;
   private final LoggedInUserService loggedInUserService;
   private final FeedbackRepository feedbackRepository;
+  private final FeedbackService feedbackService;
 
   @Override
   public PagedResult<DeclaredActivity> getDeclaredActivities(PageCriteria pageCriteria) {
@@ -183,7 +185,13 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
   public DeclaredActivityDetailsData getDeclaredActivityDetails(UUID declaredActivityId) {
     DeclaredActivity declaredActivity =
         fetchActivityAndCheckLoggedInStudentAuthorization(declaredActivityId);
-    List<Feedback> feedbacks = feedbackRepository.findAllByDeclaredActivityId(declaredActivityId);
+    List<FeedbackData> feedbacks =
+        feedbackRepository.findAllByDeclaredActivityId(declaredActivityId).stream()
+            .map(
+                feedback ->
+                    feedbackService.getStudentFeedbackDetails(
+                        declaredActivity.getStudent().getUser(), feedback))
+            .toList();
     return new DeclaredActivityDetailsData(declaredActivity, feedbacks);
   }
 
@@ -447,7 +455,8 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
     associationService.deleteAllByIds(idsToDelete);
   }
 
-  private DeclaredActivity fetchActivityAndCheckLoggedInStudentAuthorization(
+  @Override
+  public DeclaredActivity fetchActivityAndCheckLoggedInStudentAuthorization(
       UUID declaredActivityId) {
     Student student = loggedInUserService.getLoggedInStudent();
     var graph =

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -7,30 +7,29 @@ import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValida
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.association.domain.utils.AssociationUtils;
-import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
+import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.notification.domain.model.notification.AskForFeedbackNotification;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.DeclaredActivityNotFoundException;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackInProcessException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackMaximumIterationReachedException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input.DeclaredSkillProgressService;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.trace.domain.port.input.TraceService;
 import fr.avenirsesr.portfolio.user.domain.model.Staff;
-import fr.avenirsesr.portfolio.user.domain.model.Student;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -40,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class FeedbackServiceImpl implements FeedbackService {
   private final FeedbackRepository feedbackRepository;
-  private final DeclaredActivityRepository declaredActivityRepository;
+  private final DeclaredActivityService declaredActivityService;
   private final AssociationService associationService;
   private final TraceService traceService;
   private final DeclaredSkillProgressService declaredSkillProgressService;
@@ -49,7 +48,9 @@ public class FeedbackServiceImpl implements FeedbackService {
 
   @Override
   public Feedback createFeedback(UUID declaredActivityId) {
-    DeclaredActivity declaredActivity = fetchAndAuthorizeDeclaredActivity(declaredActivityId);
+    DeclaredActivity declaredActivity =
+        declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+            declaredActivityId);
 
     validateOptionalEnrichedTextMaxLength(
         "reflexion", declaredActivity.getReflection(), RICH_DESCRIPTION_LENGTH);
@@ -111,19 +112,56 @@ public class FeedbackServiceImpl implements FeedbackService {
   }
 
   @Override
-  public Feedback getFeedbackDetails(UUID feedbackId) {
+  public FeedbackData getFeedbackDetails(UUID feedbackId, EUserCategory userCategory) {
+    var user = loggedInUserService.getLoggedInUser();
     Feedback feedback =
         feedbackRepository.findById(feedbackId).orElseThrow(FeedbackNotFoundException::new);
 
-    UUID loggedInUserId = loggedInUserService.getLoggedInUser().getId();
-    UUID studentId = feedback.getDeclaredActivity().getStudent().getId();
-    UUID authorId = feedback.getDeclaredActivity().getActivity().getAuthor().getId();
+    return switch (userCategory) {
+      case STUDENT -> getStudentFeedbackDetails(user, feedback);
+      case STAFF -> getStaffFeedbackDetails(user, feedback);
+    };
+  }
 
-    if (!loggedInUserId.equals(studentId) || !loggedInUserId.equals(authorId)) {
+  private FeedbackData getStaffFeedbackDetails(User loggedInUser, Feedback feedback) {
+    if (!loggedInUser.equals(feedback.getDeclaredActivity().getActivity().getAuthor().getUser())) {
       throw new UserNotAuthorizedException();
     }
 
-    return feedback;
+    return new FeedbackData(
+        feedback.getId(),
+        feedback.getCreatedAt(),
+        feedback.getUpdatedAt(),
+        feedback.getDeclaredActivity(),
+        feedback.getReflexion().orElse(null),
+        feedback.getFeedback().orElse(null),
+        feedback.getStatus(),
+        feedback.getIteration(),
+        feedback.getAssociatedTraces(),
+        feedback.getAssociatedDeclaredSkills());
+  }
+
+  @Override
+  public FeedbackData getStudentFeedbackDetails(User loggedInUser, Feedback feedback) {
+    if (!loggedInUser.equals(feedback.getDeclaredActivity().getStudent().getUser())) {
+      throw new UserNotAuthorizedException();
+    }
+
+    String feedbackText =
+        feedback.getStatus() == EFeedbackStatus.SUBMITTED
+            ? feedback.getFeedback().orElse(null)
+            : null;
+    return new FeedbackData(
+        feedback.getId(),
+        feedback.getCreatedAt(),
+        feedback.getUpdatedAt(),
+        feedback.getDeclaredActivity(),
+        feedback.getReflexion().orElse(null),
+        feedbackText,
+        feedback.getStatus(),
+        feedback.getIteration(),
+        feedback.getAssociatedTraces(),
+        feedback.getAssociatedDeclaredSkills());
   }
 
   @Override
@@ -149,21 +187,5 @@ public class FeedbackServiceImpl implements FeedbackService {
       EFeedbackStatus statusFilter, UUID activityId, PageCriteria pageCriteria) {
     var staff = loggedInUserService.getLoggedInStaff();
     return feedbackRepository.findByStaff(staff.getId(), statusFilter, activityId, pageCriteria);
-  }
-
-  private DeclaredActivity fetchAndAuthorizeDeclaredActivity(UUID declaredActivityId) {
-    Student student = loggedInUserService.getLoggedInStudent();
-    var graph =
-        FetchGraph.init().add("student").fetch("user").root().add("activity").fetch("author");
-
-    DeclaredActivity declaredActivity =
-        declaredActivityRepository
-            .findById(declaredActivityId, graph)
-            .orElseThrow(DeclaredActivityNotFoundException::new);
-
-    if (!declaredActivity.getStudent().equals(student)) {
-      throw new UserNotAuthorizedException();
-    }
-    return declaredActivity;
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/service/DeclaredActivityServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/service/DeclaredActivityServiceConfig.java
@@ -5,6 +5,7 @@ import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.association.domain.service.AssociationSearchHelper;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.service.DeclaredActivityServiceImpl;
@@ -29,7 +30,9 @@ public class DeclaredActivityServiceConfig {
 
   @Bean
   public DeclaredActivityService declaredActivityService(
-      @Lazy ActivityService activityService, @Lazy TraceService traceService) {
+      @Lazy ActivityService activityService,
+      @Lazy TraceService traceService,
+      @Lazy FeedbackService feedbackService) {
     return new DeclaredActivityServiceImpl(
         declaredActivityRepository,
         activityService,
@@ -38,6 +41,7 @@ public class DeclaredActivityServiceConfig {
         associationService,
         associationSearchHelper,
         loggedInUserService,
-        feedbackRepository);
+        feedbackRepository,
+        feedbackService);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/service/FeedbackServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/service/FeedbackServiceConfig.java
@@ -3,8 +3,8 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.infrastructur
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.service.FeedbackServiceImpl;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input.DeclaredSkillProgressService;
@@ -20,17 +20,17 @@ import org.springframework.context.annotation.Lazy;
 @RequiredArgsConstructor
 public class FeedbackServiceConfig {
   private final FeedbackRepository feedbackRepository;
-  private final DeclaredActivityRepository declaredActivityRepository;
   private final AssociationService associationService;
   private final DeclaredSkillProgressService declaredSkillProgressService;
   private final LoggedInUserService loggedInUserService;
   private final NotificationService notificationService;
 
   @Bean
-  public FeedbackService feedbackService(@Lazy TraceService traceService) {
+  public FeedbackService feedbackService(
+      @Lazy TraceService traceService, @Lazy DeclaredActivityService declaredActivityService) {
     return new FeedbackServiceImpl(
         feedbackRepository,
-        declaredActivityRepository,
+        declaredActivityService,
         associationService,
         traceService,
         declaredSkillProgressService,

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
@@ -92,6 +92,10 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
     return objectMapper.readTree(body).get("id").asText();
   }
 
+  private String feedbackPath(String userCategory, String feedbackId) {
+    return BASE_PATH + "/" + userCategory + "/" + feedbackId;
+  }
+
   // ── POST /{declaredActivityId}/ask-for-feedback ─────────────────────
 
   @Test
@@ -167,7 +171,7 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
         .isForbidden();
   }
 
-  // ── GET /me/activity-progress/feedbacks/{feedbackId} ────────────────
+  // ── GET /me/activity-progress/feedbacks/{userCategory}/{feedbackId} ──
 
   @Test
   @Transactional
@@ -180,7 +184,7 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
 
     webTestClient
         .get()
-        .uri(BASE_PATH + "/" + feedbackId)
+        .uri(feedbackPath("STUDENT", feedbackId))
         .header("X-Signed-Context", studentPayload)
         .header("X-Context-Kid", secretKey)
         .header("X-Context-Signature", studentSignature)
@@ -214,7 +218,7 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
 
     webTestClient
         .get()
-        .uri(BASE_PATH + "/" + feedbackId)
+        .uri(feedbackPath("STAFF", feedbackId))
         .header("X-Signed-Context", studentPayload)
         .header("X-Context-Kid", secretKey)
         .header("X-Context-Signature", studentSignature)
@@ -232,12 +236,12 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
     BddLogger.given("a feedback belonging to another student on activity authored by another user");
     String feedbackId = askForFeedbackAndGetId(declaredActivityId);
 
-    BddLogger.when("a third user (otherStudent) tries to fetch the feedback details");
+    BddLogger.when("a third user (otherStudent) tries to fetch the feedback details as STUDENT");
     BddLogger.then("403 Forbidden is returned");
 
     webTestClient
         .get()
-        .uri(BASE_PATH + "/" + feedbackId)
+        .uri(feedbackPath("STUDENT", feedbackId))
         .header("X-Signed-Context", otherStudentPayload)
         .header("X-Context-Kid", secretKey)
         .header("X-Context-Signature", otherStudentSignature)
@@ -254,7 +258,7 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
 
     webTestClient
         .get()
-        .uri(BASE_PATH + "/" + notFoundId)
+        .uri(feedbackPath("STUDENT", notFoundId))
         .header("X-Signed-Context", studentPayload)
         .header("X-Context-Kid", secretKey)
         .header("X-Context-Signature", studentSignature)
@@ -268,13 +272,13 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
 
   @Test
   void shouldReturn401WhenNotAuthenticatedOnFeedbackDetailsEndpoint() {
-    BddLogger.given("the GET /me/activity-progress/feedbacks/{feedbackId} endpoint");
+    BddLogger.given("the GET /me/activity-progress/feedbacks/{userCategory}/{feedbackId} endpoint");
     BddLogger.when("performing a GET without authentication headers");
     BddLogger.then("401 Unauthorized is returned");
 
     webTestClient
         .get()
-        .uri(BASE_PATH + "/" + notFoundId)
+        .uri(feedbackPath("STUDENT", notFoundId))
         .exchange()
         .expectStatus()
         .isUnauthorized();

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
@@ -9,12 +9,14 @@ import static org.mockito.Mockito.*;
 import fr.avenirsesr.portfolio.common.data.application.adapter.response.PagedResponse;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
+import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.UpdateFeedbackRequest;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackDetailsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackStaffListItemDTOMapper;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
@@ -103,10 +105,11 @@ class FeedbackControllerTest {
 
   @Test
   void getFeedbackDetails_should_return_200_with_mapped_dto() {
-    BddLogger.given("A feedback ID and a service returning the feedback");
+    BddLogger.given("A feedback ID, a user category STUDENT and a service returning FeedbackData");
 
     UUID feedbackId = UUID.randomUUID();
-    Feedback feedback = mock(Feedback.class);
+    EUserCategory userCategory = EUserCategory.STUDENT;
+    FeedbackData feedbackData = mock(FeedbackData.class);
     FeedbackDetailsDTO expectedDto =
         new FeedbackDetailsDTO(
             feedbackId,
@@ -120,36 +123,37 @@ class FeedbackControllerTest {
             Instant.now(),
             Instant.now());
 
-    when(feedbackService.getFeedbackDetails(feedbackId)).thenReturn(feedback);
-    when(feedbackDetailsDTOMapper.toDTO(feedback)).thenReturn(expectedDto);
+    when(feedbackService.getFeedbackDetails(feedbackId, userCategory)).thenReturn(feedbackData);
+    when(feedbackDetailsDTOMapper.toDTO(feedbackData)).thenReturn(expectedDto);
 
-    BddLogger.when("getFeedbackDetails is called");
+    BddLogger.when("getFeedbackDetails is called with STUDENT category");
     ResponseEntity<FeedbackDetailsDTO> response =
-        controller.getFeedbackDetails(principal, feedbackId);
+        controller.getFeedbackDetails(principal, feedbackId, userCategory);
 
     BddLogger.then("200 OK is returned with the mapped FeedbackDetailsDTO");
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody()).isSameAs(expectedDto);
 
-    verify(feedbackService).getFeedbackDetails(feedbackId);
-    verify(feedbackDetailsDTOMapper).toDTO(feedback);
+    verify(feedbackService).getFeedbackDetails(feedbackId, userCategory);
+    verify(feedbackDetailsDTOMapper).toDTO(feedbackData);
   }
 
   @Test
-  void getFeedbackDetails_should_delegate_to_service_with_correct_id() {
-    BddLogger.given("A feedback ID");
+  void getFeedbackDetails_should_delegate_to_service_with_correct_id_and_category() {
+    BddLogger.given("A feedback ID and a STAFF user category");
 
     UUID feedbackId = UUID.randomUUID();
-    Feedback feedback = mock(Feedback.class);
+    EUserCategory userCategory = EUserCategory.STAFF;
+    FeedbackData feedbackData = mock(FeedbackData.class);
 
-    when(feedbackService.getFeedbackDetails(feedbackId)).thenReturn(feedback);
-    when(feedbackDetailsDTOMapper.toDTO(feedback)).thenReturn(mock(FeedbackDetailsDTO.class));
+    when(feedbackService.getFeedbackDetails(feedbackId, userCategory)).thenReturn(feedbackData);
+    when(feedbackDetailsDTOMapper.toDTO(feedbackData)).thenReturn(mock(FeedbackDetailsDTO.class));
 
-    BddLogger.when("getFeedbackDetails is called");
-    controller.getFeedbackDetails(principal, feedbackId);
+    BddLogger.when("getFeedbackDetails is called with STAFF category");
+    controller.getFeedbackDetails(principal, feedbackId, userCategory);
 
-    BddLogger.then("The service is called exactly once with the right feedback ID");
-    verify(feedbackService, times(1)).getFeedbackDetails(feedbackId);
+    BddLogger.then("The service is called exactly once with the correct feedback ID and category");
+    verify(feedbackService, times(1)).getFeedbackDetails(feedbackId, userCategory);
     verifyNoMoreInteractions(feedbackService);
   }
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
@@ -8,8 +8,8 @@ import fr.avenirsesr.portfolio.activity.infrastructure.fixture.ActivityFixture;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.DeclaredActivityDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.DeclaredActivityDetailsData;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EDeclaredActivityStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
@@ -74,16 +74,19 @@ class DeclaredActivityPresentationDTOMapperTest {
 
   @Test
   void shouldMapFeedbacksFromDetailsDataToFeedbackOverviewDTOs() {
-    BddLogger.given("a declared activity with 2 feedbacks");
+    BddLogger.given("a declared activity with 2 FeedbackData");
 
     Student student = StudentFixture.create().toModel();
     Activity activity = ActivityFixture.create().toModel();
     DeclaredActivity declaredActivity =
         DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
 
-    Feedback feedback1 =
-        Feedback.toDomain(
-            UUID.randomUUID(),
+    UUID feedbackId1 = UUID.randomUUID();
+    UUID feedbackId2 = UUID.randomUUID();
+
+    FeedbackData feedbackData1 =
+        new FeedbackData(
+            feedbackId1,
             Instant.now(),
             Instant.now(),
             declaredActivity,
@@ -94,9 +97,9 @@ class DeclaredActivityPresentationDTOMapperTest {
             List.of(),
             List.of());
 
-    Feedback feedback2 =
-        Feedback.toDomain(
-            UUID.randomUUID(),
+    FeedbackData feedbackData2 =
+        new FeedbackData(
+            feedbackId2,
             Instant.now(),
             Instant.now(),
             declaredActivity,
@@ -111,7 +114,8 @@ class DeclaredActivityPresentationDTOMapperTest {
 
     DeclaredActivityDetailsDTO dto =
         mapper.toDTO(
-            new DeclaredActivityDetailsData(declaredActivity, List.of(feedback1, feedback2)),
+            new DeclaredActivityDetailsData(
+                declaredActivity, List.of(feedbackData1, feedbackData2)),
             EDeclaredActivityStatus.SUBMITTED);
 
     BddLogger.then("the feedbacks list is mapped and contains 2 FeedbackOverviewDTOs");
@@ -119,9 +123,9 @@ class DeclaredActivityPresentationDTOMapperTest {
     assertNotNull(dto.feedbacks());
     assertEquals(2, dto.feedbacks().size());
     assertEquals(EDeclaredActivityStatus.SUBMITTED, dto.status());
-    assertEquals(feedback1.getId(), dto.feedbacks().get(0).id());
+    assertEquals(feedbackId1, dto.feedbacks().get(0).id());
     assertEquals(EFeedbackStatus.NEW, dto.feedbacks().get(0).status());
-    assertEquals(feedback2.getId(), dto.feedbacks().get(1).id());
+    assertEquals(feedbackId2, dto.feedbacks().get(1).id());
     assertEquals(EFeedbackStatus.SUBMITTED, dto.feedbacks().get(1).status());
   }
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -29,10 +29,12 @@ import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorize
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.DeclaredActivityDetailsData;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.*;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.exception.DeclaredSkillProgressNotFoundException;
@@ -68,6 +70,7 @@ class DeclaredActivityServiceImplTest {
   @Mock private DeclaredSkillProgressService declaredSkillProgressService;
   @Mock private LoggedInUserService loggedInUserService;
   @Mock private FeedbackRepository feedbackRepository;
+  @Mock private FeedbackService feedbackService;
 
   @InjectMocks private DeclaredActivityServiceImpl service;
 
@@ -89,7 +92,8 @@ class DeclaredActivityServiceImplTest {
             associationService,
             associationSearchHelper,
             loggedInUserService,
-            feedbackRepository);
+            feedbackRepository,
+            feedbackService);
   }
 
   @Test
@@ -445,14 +449,15 @@ class DeclaredActivityServiceImplTest {
     BddLogger.when("He requests declared activity details");
     DeclaredActivityDetailsData result = service.getDeclaredActivityDetails(declaredActivityId);
 
-    BddLogger.then("The declared activity is returned and no save is performed");
+    BddLogger.then("The declared activity is returned with an empty feedbacks list");
     assertThat(result.declaredActivity()).isSameAs(declaredActivity);
+    assertThat(result.feedbacks()).isEmpty();
     verify(declaredActivityRepository).findById(eq(declaredActivityId), any(FetchGraph.class));
     verify(declaredActivityRepository, never()).save(any());
   }
 
   @Test
-  void getDeclaredActivityDetails_should_include_feedbacks_fetched_from_repository() {
+  void getDeclaredActivityDetails_should_include_feedbacks_mapped_as_FeedbackData() {
     BddLogger.given(
         "A logged-in student, his declared activity, and 2 feedbacks in the repository");
     UUID declaredActivityId = UUID.randomUUID();
@@ -462,20 +467,30 @@ class DeclaredActivityServiceImplTest {
 
     Feedback feedback1 = mock(Feedback.class);
     Feedback feedback2 = mock(Feedback.class);
+    FeedbackData feedbackData1 = mock(FeedbackData.class);
+    FeedbackData feedbackData2 = mock(FeedbackData.class);
 
     when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
     when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
         .thenReturn(Optional.of(declaredActivity));
     when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
         .thenReturn(List.of(feedback1, feedback2));
+    when(feedbackService.getStudentFeedbackDetails(student.getUser(), feedback1))
+        .thenReturn(feedbackData1);
+    when(feedbackService.getStudentFeedbackDetails(student.getUser(), feedback2))
+        .thenReturn(feedbackData2);
 
     BddLogger.when("getDeclaredActivityDetails is called");
     DeclaredActivityDetailsData result = service.getDeclaredActivityDetails(declaredActivityId);
 
-    BddLogger.then("The result contains the declared activity and its 2 feedbacks");
+    BddLogger.then(
+        "The result contains the declared activity and 2 FeedbackData mapped via"
+            + " getStudentFeedbackDetails");
     assertThat(result.declaredActivity()).isSameAs(declaredActivity);
-    assertThat(result.feedbacks()).containsExactly(feedback1, feedback2);
+    assertThat(result.feedbacks()).containsExactly(feedbackData1, feedbackData2);
     verify(feedbackRepository).findAllByDeclaredActivityId(declaredActivityId);
+    verify(feedbackService).getStudentFeedbackDetails(student.getUser(), feedback1);
+    verify(feedbackService).getStudentFeedbackDetails(student.getUser(), feedback2);
   }
 
   @Test
@@ -498,6 +513,7 @@ class DeclaredActivityServiceImplTest {
     assertThat(result.declaredActivity()).isSameAs(declaredActivity);
     assertThat(result.feedbacks()).isEmpty();
     verify(feedbackRepository).findAllByDeclaredActivityId(declaredActivityId);
+    verifyNoInteractions(feedbackService);
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -4,20 +4,20 @@ import static fr.avenirsesr.portfolio.common.validation.domain.constraints.Field
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.activity.infrastructure.fixture.ActivityFixture;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
-import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
+import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.error.domain.exception.FieldValidationException;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.DeclaredActivityNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackInProcessException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackMaximumIterationReachedException;
@@ -25,7 +25,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.excepti
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input.DeclaredSkillProgressService;
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -52,7 +53,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class FeedbackServiceImplTest {
 
   @Mock private FeedbackRepository feedbackRepository;
-  @Mock private DeclaredActivityRepository declaredActivityRepository;
+  @Mock private DeclaredActivityService declaredActivityService;
   @Mock private AssociationService associationService;
   @Mock private TraceService traceService;
   @Mock private DeclaredSkillProgressService declaredSkillProgressService;
@@ -70,481 +71,745 @@ class FeedbackServiceImplTest {
     student = StudentFixture.create().toModel();
   }
 
-  // ── createFeedback ────────────────────────────────────────────────────────
+  @Nested
+  class CreateFeedback {
 
-  @Test
-  void createFeedback_should_save_feedback_with_empty_associations_when_none_linked() {
-    BddLogger.given(
-        "A logged-in student, his declared activity with null reflexion and no associations");
-    UUID declaredActivityId = UUID.randomUUID();
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
+    @Test
+    void should_save_feedback_with_empty_associations_when_none_linked() {
+      BddLogger.given(
+          "A logged-in student, his declared activity with null reflexion and no associations");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
 
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.of(declaredActivity));
-    when(associationService.getAllOf(
-            any(UUID.class), any(Class.class), ArgumentMatchers.<List<EAssociationType>>any()))
-        .thenReturn(List.of());
-    when(traceService.findAllTracesById(List.of())).thenReturn(List.of());
-    when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of()))
-        .thenReturn(List.of());
-    when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId)).thenReturn(List.of());
-    when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenReturn(declaredActivity);
+      when(associationService.getAllOf(
+              any(UUID.class), any(Class.class), ArgumentMatchers.<List<EAssociationType>>any()))
+          .thenReturn(List.of());
+      when(traceService.findAllTracesById(List.of())).thenReturn(List.of());
+      when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of()))
+          .thenReturn(List.of());
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of());
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
 
-    BddLogger.when("createFeedback is called");
-    service.createFeedback(declaredActivityId);
+      BddLogger.when("createFeedback is called");
+      service.createFeedback(declaredActivityId);
 
-    BddLogger.then("A feedback with empty associations and null reflexion is saved");
-    verify(feedbackRepository).save(feedbackCaptor.capture());
-    Feedback captured = feedbackCaptor.getValue();
-    assertThat(captured.getAssociatedTraces()).isEmpty();
-    assertThat(captured.getAssociatedDeclaredSkills()).isEmpty();
-    assertThat(captured.getReflexion()).isEmpty();
+      BddLogger.then("A feedback with empty associations and null reflexion is saved");
+      verify(feedbackRepository).save(feedbackCaptor.capture());
+      Feedback captured = feedbackCaptor.getValue();
+      assertThat(captured.getAssociatedTraces()).isEmpty();
+      assertThat(captured.getAssociatedDeclaredSkills()).isEmpty();
+      assertThat(captured.getReflexion()).isEmpty();
+    }
+
+    @Test
+    void should_save_feedback_with_reflexion_and_associations_from_declared_activity() {
+      BddLogger.given(
+          "A logged-in student, his declared activity with a reflexion, 1 trace association and 1"
+              + " skill association");
+      UUID declaredActivityId = UUID.randomUUID();
+      UUID traceId = UUID.randomUUID();
+      UUID skillId = UUID.randomUUID();
+      String reflexion = "Ma réflexion sur cette activité.";
+
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, reflexion, null, null, null);
+
+      var traceAssociation =
+          mock(fr.avenirsesr.portfolio.association.domain.model.Association.class);
+      var skillAssociation =
+          mock(fr.avenirsesr.portfolio.association.domain.model.Association.class);
+      Trace trace = mock(Trace.class);
+      DeclaredSkillProgress skill = mock(DeclaredSkillProgress.class);
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenReturn(declaredActivity);
+
+      when(traceAssociation.getAssociationType())
+          .thenReturn(EAssociationType.DECLARED_ACTIVITY_TRACE);
+      when(traceAssociation.getId2()).thenReturn(traceId);
+      when(skillAssociation.getAssociationType())
+          .thenReturn(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL);
+      when(skillAssociation.getId2()).thenReturn(skillId);
+
+      when(associationService.getAllOf(
+              any(UUID.class), any(Class.class), ArgumentMatchers.<List<EAssociationType>>any()))
+          .thenReturn(List.of(traceAssociation, skillAssociation));
+      when(traceService.findAllTracesById(List.of(traceId))).thenReturn(List.of(trace));
+      when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of(skillId)))
+          .thenReturn(List.of(skill));
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of());
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+
+      BddLogger.when("createFeedback is called");
+      service.createFeedback(declaredActivityId);
+
+      BddLogger.then(
+          "A feedback is saved with the activity's reflexion, 1 trace and 1 declared skill");
+      verify(feedbackRepository).save(feedbackCaptor.capture());
+      Feedback captured = feedbackCaptor.getValue();
+      assertThat(captured.getReflexion().orElse(null)).isEqualTo(reflexion);
+      assertThat(captured.getAssociatedTraces()).containsExactly(trace);
+      assertThat(captured.getAssociatedDeclaredSkills()).containsExactly(skill);
+    }
+
+    @Test
+    void should_throw_DeclaredActivityNotFoundException_when_activity_not_found() {
+      BddLogger.given("A logged-in student and a non-existent declared activity ID");
+      UUID declaredActivityId = UUID.randomUUID();
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenThrow(new DeclaredActivityNotFoundException());
+
+      BddLogger.when("createFeedback is called");
+
+      BddLogger.then("A DeclaredActivityNotFoundException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
+          .isInstanceOf(DeclaredActivityNotFoundException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_activity_belongs_to_another_student() {
+      BddLogger.given("A logged-in student and a declared activity belonging to another student");
+      UUID declaredActivityId = UUID.randomUUID();
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenThrow(new UserNotAuthorizedException());
+
+      BddLogger.when("createFeedback is called");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
+          .isInstanceOf(UserNotAuthorizedException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_FieldValidationException_when_reflexion_exceeds_max_length() {
+      BddLogger.given(
+          "A logged-in student and his declared activity with a reflexion exceeding"
+              + " RICH_DESCRIPTION_LENGTH");
+      UUID declaredActivityId = UUID.randomUUID();
+      String tooLongReflexion = "a".repeat(RICH_DESCRIPTION_LENGTH + 1);
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, tooLongReflexion, null, null, null);
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenReturn(declaredActivity);
+
+      BddLogger.when("createFeedback is called");
+
+      BddLogger.then("A FieldValidationException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
+          .isInstanceOf(FieldValidationException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_FeedbackInProcessException_when_last_feedback_is_IN_PROCESS() {
+      BddLogger.given(
+          "A logged-in student whose last feedback on the declared activity is IN_PROCESS");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+
+      Feedback inProcessFeedback =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              null,
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenReturn(declaredActivity);
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of(inProcessFeedback));
+
+      BddLogger.when("createFeedback is called");
+
+      BddLogger.then("A FeedbackInProcessException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
+          .isInstanceOf(FeedbackInProcessException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_update_existing_feedback_when_last_feedback_is_NEW() {
+      BddLogger.given(
+          "A logged-in student whose last feedback is NEW, and the declared activity has a"
+              + " reflexion and associations");
+      UUID declaredActivityId = UUID.randomUUID();
+      UUID traceId = UUID.randomUUID();
+      UUID skillId = UUID.randomUUID();
+      String updatedReflexion = "Nouvelle réflexion mise à jour.";
+
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, updatedReflexion, null, null, null);
+
+      UUID existingFeedbackId = UUID.randomUUID();
+      Feedback existingFeedback =
+          Feedback.toDomain(
+              existingFeedbackId,
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              "Ancienne réflexion",
+              null,
+              EFeedbackStatus.NEW,
+              1,
+              List.of(),
+              List.of());
+
+      var traceAssociation =
+          mock(fr.avenirsesr.portfolio.association.domain.model.Association.class);
+      var skillAssociation =
+          mock(fr.avenirsesr.portfolio.association.domain.model.Association.class);
+      Trace trace = mock(Trace.class);
+      DeclaredSkillProgress skill = mock(DeclaredSkillProgress.class);
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenReturn(declaredActivity);
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of(existingFeedback));
+
+      when(traceAssociation.getAssociationType())
+          .thenReturn(EAssociationType.DECLARED_ACTIVITY_TRACE);
+      when(traceAssociation.getId2()).thenReturn(traceId);
+      when(skillAssociation.getAssociationType())
+          .thenReturn(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL);
+      when(skillAssociation.getId2()).thenReturn(skillId);
+      when(associationService.getAllOf(
+              any(UUID.class), any(Class.class), ArgumentMatchers.<List<EAssociationType>>any()))
+          .thenReturn(List.of(traceAssociation, skillAssociation));
+      when(traceService.findAllTracesById(List.of(traceId))).thenReturn(List.of(trace));
+      when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of(skillId)))
+          .thenReturn(List.of(skill));
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+
+      BddLogger.when("createFeedback is called");
+      service.createFeedback(declaredActivityId);
+
+      BddLogger.then(
+          "The existing feedback is updated and saved — same ID, updated reflexion, traces and"
+              + " skills, status stays NEW");
+      verify(feedbackRepository).save(feedbackCaptor.capture());
+      Feedback saved = feedbackCaptor.getValue();
+      assertThat(saved.getId()).isEqualTo(existingFeedbackId);
+      assertThat(saved.getReflexion()).contains(updatedReflexion);
+      assertThat(saved.getAssociatedTraces()).containsExactly(trace);
+      assertThat(saved.getAssociatedDeclaredSkills()).containsExactly(skill);
+      assertThat(saved.getStatus()).isEqualTo(EFeedbackStatus.NEW);
+    }
+
+    @Test
+    void should_create_new_feedback_when_last_feedback_is_SUBMITTED_and_limit_not_reached() {
+      BddLogger.given(
+          "A logged-in student with 1 SUBMITTED feedback and feedbackAllowedIterations=2");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().withFeedbackAllowedIterations(2).toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+
+      Feedback submittedFeedback =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              "Retour du formateur",
+              EFeedbackStatus.SUBMITTED,
+              1,
+              List.of(),
+              List.of());
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenReturn(declaredActivity);
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of(submittedFeedback));
+      when(associationService.getAllOf(
+              any(UUID.class), any(Class.class), ArgumentMatchers.<List<EAssociationType>>any()))
+          .thenReturn(List.of());
+      when(traceService.findAllTracesById(List.of())).thenReturn(List.of());
+      when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of()))
+          .thenReturn(List.of());
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+
+      BddLogger.when("createFeedback is called");
+      service.createFeedback(declaredActivityId);
+
+      BddLogger.then(
+          "A new feedback is created with a different ID from the submitted one and status NEW");
+      verify(feedbackRepository).save(feedbackCaptor.capture());
+      Feedback saved = feedbackCaptor.getValue();
+      assertThat(saved.getId()).isNotEqualTo(submittedFeedback.getId());
+      assertThat(saved.getStatus()).isEqualTo(EFeedbackStatus.NEW);
+    }
+
+    @Test
+    void should_throw_FeedbackMaximumIterationReachedException_when_limit_is_reached() {
+      BddLogger.given(
+          "A logged-in student with 2 SUBMITTED feedbacks and feedbackAllowedIterations=2");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().withFeedbackAllowedIterations(2).toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+
+      Feedback feedback1 =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now().minusSeconds(120),
+              Instant.now().minusSeconds(120),
+              declaredActivity,
+              null,
+              "Retour 1",
+              EFeedbackStatus.SUBMITTED,
+              1,
+              List.of(),
+              List.of());
+      Feedback feedback2 =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              "Retour 2",
+              EFeedbackStatus.SUBMITTED,
+              1,
+              List.of(),
+              List.of());
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenReturn(declaredActivity);
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of(feedback1, feedback2));
+
+      BddLogger.when("createFeedback is called");
+
+      BddLogger.then("A FeedbackMaximumIterationReachedException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
+          .isInstanceOf(FeedbackMaximumIterationReachedException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
   }
 
-  @Test
-  void
-      createFeedback_should_save_feedback_with_reflexion_and_associations_from_declared_activity() {
-    BddLogger.given(
-        "A logged-in student, his declared activity with a reflexion, 1 trace association and 1"
-            + " skill association");
-    UUID declaredActivityId = UUID.randomUUID();
-    UUID traceId = UUID.randomUUID();
-    UUID skillId = UUID.randomUUID();
-    String reflexion = "Ma réflexion sur cette activité.";
+  @Nested
+  class GetFeedbackDetails {
 
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(
-            UUID.randomUUID(), student, activity, null, reflexion, null, null, null);
+    @Test
+    void should_return_FeedbackData_with_feedback_visible_when_student_and_SUBMITTED() {
+      BddLogger.given("A logged-in student requesting details of their own SUBMITTED feedback");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      String feedbackText = "Très bon travail !";
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              "Ma réflexion",
+              feedbackText,
+              EFeedbackStatus.SUBMITTED,
+              1,
+              List.of(),
+              List.of());
 
-    var traceAssociation = mock(fr.avenirsesr.portfolio.association.domain.model.Association.class);
-    var skillAssociation = mock(fr.avenirsesr.portfolio.association.domain.model.Association.class);
-    Trace trace = mock(Trace.class);
-    DeclaredSkillProgress skill = mock(DeclaredSkillProgress.class);
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
 
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.of(declaredActivity));
+      BddLogger.when("getFeedbackDetails is called with STUDENT category");
+      FeedbackData result = service.getFeedbackDetails(feedbackId, EUserCategory.STUDENT);
 
-    when(traceAssociation.getAssociationType())
-        .thenReturn(EAssociationType.DECLARED_ACTIVITY_TRACE);
-    when(traceAssociation.getId2()).thenReturn(traceId);
-    when(skillAssociation.getAssociationType())
-        .thenReturn(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL);
-    when(skillAssociation.getId2()).thenReturn(skillId);
+      BddLogger.then("FeedbackData is returned with the feedback text visible");
+      assertThat(result.feedback()).isEqualTo(feedbackText);
+      assertThat(result.status()).isEqualTo(EFeedbackStatus.SUBMITTED);
+      assertThat(result.id()).isEqualTo(feedbackId);
+    }
 
-    when(associationService.getAllOf(
-            any(UUID.class), any(Class.class), ArgumentMatchers.<List<EAssociationType>>any()))
-        .thenReturn(List.of(traceAssociation, skillAssociation));
-    when(traceService.findAllTracesById(List.of(traceId))).thenReturn(List.of(trace));
-    when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of(skillId)))
-        .thenReturn(List.of(skill));
-    when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId)).thenReturn(List.of());
-    when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+    @Test
+    void should_return_FeedbackData_with_null_feedback_when_student_and_NEW() {
+      BddLogger.given("A logged-in student requesting details of their own NEW feedback");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              "Ma réflexion",
+              "Retour non encore soumis",
+              EFeedbackStatus.NEW,
+              1,
+              List.of(),
+              List.of());
 
-    BddLogger.when("createFeedback is called");
-    service.createFeedback(declaredActivityId);
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
 
-    BddLogger.then(
-        "A feedback is saved with the activity's reflexion, 1 trace and 1 declared skill");
-    verify(feedbackRepository).save(feedbackCaptor.capture());
-    Feedback captured = feedbackCaptor.getValue();
-    assertThat(captured.getReflexion().orElse(null)).isEqualTo(reflexion);
-    assertThat(captured.getAssociatedTraces()).containsExactly(trace);
-    assertThat(captured.getAssociatedDeclaredSkills()).containsExactly(skill);
+      BddLogger.when("getFeedbackDetails is called with STUDENT category");
+      FeedbackData result = service.getFeedbackDetails(feedbackId, EUserCategory.STUDENT);
+
+      BddLogger.then("FeedbackData is returned with feedback set to null (not yet submitted)");
+      assertThat(result.feedback()).isNull();
+      assertThat(result.status()).isEqualTo(EFeedbackStatus.NEW);
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_student_is_not_owner() {
+      BddLogger.given("A logged-in student requesting details of another student's feedback");
+      UUID feedbackId = UUID.randomUUID();
+      Student anotherStudent = StudentFixture.create().toModel();
+      Activity activity = ActivityFixture.create().toModel();
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), anotherStudent, activity, null, null, null, null, null),
+              null,
+              null,
+              EFeedbackStatus.NEW,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
+
+      BddLogger.when("getFeedbackDetails is called with STUDENT category");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown");
+      assertThatThrownBy(() -> service.getFeedbackDetails(feedbackId, EUserCategory.STUDENT))
+          .isInstanceOf(UserNotAuthorizedException.class);
+    }
+
+    @Test
+    void should_return_FeedbackData_with_feedback_when_staff_is_author() {
+      BddLogger.given("A logged-in staff who is the author of the activity");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
+      String feedbackText = "Excellent travail !";
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              "Réflexion",
+              feedbackText,
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+
+      BddLogger.when("getFeedbackDetails is called with STAFF category");
+      FeedbackData result = service.getFeedbackDetails(feedbackId, EUserCategory.STAFF);
+
+      BddLogger.then("FeedbackData is returned with the feedback text visible to staff");
+      assertThat(result.feedback()).isEqualTo(feedbackText);
+      assertThat(result.id()).isEqualTo(feedbackId);
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_staff_is_not_author() {
+      BddLogger.given("A logged-in user who is NOT the author of the activity");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      User differentUser = UserFixture.create().toModel();
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              null,
+              null,
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(differentUser);
+
+      BddLogger.when("getFeedbackDetails is called with STAFF category");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown");
+      assertThatThrownBy(() -> service.getFeedbackDetails(feedbackId, EUserCategory.STAFF))
+          .isInstanceOf(UserNotAuthorizedException.class);
+    }
+
+    @Test
+    void should_throw_FeedbackNotFoundException_when_feedback_not_found() {
+      BddLogger.given("A non-existent feedback ID");
+      UUID feedbackId = UUID.randomUUID();
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.empty());
+      when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
+
+      BddLogger.when("getFeedbackDetails is called");
+
+      BddLogger.then("A FeedbackNotFoundException is thrown");
+      assertThatThrownBy(() -> service.getFeedbackDetails(feedbackId, EUserCategory.STUDENT))
+          .isInstanceOf(FeedbackNotFoundException.class);
+    }
   }
 
-  @Test
-  void createFeedback_should_throw_DeclaredActivityNotFoundException_when_activity_not_found() {
-    BddLogger.given("A logged-in student and a non-existent declared activity ID");
-    UUID declaredActivityId = UUID.randomUUID();
+  @Nested
+  class GetStudentFeedbackDetails {
 
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.empty());
+    @Test
+    void should_return_null_feedback_when_status_is_not_SUBMITTED() {
+      BddLogger.given("A feedback with status IN_PROCESS and a feedback text set");
+      Activity activity = ActivityFixture.create().toModel();
+      Feedback feedback =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              "Ma réflexion",
+              "Retour du formateur",
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
 
-    BddLogger.when("createFeedback is called");
+      BddLogger.when("getStudentFeedbackDetails is called with the student's own user");
+      FeedbackData result = service.getStudentFeedbackDetails(student.getUser(), feedback);
 
-    BddLogger.then("A DeclaredActivityNotFoundException is thrown and nothing is saved");
-    assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
-        .isInstanceOf(DeclaredActivityNotFoundException.class);
+      BddLogger.then("FeedbackData is returned with feedback set to null");
+      assertThat(result.feedback()).isNull();
+      assertThat(result.reflexion()).isEqualTo("Ma réflexion");
+      assertThat(result.status()).isEqualTo(EFeedbackStatus.IN_PROCESS);
+    }
 
-    verify(feedbackRepository, never()).save(any());
+    @Test
+    void should_return_feedback_text_when_status_is_SUBMITTED() {
+      BddLogger.given("A SUBMITTED feedback with a feedback text");
+      Activity activity = ActivityFixture.create().toModel();
+      String feedbackText = "Excellent travail, continuez ainsi !";
+      Feedback feedback =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              "Ma réflexion",
+              feedbackText,
+              EFeedbackStatus.SUBMITTED,
+              1,
+              List.of(),
+              List.of());
+
+      BddLogger.when("getStudentFeedbackDetails is called with the student's own user");
+      FeedbackData result = service.getStudentFeedbackDetails(student.getUser(), feedback);
+
+      BddLogger.then("FeedbackData is returned with the feedback text visible");
+      assertThat(result.feedback()).isEqualTo(feedbackText);
+      assertThat(result.status()).isEqualTo(EFeedbackStatus.SUBMITTED);
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_user_is_not_student() {
+      BddLogger.given("A feedback belonging to one student but called with a different user");
+      Activity activity = ActivityFixture.create().toModel();
+      Feedback feedback =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              null,
+              null,
+              EFeedbackStatus.NEW,
+              1,
+              List.of(),
+              List.of());
+      User differentUser = UserFixture.create().toModel();
+
+      BddLogger.when("getStudentFeedbackDetails is called with a different user");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown");
+      assertThatThrownBy(() -> service.getStudentFeedbackDetails(differentUser, feedback))
+          .isInstanceOf(UserNotAuthorizedException.class);
+    }
   }
 
-  @Test
-  void
-      createFeedback_should_throw_UserNotAuthorizedException_when_activity_belongs_to_another_student() {
-    BddLogger.given("A logged-in student and a declared activity belonging to another student");
-    UUID declaredActivityId = UUID.randomUUID();
-    Student anotherStudent = StudentFixture.create().toModel();
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(
-            UUID.randomUUID(), anotherStudent, activity, null, null, null, null, null);
+  @Nested
+  class UpdateFeedback {
 
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.of(declaredActivity));
+    @Test
+    void should_save_feedback_with_updated_text_when_user_is_author() {
+      BddLogger.given("A logged-in staff who is the author of the activity and a valid feedback");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              null,
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+      String feedbackText = "Excellent travail, bravo !";
+      User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
 
-    BddLogger.when("createFeedback is called");
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
 
-    BddLogger.then("A UserNotAuthorizedException is thrown and nothing is saved");
-    assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
-        .isInstanceOf(UserNotAuthorizedException.class);
+      BddLogger.when("updateFeedback is called with the new feedback text");
+      service.updateFeedback(feedbackId, feedbackText);
 
-    verify(feedbackRepository, never()).save(any());
-  }
+      BddLogger.then("The feedback is saved with the updated text");
+      verify(feedbackRepository).save(feedbackCaptor.capture());
+      Feedback saved = feedbackCaptor.getValue();
+      assertThat(saved.getFeedback()).contains(feedbackText);
+    }
 
-  @Test
-  void createFeedback_should_throw_FieldValidationException_when_reflexion_exceeds_max_length() {
-    BddLogger.given(
-        "A logged-in student and his declared activity with a reflexion exceeding"
-            + " RICH_DESCRIPTION_LENGTH");
-    UUID declaredActivityId = UUID.randomUUID();
-    String tooLongReflexion = "a".repeat(RICH_DESCRIPTION_LENGTH + 1);
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(
-            UUID.randomUUID(), student, activity, null, tooLongReflexion, null, null, null);
+    @Test
+    void should_throw_FeedbackNotFoundException_when_feedback_does_not_exist() {
+      BddLogger.given("A non-existent feedback ID");
+      UUID feedbackId = UUID.randomUUID();
 
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.of(declaredActivity));
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.empty());
 
-    BddLogger.when("createFeedback is called");
+      BddLogger.when("updateFeedback is called");
 
-    BddLogger.then("A FieldValidationException is thrown and nothing is saved");
-    assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
-        .isInstanceOf(FieldValidationException.class);
+      BddLogger.then("A FeedbackNotFoundException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.updateFeedback(feedbackId, "some text"))
+          .isInstanceOf(FeedbackNotFoundException.class);
 
-    verify(feedbackRepository, never()).save(any());
-  }
+      verify(feedbackRepository, never()).save(any());
+    }
 
-  @Test
-  void createFeedback_should_throw_FeedbackInProcessException_when_last_feedback_is_IN_PROCESS() {
-    BddLogger.given(
-        "A logged-in student whose last feedback on the declared activity is IN_PROCESS");
-    UUID declaredActivityId = UUID.randomUUID();
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
+    @Test
+    void should_throw_UserNotAuthorizedException_when_user_is_not_the_author() {
+      BddLogger.given("A logged-in user who is NOT the author of the activity");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              null,
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+      User differentUser = UserFixture.create().toModel();
 
-    Feedback inProcessFeedback =
-        Feedback.toDomain(
-            UUID.randomUUID(),
-            Instant.now(),
-            Instant.now(),
-            declaredActivity,
-            null,
-            null,
-            EFeedbackStatus.IN_PROCESS,
-            1,
-            List.of(),
-            List.of());
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(differentUser);
 
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.of(declaredActivity));
-    when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
-        .thenReturn(List.of(inProcessFeedback));
+      BddLogger.when("updateFeedback is called");
 
-    BddLogger.when("createFeedback is called");
+      BddLogger.then("A UserNotAuthorizedException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.updateFeedback(feedbackId, "some text"))
+          .isInstanceOf(UserNotAuthorizedException.class);
 
-    BddLogger.then("A FeedbackInProcessException is thrown and nothing is saved");
-    assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
-        .isInstanceOf(FeedbackInProcessException.class);
+      verify(feedbackRepository, never()).save(any());
+    }
 
-    verify(feedbackRepository, never()).save(any());
-  }
+    @Test
+    void should_throw_FieldValidationException_when_feedback_text_exceeds_max_length() {
+      BddLogger.given("A valid feedback and a feedback text exceeding RICH_DESCRIPTION_LENGTH");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              null,
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+      String tooLongFeedback = "a".repeat(RICH_DESCRIPTION_LENGTH + 1);
+      User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
 
-  @Test
-  void createFeedback_should_update_existing_feedback_when_last_feedback_is_NEW() {
-    BddLogger.given(
-        "A logged-in student whose last feedback is NEW, and the declared activity has a reflexion"
-            + " and associations");
-    UUID declaredActivityId = UUID.randomUUID();
-    UUID traceId = UUID.randomUUID();
-    UUID skillId = UUID.randomUUID();
-    String updatedReflexion = "Nouvelle réflexion mise à jour.";
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
 
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(
-            UUID.randomUUID(), student, activity, null, updatedReflexion, null, null, null);
+      BddLogger.when("updateFeedback is called with a text that is too long");
 
-    UUID existingFeedbackId = UUID.randomUUID();
-    Feedback existingFeedback =
-        Feedback.toDomain(
-            existingFeedbackId,
-            Instant.now(),
-            Instant.now(),
-            declaredActivity,
-            "Ancienne réflexion",
-            null,
-            EFeedbackStatus.NEW,
-            1,
-            List.of(),
-            List.of());
+      BddLogger.then("A FieldValidationException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.updateFeedback(feedbackId, tooLongFeedback))
+          .isInstanceOf(FieldValidationException.class);
 
-    var traceAssociation = mock(fr.avenirsesr.portfolio.association.domain.model.Association.class);
-    var skillAssociation = mock(fr.avenirsesr.portfolio.association.domain.model.Association.class);
-    Trace trace = mock(Trace.class);
-    DeclaredSkillProgress skill = mock(DeclaredSkillProgress.class);
-
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.of(declaredActivity));
-    when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
-        .thenReturn(List.of(existingFeedback));
-
-    when(traceAssociation.getAssociationType())
-        .thenReturn(EAssociationType.DECLARED_ACTIVITY_TRACE);
-    when(traceAssociation.getId2()).thenReturn(traceId);
-    when(skillAssociation.getAssociationType())
-        .thenReturn(EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL);
-    when(skillAssociation.getId2()).thenReturn(skillId);
-    when(associationService.getAllOf(
-            any(UUID.class), any(Class.class), ArgumentMatchers.<List<EAssociationType>>any()))
-        .thenReturn(List.of(traceAssociation, skillAssociation));
-    when(traceService.findAllTracesById(List.of(traceId))).thenReturn(List.of(trace));
-    when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of(skillId)))
-        .thenReturn(List.of(skill));
-    when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
-
-    BddLogger.when("createFeedback is called");
-    service.createFeedback(declaredActivityId);
-
-    BddLogger.then(
-        "The existing feedback is updated and saved — same ID, updated reflexion, traces and"
-            + " skills, status stays NEW");
-    verify(feedbackRepository).save(feedbackCaptor.capture());
-    Feedback saved = feedbackCaptor.getValue();
-    assertThat(saved.getId()).isEqualTo(existingFeedbackId);
-    assertThat(saved.getReflexion()).contains(updatedReflexion);
-    assertThat(saved.getAssociatedTraces()).containsExactly(trace);
-    assertThat(saved.getAssociatedDeclaredSkills()).containsExactly(skill);
-    assertThat(saved.getStatus()).isEqualTo(EFeedbackStatus.NEW);
-  }
-
-  @Test
-  void
-      createFeedback_should_create_new_feedback_when_last_feedback_is_SUBMITTED_and_limit_not_reached() {
-    BddLogger.given(
-        "A logged-in student with 1 SUBMITTED feedback and feedbackAllowedIterations=2");
-    UUID declaredActivityId = UUID.randomUUID();
-    Activity activity = ActivityFixture.create().withFeedbackAllowedIterations(2).toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
-
-    Feedback submittedFeedback =
-        Feedback.toDomain(
-            UUID.randomUUID(),
-            Instant.now(),
-            Instant.now(),
-            declaredActivity,
-            null,
-            "Retour du formateur",
-            EFeedbackStatus.SUBMITTED,
-            1,
-            List.of(),
-            List.of());
-
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.of(declaredActivity));
-    when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
-        .thenReturn(List.of(submittedFeedback));
-    when(associationService.getAllOf(
-            any(UUID.class), any(Class.class), ArgumentMatchers.<List<EAssociationType>>any()))
-        .thenReturn(List.of());
-    when(traceService.findAllTracesById(List.of())).thenReturn(List.of());
-    when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of()))
-        .thenReturn(List.of());
-    when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
-
-    BddLogger.when("createFeedback is called");
-    service.createFeedback(declaredActivityId);
-
-    BddLogger.then(
-        "A new feedback is created with a different ID from the submitted one and status NEW");
-    verify(feedbackRepository).save(feedbackCaptor.capture());
-    Feedback saved = feedbackCaptor.getValue();
-    assertThat(saved.getId()).isNotEqualTo(submittedFeedback.getId());
-    assertThat(saved.getStatus()).isEqualTo(EFeedbackStatus.NEW);
-  }
-
-  @Test
-  void
-      createFeedback_should_throw_FeedbackMaximumIterationReachedException_when_limit_is_reached() {
-    BddLogger.given(
-        "A logged-in student with 2 SUBMITTED feedbacks and feedbackAllowedIterations=2");
-    UUID declaredActivityId = UUID.randomUUID();
-    Activity activity = ActivityFixture.create().withFeedbackAllowedIterations(2).toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
-
-    Feedback feedback1 =
-        Feedback.toDomain(
-            UUID.randomUUID(),
-            Instant.now().minusSeconds(120),
-            Instant.now().minusSeconds(120),
-            declaredActivity,
-            null,
-            "Retour 1",
-            EFeedbackStatus.SUBMITTED,
-            1,
-            List.of(),
-            List.of());
-    Feedback feedback2 =
-        Feedback.toDomain(
-            UUID.randomUUID(),
-            Instant.now(),
-            Instant.now(),
-            declaredActivity,
-            null,
-            "Retour 2",
-            EFeedbackStatus.SUBMITTED,
-            1,
-            List.of(),
-            List.of());
-
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
-    when(declaredActivityRepository.findById(eq(declaredActivityId), any(FetchGraph.class)))
-        .thenReturn(Optional.of(declaredActivity));
-    when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
-        .thenReturn(List.of(feedback1, feedback2));
-
-    BddLogger.when("createFeedback is called");
-
-    BddLogger.then("A FeedbackMaximumIterationReachedException is thrown and nothing is saved");
-    assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
-        .isInstanceOf(FeedbackMaximumIterationReachedException.class);
-
-    verify(feedbackRepository, never()).save(any());
-  }
-
-  // ── updateFeedback ────────────────────────────────────────────────────────
-
-  @Test
-  void updateFeedback_should_save_feedback_with_updated_text_when_user_is_author() {
-    BddLogger.given("A logged-in staff who is the author of the activity and a valid feedback");
-    UUID feedbackId = UUID.randomUUID();
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
-    Feedback feedback =
-        Feedback.toDomain(
-            feedbackId,
-            Instant.now(),
-            Instant.now(),
-            declaredActivity,
-            null,
-            null,
-            EFeedbackStatus.IN_PROCESS,
-            1,
-            List.of(),
-            List.of());
-    String feedbackText = "Excellent travail, bravo !";
-    User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
-
-    when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
-    when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
-    when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
-
-    BddLogger.when("updateFeedback is called with the new feedback text");
-    service.updateFeedback(feedbackId, feedbackText);
-
-    BddLogger.then("The feedback is saved with the updated text");
-    verify(feedbackRepository).save(feedbackCaptor.capture());
-    Feedback saved = feedbackCaptor.getValue();
-    assertThat(saved.getFeedback()).contains(feedbackText);
-  }
-
-  @Test
-  void updateFeedback_should_throw_FeedbackNotFoundException_when_feedback_does_not_exist() {
-    BddLogger.given("A non-existent feedback ID");
-    UUID feedbackId = UUID.randomUUID();
-
-    when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.empty());
-
-    BddLogger.when("updateFeedback is called");
-
-    BddLogger.then("A FeedbackNotFoundException is thrown and nothing is saved");
-    assertThatThrownBy(() -> service.updateFeedback(feedbackId, "some text"))
-        .isInstanceOf(FeedbackNotFoundException.class);
-
-    verify(feedbackRepository, never()).save(any());
-  }
-
-  @Test
-  void updateFeedback_should_throw_UserNotAuthorizedException_when_user_is_not_the_author() {
-    BddLogger.given("A logged-in user who is NOT the author of the activity");
-    UUID feedbackId = UUID.randomUUID();
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
-    Feedback feedback =
-        Feedback.toDomain(
-            feedbackId,
-            Instant.now(),
-            Instant.now(),
-            declaredActivity,
-            null,
-            null,
-            EFeedbackStatus.IN_PROCESS,
-            1,
-            List.of(),
-            List.of());
-    User differentUser = UserFixture.create().toModel();
-
-    when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
-    when(loggedInUserService.getLoggedInUser()).thenReturn(differentUser);
-
-    BddLogger.when("updateFeedback is called");
-
-    BddLogger.then("A UserNotAuthorizedException is thrown and nothing is saved");
-    assertThatThrownBy(() -> service.updateFeedback(feedbackId, "some text"))
-        .isInstanceOf(UserNotAuthorizedException.class);
-
-    verify(feedbackRepository, never()).save(any());
-  }
-
-  @Test
-  void
-      updateFeedback_should_throw_FieldValidationException_when_feedback_text_exceeds_max_length() {
-    BddLogger.given("A valid feedback and a feedback text exceeding RICH_DESCRIPTION_LENGTH");
-    UUID feedbackId = UUID.randomUUID();
-    Activity activity = ActivityFixture.create().toModel();
-    DeclaredActivity declaredActivity =
-        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
-    Feedback feedback =
-        Feedback.toDomain(
-            feedbackId,
-            Instant.now(),
-            Instant.now(),
-            declaredActivity,
-            null,
-            null,
-            EFeedbackStatus.IN_PROCESS,
-            1,
-            List.of(),
-            List.of());
-    String tooLongFeedback = "a".repeat(RICH_DESCRIPTION_LENGTH + 1);
-    User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
-
-    when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
-    when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
-
-    BddLogger.when("updateFeedback is called with a text that is too long");
-
-    BddLogger.then("A FieldValidationException is thrown and nothing is saved");
-    assertThatThrownBy(() -> service.updateFeedback(feedbackId, tooLongFeedback))
-        .isInstanceOf(FieldValidationException.class);
-
-    verify(feedbackRepository, never()).save(any());
+      verify(feedbackRepository, never()).save(any());
+    }
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Extraction du `FeedbackService` et `FeedbackController` depuis `DeclaredActivityService`/`DeclaredActivityController`. Ajout du record `FeedbackData` pour porter les détails d'un feedback avec une visibilité basée sur le rôle (le champ `feedback` est `null` pour l'étudiant tant que le statut n'est pas `SUBMITTED`). Ajout du path param `userCategory` sur l'endpoint `GET /{userCategory}/{feedbackId}` et adaptation de tous les tests unitaires et d'intégration.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1862

---

### Documentation
> Aucune mise à jour de documentation requise.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `FeedbackData` est un record dédié qui masque le champ `feedback` aux étudiants tant que le statut est différent de `SUBMITTED`
> - `FeedbackController` expose désormais `GET /me/activity-progress/feedbacks/{userCategory}/{feedbackId}` pour distinguer la vue étudiant vs staff
> - Les mocks `DeclaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization` ont été ajoutés dans `FeedbackServiceImplTest` pour refléter la délégation effective

---

### Known Limitations or Side Effects
> Aucune régression connue.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process