### PR TITLE
feat(feedback): add submit feedback endpoint

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
@@ -99,4 +99,13 @@ public class FeedbackController {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(feedbackDetailsDTOMapper.toDTO(feedbackService.createFeedback(declaredActivityId)));
   }
+
+  @PostMapping("/{feedbackId}/submit")
+  public ResponseEntity<Void> submitFeedback(
+      Principal principal, @Valid @PathVariable UUID feedbackId) {
+    log.debug(
+        "Received request to submit feedback [{}] by user [{}]", feedbackId, principal.getName());
+    feedbackService.submitFeedback(feedbackId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
@@ -20,4 +20,6 @@ public interface FeedbackService {
 
   PagedResult<Feedback> getStaffFeedbacks(
       EFeedbackStatus statusFilter, UUID activityId, PageCriteria pageCriteria);
+
+  void submitFeedback(UUID feedbackId);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -1,6 +1,7 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.service;
 
 import static fr.avenirsesr.portfolio.common.validation.domain.constraints.FieldMaxLengths.RICH_DESCRIPTION_LENGTH;
+import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.requireNotNull;
 import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.validateOptionalEnrichedTextMaxLength;
 import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.validateOptionalTextMaxLength;
 
@@ -187,5 +188,23 @@ public class FeedbackServiceImpl implements FeedbackService {
       EFeedbackStatus statusFilter, UUID activityId, PageCriteria pageCriteria) {
     var staff = loggedInUserService.getLoggedInStaff();
     return feedbackRepository.findByStaff(staff.getId(), statusFilter, activityId, pageCriteria);
+  }
+
+  @Override
+  public void submitFeedback(UUID feedbackId) {
+    Feedback feedback =
+        feedbackRepository.findById(feedbackId).orElseThrow(FeedbackNotFoundException::new);
+
+    Staff loggedInStaff = loggedInUserService.getLoggedInStaff();
+    Staff author = feedback.getDeclaredActivity().getActivity().getAuthor();
+
+    if (!loggedInStaff.equals(author)) {
+      throw new UserNotAuthorizedException();
+    }
+
+    requireNotNull("feedback", feedback.getFeedback().orElse(null));
+
+    feedback.setStatus(EFeedbackStatus.SUBMITTED);
+    feedbackRepository.save(feedback);
   }
 }

--- a/src/main/resources/seeder/activities.json
+++ b/src/main/resources/seeder/activities.json
@@ -34,7 +34,7 @@
     },
     "authorStaffId": "5fcd76c5-017c-4d61-99d2-62a6f199c94e",
     "traceAllowedAssociations": -1,
-    "feedbackAllowedIterations": 7,
+    "feedbackAllowedIterations": 70,
     "enableReflection": false,
     "createdAt": "2024-06-01T10:00:00Z",
     "updatedAt": "2024-06-01T10:00:00Z"

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
@@ -96,6 +96,20 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
     return BASE_PATH + "/" + userCategory + "/" + feedbackId;
   }
 
+  private void updateFeedbackWithText(String feedbackId, String feedbackText) {
+    webTestClient
+        .put()
+        .uri(BASE_PATH + "/" + feedbackId)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"feedback\": \"" + feedbackText + "\"}")
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+  }
+
   // ── POST /{declaredActivityId}/ask-for-feedback ─────────────────────
 
   @Test
@@ -430,6 +444,121 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
     for (JsonNode item : data) {
       assertThat(item.get("status").asText()).isEqualTo("NEW");
     }
+  }
+
+  // ── POST /{feedbackId}/submit ────────────────────────────────────────
+
+  @Test
+  @Transactional
+  void shouldSubmitFeedbackSuccessfully() throws Exception {
+    BddLogger.given("a staff/student who asked for feedback and set a feedback text on it");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    updateFeedbackWithText(feedbackId, "Excellent travail !");
+
+    BddLogger.when("the staff author submits the feedback");
+    BddLogger.then("204 No Content is returned and the feedback status becomes SUBMITTED");
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + feedbackId + "/submit")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn400WhenFeedbackTextIsNullOnSubmit() throws Exception {
+    BddLogger.given("a feedback that was never updated — its feedback text is null");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+
+    BddLogger.when("the staff author tries to submit the feedback without setting a text");
+    BddLogger.then("400 Bad Request is returned");
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + feedbackId + "/submit")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void shouldReturn404WhenFeedbackNotFoundOnSubmit() {
+    BddLogger.given("a non-existent feedback ID");
+    BddLogger.when("the staff tries to submit it");
+    BddLogger.then("404 Not Found is returned");
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + notFoundId + "/submit")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  void shouldReturn401WhenNotAuthenticatedOnSubmit() {
+    BddLogger.given("the POST /me/activity-progress/feedbacks/{feedbackId}/submit endpoint");
+    BddLogger.when("performing a POST without authentication headers");
+    BddLogger.then("401 Unauthorized is returned");
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + notFoundId + "/submit")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn403WhenNonStaffUserTriesToSubmit() throws Exception {
+    BddLogger.given("a feedback and a user who is not registered as staff");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+
+    BddLogger.when("the non-staff user tries to submit the feedback");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + feedbackId + "/submit")
+        .header("X-Signed-Context", otherStudentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", otherStudentSignature)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn403WhenStaffIsNotAuthorOnSubmit() throws Exception {
+    BddLogger.given("a feedback on an activity whose author is not the currently logged-in staff");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    updateFeedbackWithText(feedbackId, "Quelques remarques.");
+
+    BddLogger.when("a different staff (not the activity author) tries to submit");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + feedbackId + "/submit")
+        .header("X-Signed-Context", staffPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", staffSignature)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
@@ -291,4 +291,35 @@ class FeedbackControllerTest {
     verify(feedbackService, times(1)).updateFeedback(feedbackId, feedbackText);
     verifyNoMoreInteractions(feedbackService);
   }
+
+  @Test
+  void submitFeedback_should_return_204_no_content() {
+    BddLogger.given("A valid feedback ID and a staff ready to submit");
+
+    UUID feedbackId = UUID.randomUUID();
+    doNothing().when(feedbackService).submitFeedback(feedbackId);
+
+    BddLogger.when("submitFeedback is called");
+    ResponseEntity<Void> response = controller.submitFeedback(principal, feedbackId);
+
+    BddLogger.then("204 No Content is returned with no body");
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(response.getBody()).isNull();
+
+    verify(feedbackService).submitFeedback(feedbackId);
+  }
+
+  @Test
+  void submitFeedback_should_delegate_to_service_with_correct_feedback_id() {
+    BddLogger.given("A feedback ID");
+
+    UUID feedbackId = UUID.randomUUID();
+
+    BddLogger.when("submitFeedback is called");
+    controller.submitFeedback(principal, feedbackId);
+
+    BddLogger.then("The service is called exactly once with the correct feedback ID");
+    verify(feedbackService, times(1)).submitFeedback(feedbackId);
+    verifyNoMoreInteractions(feedbackService);
+  }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -31,7 +31,10 @@ import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.Decl
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input.DeclaredSkillProgressService;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.trace.domain.port.input.TraceService;
+import fr.avenirsesr.portfolio.user.domain.exception.UserIsNotStaffException;
+import fr.avenirsesr.portfolio.user.domain.model.Staff;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.StaffFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.time.Instant;
@@ -807,6 +810,164 @@ class FeedbackServiceImplTest {
 
       BddLogger.then("A FieldValidationException is thrown and nothing is saved");
       assertThatThrownBy(() -> service.updateFeedback(feedbackId, tooLongFeedback))
+          .isInstanceOf(FieldValidationException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+  }
+
+  @Nested
+  class SubmitFeedback {
+
+    @Test
+    void should_set_status_to_SUBMITTED_and_save_when_staff_is_author_and_feedback_is_not_null() {
+      BddLogger.given(
+          "A logged-in staff who is the author of the activity and a feedback with non-null text");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff staff = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, "Ma réflexion", null, null, null);
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              "Ma réflexion",
+              "Bon travail !",
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+
+      BddLogger.when("submitFeedback is called");
+      service.submitFeedback(feedbackId);
+
+      BddLogger.then("The feedback status is set to SUBMITTED and the feedback is saved");
+      verify(feedbackRepository).save(feedbackCaptor.capture());
+      Feedback saved = feedbackCaptor.getValue();
+      assertThat(saved.getStatus()).isEqualTo(EFeedbackStatus.SUBMITTED);
+      assertThat(saved.getId()).isEqualTo(feedbackId);
+    }
+
+    @Test
+    void should_throw_FeedbackNotFoundException_when_feedback_does_not_exist() {
+      BddLogger.given("A non-existent feedback ID");
+      UUID feedbackId = UUID.randomUUID();
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.empty());
+
+      BddLogger.when("submitFeedback is called");
+
+      BddLogger.then("A FeedbackNotFoundException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.submitFeedback(feedbackId))
+          .isInstanceOf(FeedbackNotFoundException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_UserIsNotStaffException_when_logged_in_user_is_not_staff() {
+      BddLogger.given("A logged-in user who is not registered as staff");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              "Bon travail !",
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenThrow(new UserIsNotStaffException());
+
+      BddLogger.when("submitFeedback is called");
+
+      BddLogger.then("A UserIsNotStaffException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.submitFeedback(feedbackId))
+          .isInstanceOf(UserIsNotStaffException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_staff_is_not_the_author() {
+      BddLogger.given("A logged-in staff who is NOT the author of the activity");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff differentStaff = StaffFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              "Bon travail !",
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(differentStaff);
+
+      BddLogger.when("submitFeedback is called");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.submitFeedback(feedbackId))
+          .isInstanceOf(UserNotAuthorizedException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_FieldValidationException_when_feedback_text_is_null() {
+      BddLogger.given("A logged-in staff who is the author but the feedback text field is null");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff staff = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              null,
+              EFeedbackStatus.NEW,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+
+      BddLogger.when("submitFeedback is called");
+
+      BddLogger.then("A FieldValidationException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.submitFeedback(feedbackId))
           .isInstanceOf(FieldValidationException.class);
 
       verify(feedbackRepository, never()).save(any());


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a new `POST /{feedbackId}/submit` endpoint that allows the activity author (staff) to submit a feedback. The endpoint validates that:
> - the feedback exists (404 otherwise)
> - the logged-in user is a registered staff member (403 otherwise)
> - the logged-in staff is the author of the activity linked to the feedback (403 otherwise)
> - the feedback text is not null before transitioning the status to `SUBMITTED` (400 otherwise)
>
> Also refactors `FeedbackController` and `FeedbackService` by splitting declared-activity concerns from pure feedback concerns, and fixes null feedback visibility.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1757

---

### Documentation
> No documentation update required. The endpoint follows the existing REST conventions of the feedback module.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `requireNotNull` from `FieldValidationUtils` is reused to validate the feedback text before submission, keeping validation consistent with other fields.
> - The `feedbackAllowedIterations` in `activities.json` seeder was raised from 7 to 70 to avoid hitting the iteration cap during integration tests.
> - The refactor commit (`ca040a83`) that precedes the feature commit is included in this PR as it was a prerequisite split of `FeedbackController`/`FeedbackService` from `DeclaredActivityController`/`DeclaredActivityService`.

---

### Known Limitations or Side Effects
> - No state-machine guard is in place yet: a feedback already in `SUBMITTED` status can be re-submitted without error. A follow-up issue should add idempotency or transition guards if needed.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process