### PR TITLE
refactor(1922): extract quick links from profile overview into QuickLinksDTO

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/port/output/repository/NotificationRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/port/output/repository/NotificationRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 public interface NotificationRepository extends GenericRepositoryPort<Notification> {
   PagedResult<Notification> findByUserAndCategory(
       UUID userId, EUserCategory userCategory, PageCriteria pageCriteria);
+
+  long countUnreadByUserAndCategory(UUID userId, EUserCategory userCategory);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/repository/NotificationDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/repository/NotificationDatabaseRepository.java
@@ -34,4 +34,13 @@ public class NotificationDatabaseRepository
         PageRequest.of(
             pageCriteria.page(), pageCriteria.pageSize(), Sort.by("createdAt").descending()));
   }
+
+  @Override
+  public long countUnreadByUserAndCategory(UUID userId, EUserCategory userCategory) {
+    var specification =
+        NotificationSpecification.hasUser(userId)
+            .and(NotificationSpecification.hasUserCategoryNullOrEquals(userCategory))
+            .and(NotificationSpecification.isNotSeen());
+    return jpaSpecificationExecutor.count(specification);
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/specification/NotificationSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/specification/NotificationSpecification.java
@@ -18,4 +18,8 @@ public final class NotificationSpecification {
     return (root, query, cb) ->
         cb.or(root.get("userCategory").isNull(), cb.equal(root.get("userCategory"), userCategory));
   }
+
+  public static Specification<NotificationEntity> isNotSeen() {
+    return (root, query, cb) -> cb.isFalse(root.get("seen"));
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserController.java
@@ -4,6 +4,7 @@ import static fr.avenirsesr.portfolio.shared.application.adapter.Utils.extractOr
 
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.user.application.adapter.dto.ProfileOverviewDTO;
+import fr.avenirsesr.portfolio.user.application.adapter.dto.QuickLinksDTO;
 import fr.avenirsesr.portfolio.user.application.adapter.mapper.ProfileOverviewMapper;
 import fr.avenirsesr.portfolio.user.application.adapter.request.NotificationPreferencesRequest;
 import fr.avenirsesr.portfolio.user.application.adapter.request.ProfileUpdateRequest;
@@ -57,6 +58,27 @@ public class UserController {
 
     String baseUrl = extractOrigin(request);
     return ResponseEntity.ok(profileOverviewMapper.userDomainToDto(overview, baseUrl));
+  }
+
+  @GetMapping("/{userCategory}/quick-links")
+  public ResponseEntity<QuickLinksDTO> getQuickLinks(
+      @Valid
+          @Parameter(
+              name = "userCategory",
+              in = ParameterIn.PATH,
+              required = true,
+              schema = @Schema(ref = "#/components/schemas/EUserCategory"))
+          @PathVariable
+          EUserCategory userCategory) {
+    var data = userService.getQuickLinks(userCategory);
+    return ResponseEntity.ok(
+        new QuickLinksDTO(
+            data.userId(),
+            data.firstname(),
+            data.lastname(),
+            data.hasUnseenNotification(),
+            data.unreadNotifications(),
+            data.notificationEnabled()));
   }
 
   @PutMapping("/{userCategory}/update")

--- a/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/dto/ProfileOverviewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/dto/ProfileOverviewDTO.java
@@ -11,8 +11,6 @@ import java.util.UUID;
       "lastname",
       "bio",
       "email",
-      "hasUnseenNotification",
-      "notificationEnabled",
       "profilePicture",
       "coverPicture"
     })
@@ -22,7 +20,5 @@ public record ProfileOverviewDTO(
     String lastname,
     String bio,
     String email,
-    boolean hasUnseenNotification,
-    boolean notificationEnabled,
     FileDTO profilePicture,
     FileDTO coverPicture) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/dto/QuickLinksDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/dto/QuickLinksDTO.java
@@ -1,0 +1,21 @@
+package fr.avenirsesr.portfolio.user.application.adapter.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(
+    requiredProperties = {
+      "userId",
+      "firstname",
+      "lastname",
+      "hasUnseenNotification",
+      "unreadNotifications",
+      "notificationEnabled"
+    })
+public record QuickLinksDTO(
+    UUID userId,
+    String firstname,
+    String lastname,
+    boolean hasUnseenNotification,
+    int unreadNotifications,
+    boolean notificationEnabled) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/mapper/ProfileOverviewMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/application/adapter/mapper/ProfileOverviewMapper.java
@@ -15,8 +15,6 @@ public interface ProfileOverviewMapper {
         overview.lastName(),
         overview.bio(),
         overview.email(),
-        overview.hasUnseenNotification(),
-        overview.notificationEnabled(),
         new FileDTO(
             overview.profilePhoto().id().orElse(null),
             overview.profilePhoto().name().orElse(null),

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/data/UserProfileOverviewData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/data/UserProfileOverviewData.java
@@ -9,7 +9,5 @@ public record UserProfileOverviewData(
     String lastName,
     String email,
     String bio,
-    boolean hasUnseenNotification,
-    boolean notificationEnabled,
     FileData coverPhoto,
     FileData profilePhoto) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/data/UserQuickLinksData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/data/UserQuickLinksData.java
@@ -1,0 +1,11 @@
+package fr.avenirsesr.portfolio.user.domain.data;
+
+import java.util.UUID;
+
+public record UserQuickLinksData(
+    UUID userId,
+    String firstname,
+    String lastname,
+    boolean hasUnseenNotification,
+    int unreadNotifications,
+    boolean notificationEnabled) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/port/input/UserService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/port/input/UserService.java
@@ -3,6 +3,7 @@ package fr.avenirsesr.portfolio.user.domain.port.input;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.user.domain.port.output.BaseUserService;
+import fr.avenirsesr.portfolio.user.domain.data.UserQuickLinksData;
 import java.util.UUID;
 
 @SuppressWarnings("PMD.MissingOverride")
@@ -14,4 +15,6 @@ public interface UserService extends BaseUserService {
   void updateNotificationPreferences(boolean notificationEnabled);
 
   User createUser(UUID id, String firstname, String lastname, String email, String eppn);
+
+  UserQuickLinksData getQuickLinks(EUserCategory userCategory);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImpl.java
@@ -43,8 +43,6 @@ public class StaffServiceImpl implements StaffService {
         staff.getUser().getLastName(),
         staff.getInstitutionEmail(),
         staff.getBio(),
-        staff.isHasUnseenNotification(),
-        staff.getUser().isNotificationEnabled(),
         FileDataMapper.mapFileData(
             staff.getCoverPicture().orElse(null), FileStorageConstants.DEFAULT_COVER_FILE_URL),
         FileDataMapper.mapFileData(

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StudentServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StudentServiceImpl.java
@@ -47,8 +47,6 @@ public class StudentServiceImpl implements StudentService {
         student.getUser().getLastName(),
         student.getUser().getEmail(),
         student.getBio(),
-        student.isHasUnseenNotification(),
-        student.getUser().isNotificationEnabled(),
         FileDataMapper.mapFileData(
             student.getCoverPicture().orElse(null), FileStorageConstants.DEFAULT_COVER_FILE_URL),
         FileDataMapper.mapFileData(

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
@@ -7,7 +7,9 @@ import fr.avenirsesr.portfolio.common.error.domain.model.enums.EErrorCode;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.common.user.domain.exceptions.ExternalUserNotFoundException;
 import fr.avenirsesr.portfolio.common.user.domain.model.enums.EUserStatus;
+import fr.avenirsesr.portfolio.notification.domain.port.output.repository.NotificationRepository;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.user.domain.data.UserQuickLinksData;
 import fr.avenirsesr.portfolio.user.domain.port.input.StaffService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
 import fr.avenirsesr.portfolio.user.domain.port.input.UserService;
@@ -27,6 +29,7 @@ public class UserServiceImpl implements UserService {
   private final StudentService studentService;
   private final ExternalUserClient externalUserClient;
   private final LoggedInUserService loggedInUserService;
+  private final NotificationRepository notificationRepository;
 
   @Override
   public User getUser(UUID id) {
@@ -77,6 +80,33 @@ public class UserServiceImpl implements UserService {
     userRepository.save(user);
     userPrincipalRepository.saveOrUpdate(user, eppn);
     return user;
+  }
+
+  @Override
+  public UserQuickLinksData getQuickLinks(EUserCategory userCategory) {
+    User user;
+    boolean hasUnseenNotification =
+        switch (userCategory) {
+          case STUDENT -> {
+            var student = loggedInUserService.getLoggedInStudent();
+            user = student.getUser();
+            yield student.isHasUnseenNotification();
+          }
+          case STAFF -> {
+            var staff = loggedInUserService.getLoggedInStaff();
+            user = staff.getUser();
+            yield staff.isHasUnseenNotification();
+          }
+        };
+    int unreadNotifications =
+        (int) notificationRepository.countUnreadByUserAndCategory(user.getId(), userCategory);
+    return new UserQuickLinksData(
+        user.getId(),
+        user.getFirstName(),
+        user.getLastName(),
+        hasUnseenNotification,
+        unreadNotifications,
+        user.isNotificationEnabled());
   }
 
   private User createUserFromExternalUser(String eppn) {

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/service/TransactionalUserService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/service/TransactionalUserService.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.user.infrastructure.adapter.service;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
+import fr.avenirsesr.portfolio.user.domain.data.UserQuickLinksData;
 import fr.avenirsesr.portfolio.user.domain.port.input.UserService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +39,10 @@ public class TransactionalUserService implements UserService {
   @Transactional
   public User createUser(UUID id, String firstname, String lastname, String email, String eppn) {
     return delegate.createUser(id, firstname, lastname, email, eppn);
+  }
+
+  @Override
+  public UserQuickLinksData getQuickLinks(EUserCategory userCategory) {
+    return delegate.getQuickLinks(userCategory);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/service/UserServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/service/UserServiceConfig.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.user.infrastructure.adapter.service;
 
+import fr.avenirsesr.portfolio.notification.domain.port.output.repository.NotificationRepository;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StaffService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
@@ -22,6 +23,7 @@ public class UserServiceConfig {
   private final StudentService studentService;
   private final ExternalUserClient externalUserClient;
   private final LoggedInUserService loggedInUserService;
+  private final NotificationRepository notificationRepository;
 
   @Bean
   public UserService userService() {
@@ -32,6 +34,7 @@ public class UserServiceConfig {
             staffService,
             studentService,
             externalUserClient,
-            loggedInUserService));
+            loggedInUserService,
+            notificationRepository));
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/specification/NotificationSpecificationIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/specification/NotificationSpecificationIT.java
@@ -6,6 +6,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
 import fr.avenirsesr.portfolio.notification.infrastructure.adapter.model.NotificationEntity;
+import fr.avenirsesr.portfolio.notification.infrastructure.adapter.repository.NotificationDatabaseRepository;
 import fr.avenirsesr.portfolio.notification.infrastructure.adapter.repository.NotificationJpaRepository;
 import fr.avenirsesr.portfolio.shared.infrastructure.ContainerConfigurationTest;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.UserEntity;
@@ -24,6 +25,7 @@ import org.springframework.test.context.TestPropertySource;
 class NotificationSpecificationIT extends ContainerConfigurationTest {
 
   @Autowired private NotificationJpaRepository notificationJpaRepository;
+  @Autowired private NotificationDatabaseRepository notificationDatabaseRepository;
   @Autowired private EntityManager entityManager;
 
   private UserEntity user;
@@ -144,6 +146,125 @@ class NotificationSpecificationIT extends ContainerConfigurationTest {
     assertThat(results).extracting(NotificationEntity::getId).doesNotContain(otherStaff.getId());
   }
 
+  @Test
+  void isNotSeen_should_return_only_unseen_notifications() {
+    BddLogger.given("One seen and one unseen notification for user");
+    NotificationEntity seen = persistNotificationWithSeen(user, EUserCategory.STUDENT, true);
+    NotificationEntity unseen = persistNotificationWithSeen(user, EUserCategory.STUDENT, false);
+    entityManager.flush();
+    entityManager.clear();
+
+    BddLogger.when("isNotSeen spec is applied");
+    List<NotificationEntity> results =
+        notificationJpaRepository.findAll(
+            NotificationSpecification.hasUser(user.getId())
+                .and(NotificationSpecification.isNotSeen()));
+
+    BddLogger.then("Only the unseen notification is returned");
+    assertThat(results).extracting(NotificationEntity::getId).containsExactly(unseen.getId());
+    assertThat(results).extracting(NotificationEntity::getId).doesNotContain(seen.getId());
+  }
+
+  @Test
+  void isNotSeen_combined_with_all_specs_should_exclude_seen_notifications() {
+    BddLogger.given("Mixed seen/unseen notifications for STAFF and null category");
+    NotificationEntity seenStaff = persistNotificationWithSeen(user, EUserCategory.STAFF, true);
+    NotificationEntity unseenStaff = persistNotificationWithSeen(user, EUserCategory.STAFF, false);
+    NotificationEntity unseenNull = persistNotificationWithSeen(user, null, false);
+    NotificationEntity unseenOtherUser =
+        persistNotificationWithSeen(otherUser, EUserCategory.STAFF, false);
+    entityManager.flush();
+    entityManager.clear();
+
+    BddLogger.when("hasUser + hasUserCategoryNullOrEquals(STAFF) + isNotSeen is applied for user");
+    List<NotificationEntity> results =
+        notificationJpaRepository.findAll(
+            NotificationSpecification.hasUser(user.getId())
+                .and(NotificationSpecification.hasUserCategoryNullOrEquals(EUserCategory.STAFF))
+                .and(NotificationSpecification.isNotSeen()));
+
+    BddLogger.then("Only unseen STAFF and null-category notifications for user are returned");
+    assertThat(results)
+        .extracting(NotificationEntity::getId)
+        .containsExactlyInAnyOrder(unseenStaff.getId(), unseenNull.getId());
+    assertThat(results)
+        .extracting(NotificationEntity::getId)
+        .doesNotContain(seenStaff.getId(), unseenOtherUser.getId());
+  }
+
+  @Test
+  void countUnreadByUserAndCategory_should_return_correct_count_for_student() {
+    BddLogger.given(
+        "3 unseen STUDENT notifications, 1 seen STUDENT notification, and 1 unseen STAFF notification for user");
+    persistNotificationWithSeen(user, EUserCategory.STUDENT, false);
+    persistNotificationWithSeen(user, EUserCategory.STUDENT, false);
+    persistNotificationWithSeen(user, EUserCategory.STUDENT, false);
+    persistNotificationWithSeen(user, EUserCategory.STUDENT, true);
+    persistNotificationWithSeen(user, EUserCategory.STAFF, false);
+    entityManager.flush();
+    entityManager.clear();
+
+    BddLogger.when("countUnreadByUserAndCategory is called for STUDENT");
+    long count =
+        notificationDatabaseRepository.countUnreadByUserAndCategory(
+            user.getId(), EUserCategory.STUDENT);
+
+    BddLogger.then("It should return 3");
+    assertThat(count).isEqualTo(3);
+  }
+
+  @Test
+  void countUnreadByUserAndCategory_should_include_null_category_notifications() {
+    BddLogger.given("1 unseen STAFF and 1 unseen null-category notification for user");
+    persistNotificationWithSeen(user, EUserCategory.STAFF, false);
+    persistNotificationWithSeen(user, null, false);
+    persistNotificationWithSeen(user, EUserCategory.STUDENT, false);
+    entityManager.flush();
+    entityManager.clear();
+
+    BddLogger.when("countUnreadByUserAndCategory is called for STAFF");
+    long count =
+        notificationDatabaseRepository.countUnreadByUserAndCategory(
+            user.getId(), EUserCategory.STAFF);
+
+    BddLogger.then("It should return 2 (STAFF + null-category)");
+    assertThat(count).isEqualTo(2);
+  }
+
+  @Test
+  void countUnreadByUserAndCategory_should_not_count_other_users_notifications() {
+    BddLogger.given("1 unseen STUDENT notification for user and 1 for otherUser");
+    persistNotificationWithSeen(user, EUserCategory.STUDENT, false);
+    persistNotificationWithSeen(otherUser, EUserCategory.STUDENT, false);
+    entityManager.flush();
+    entityManager.clear();
+
+    BddLogger.when("countUnreadByUserAndCategory is called for user");
+    long count =
+        notificationDatabaseRepository.countUnreadByUserAndCategory(
+            user.getId(), EUserCategory.STUDENT);
+
+    BddLogger.then("It should return 1, excluding the other user's notification");
+    assertThat(count).isEqualTo(1);
+  }
+
+  @Test
+  void countUnreadByUserAndCategory_should_return_zero_when_all_notifications_are_seen() {
+    BddLogger.given("Only seen STUDENT notifications for user");
+    persistNotificationWithSeen(user, EUserCategory.STUDENT, true);
+    persistNotificationWithSeen(user, EUserCategory.STUDENT, true);
+    entityManager.flush();
+    entityManager.clear();
+
+    BddLogger.when("countUnreadByUserAndCategory is called for STUDENT");
+    long count =
+        notificationDatabaseRepository.countUnreadByUserAndCategory(
+            user.getId(), EUserCategory.STUDENT);
+
+    BddLogger.then("It should return 0");
+    assertThat(count).isZero();
+  }
+
   private UserEntity persistUser(String email) {
     UserEntity u =
         UserEntity.of(
@@ -153,6 +274,11 @@ class NotificationSpecificationIT extends ContainerConfigurationTest {
   }
 
   private NotificationEntity persistNotification(UserEntity owner, EUserCategory category) {
+    return persistNotificationWithSeen(owner, category, false);
+  }
+
+  private NotificationEntity persistNotificationWithSeen(
+      UserEntity owner, EUserCategory category, boolean seen) {
     NotificationEntity entity =
         NotificationEntity.of(
             UUID.randomUUID(),
@@ -163,7 +289,7 @@ class NotificationSpecificationIT extends ContainerConfigurationTest {
             owner,
             category,
             List.of("param"),
-            false);
+            seen);
     entityManager.persist(entity);
     return entity;
   }

--- a/src/test/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/specification/NotificationSpecificationIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/specification/NotificationSpecificationIT.java
@@ -195,7 +195,8 @@ class NotificationSpecificationIT extends ContainerConfigurationTest {
   @Test
   void countUnreadByUserAndCategory_should_return_correct_count_for_student() {
     BddLogger.given(
-        "3 unseen STUDENT notifications, 1 seen STUDENT notification, and 1 unseen STAFF notification for user");
+        "3 unseen STUDENT notifications, 1 seen STUDENT notification, and 1 unseen STAFF"
+            + " notification for user");
     persistNotificationWithSeen(user, EUserCategory.STUDENT, false);
     persistNotificationWithSeen(user, EUserCategory.STUDENT, false);
     persistNotificationWithSeen(user, EUserCategory.STUDENT, false);

--- a/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java
@@ -230,6 +230,86 @@ public class UserControllerIT extends ContainerConfigurationTest {
   }
 
   @Nested
+  class GetQuickLinks {
+
+    @Test
+    void shouldGetStudentQuickLinks() {
+      BddLogger.given("the /me/users/STUDENT/quick-links endpoint");
+      BddLogger.when("performing a GET as a student");
+      BddLogger.then("it should return the student quick links data");
+
+      webTestClient
+          .get()
+          .uri("/me/users/STUDENT/quick-links")
+          .header("X-Signed-Context", studentPayload)
+          .header("X-Context-Kid", secretKey)
+          .header("X-Context-Signature", studentSignature)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .jsonPath("$.userId")
+          .exists()
+          .jsonPath("$.firstname")
+          .exists()
+          .jsonPath("$.lastname")
+          .exists()
+          .jsonPath("$.hasUnseenNotification")
+          .isEqualTo(false)
+          .jsonPath("$.unreadNotifications")
+          .isNumber()
+          .jsonPath("$.notificationEnabled")
+          .isBoolean();
+    }
+
+    @Test
+    void shouldGetStaffQuickLinks() {
+      BddLogger.given("the /me/users/STAFF/quick-links endpoint");
+      BddLogger.when("performing a GET as a staff member");
+      BddLogger.then("it should return the staff quick links data");
+
+      webTestClient
+          .get()
+          .uri("/me/users/STAFF/quick-links")
+          .header("X-Signed-Context", staffPayload)
+          .header("X-Context-Kid", secretKey)
+          .header("X-Context-Signature", staffSignature)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .jsonPath("$.userId")
+          .exists()
+          .jsonPath("$.hasUnseenNotification")
+          .isEqualTo(false)
+          .jsonPath("$.unreadNotifications")
+          .isNumber()
+          .jsonPath("$.notificationEnabled")
+          .isBoolean();
+    }
+
+    @Test
+    void shouldReturnUnauthorizedForUnknownUserOnQuickLinks() {
+      BddLogger.given("the /me/users/STUDENT/quick-links endpoint");
+      BddLogger.when("performing a GET with an unknown user");
+      BddLogger.then("it should return 401");
+
+      webTestClient
+          .get()
+          .uri("/me/users/STUDENT/quick-links")
+          .header("X-Signed-Context", unknownPayload)
+          .header("X-Context-Kid", secretKey)
+          .header("X-Context-Signature", unknownSignature)
+          .exchange()
+          .expectStatus()
+          .isUnauthorized()
+          .expectBody()
+          .jsonPath("$.code")
+          .isEqualTo("USER_NOT_AUTHORIZED");
+    }
+  }
+
+  @Nested
   class UpdateNotificationPreferences {
 
     @Test

--- a/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/controller/UserControllerIT.java
@@ -149,9 +149,7 @@ public class UserControllerIT extends ContainerConfigurationTest {
         .jsonPath("$.email")
         .isEqualTo("lucas.tessier@university.com")
         .jsonPath("$.bio")
-        .exists()
-        .jsonPath("$.hasUnseenNotification")
-        .isEqualTo(false);
+        .exists();
   }
 
   @Test
@@ -168,10 +166,7 @@ public class UserControllerIT extends ContainerConfigurationTest {
         .header("X-Context-Signature", staffSignature)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectBody()
-        .jsonPath("$.hasUnseenNotification")
-        .isEqualTo(false);
+        .isOk();
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/mapper/ProfileOverviewMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/application/adapter/mapper/ProfileOverviewMapperTest.java
@@ -26,15 +26,7 @@ class ProfileOverviewMapperTest {
     var cover = new FileData(Optional.of(coverFileId), Optional.of("cover.jpg"), "cover.jpg");
     UserProfileOverviewData overview =
         new UserProfileOverviewData(
-            UUID.randomUUID(),
-            "Jane",
-            "Doe",
-            "jane@example.com",
-            "My bio",
-            false,
-            true,
-            cover,
-            profile);
+            UUID.randomUUID(), "Jane", "Doe", "jane@example.com", "My bio", cover, profile);
 
     BddLogger.when("mapping to ProfileOverviewDTO");
     ProfileOverviewDTO dto = mapper.userDomainToDto(overview, "https://cdn.example.com/");
@@ -45,39 +37,11 @@ class ProfileOverviewMapperTest {
     assertEquals("Doe", dto.lastname());
     assertEquals("jane@example.com", dto.email());
     assertEquals("My bio", dto.bio());
-    assertFalse(dto.hasUnseenNotification());
-    assertTrue(dto.notificationEnabled());
     assertNotNull(dto.profilePicture());
     assertEquals(profileFileId, dto.profilePicture().id());
     assertEquals("profile.jpg", dto.profilePicture().fileName());
     assertNotNull(dto.coverPicture());
     assertEquals(coverFileId, dto.coverPicture().id());
-  }
-
-  @Test
-  void shouldMapHasUnseenNotificationTrue() {
-    BddLogger.given("a user profile overview data with unseen notifications");
-    var profile = new FileData(Optional.empty(), Optional.empty(), "default.jpg");
-    var cover = new FileData(Optional.empty(), Optional.empty(), "default-cover.jpg");
-    UserProfileOverviewData overview =
-        new UserProfileOverviewData(
-            UUID.randomUUID(),
-            "Jane",
-            "Doe",
-            "jane@example.com",
-            "My bio",
-            true,
-            false,
-            cover,
-            profile);
-
-    BddLogger.when("mapping to ProfileOverviewDTO");
-    ProfileOverviewDTO dto = mapper.userDomainToDto(overview, "https://cdn.example.com/");
-
-    BddLogger.then("it should map hasUnseenNotification as true");
-    assertNotNull(dto);
-    assertTrue(dto.hasUnseenNotification());
-    assertFalse(dto.notificationEnabled());
   }
 
   @Test
@@ -88,15 +52,7 @@ class ProfileOverviewMapperTest {
     var cover = new FileData(Optional.empty(), Optional.empty(), "default-cover.jpg");
     UserProfileOverviewData overview =
         new UserProfileOverviewData(
-            UUID.randomUUID(),
-            "John",
-            "Smith",
-            "john@example.com",
-            null,
-            false,
-            false,
-            cover,
-            profile);
+            UUID.randomUUID(), "John", "Smith", "john@example.com", null, cover, profile);
 
     BddLogger.when("mapping to ProfileOverviewDTO");
     ProfileOverviewDTO dto = mapper.userDomainToDto(overview, "https://cdn.example.com/");

--- a/src/test/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImplTest.java
@@ -34,43 +34,6 @@ class StaffServiceImplTest {
   @Nested
   class GetStaffProfile {
 
-    private Staff createStaff(boolean hasUnseenNotification) {
-      var user = UserFixture.create().toModel();
-      return Staff.toDomain(
-          user,
-          user.getEmail(),
-          "My bio",
-          hasUnseenNotification,
-          null,
-          null,
-          Instant.now(),
-          Instant.now());
-    }
-
-    @Test
-    void shouldReturnHasUnseenNotificationFalse() {
-      BddLogger.given("a logged-in staff with no unseen notifications");
-      when(loggedInUserService.getLoggedInStaff()).thenReturn(createStaff(false));
-
-      BddLogger.when("getting the staff profile");
-      var result = staffService.getStaffProfile();
-
-      BddLogger.then("hasUnseenNotification should be false");
-      assertFalse(result.hasUnseenNotification());
-    }
-
-    @Test
-    void shouldReturnHasUnseenNotificationTrue() {
-      BddLogger.given("a logged-in staff with unseen notifications");
-      when(loggedInUserService.getLoggedInStaff()).thenReturn(createStaff(true));
-
-      BddLogger.when("getting the staff profile");
-      var result = staffService.getStaffProfile();
-
-      BddLogger.then("hasUnseenNotification should be true");
-      assertTrue(result.hasUnseenNotification());
-    }
-
     @Test
     void shouldMapStaffFieldsToProfileOverviewData() {
       BddLogger.given("a logged-in staff with known field values");
@@ -101,7 +64,6 @@ class StaffServiceImplTest {
       assertEquals("Dupont", result.lastName());
       assertEquals("marie@university.com", result.email());
       assertEquals("My staff bio", result.bio());
-      assertFalse(result.hasUnseenNotification());
     }
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/user/domain/service/StudentServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/domain/service/StudentServiceImplTest.java
@@ -38,34 +38,6 @@ class StudentServiceImplTest {
   @Nested
   class GetStudentProfile {
 
-    private Student createStudent(boolean hasUnseenNotification) {
-      return StudentFixture.create().withHasUnseenNotification(hasUnseenNotification).toModel();
-    }
-
-    @Test
-    void shouldReturnHasUnseenNotificationFalse() {
-      BddLogger.given("a logged-in student with no unseen notifications");
-      when(loggedInUserService.getLoggedInStudent()).thenReturn(createStudent(false));
-
-      BddLogger.when("getting the student profile");
-      var result = studentService.getStudentProfile();
-
-      BddLogger.then("hasUnseenNotification should be false");
-      assertFalse(result.hasUnseenNotification());
-    }
-
-    @Test
-    void shouldReturnHasUnseenNotificationTrue() {
-      BddLogger.given("a logged-in student with unseen notifications");
-      when(loggedInUserService.getLoggedInStudent()).thenReturn(createStudent(true));
-
-      BddLogger.when("getting the student profile");
-      var result = studentService.getStudentProfile();
-
-      BddLogger.then("hasUnseenNotification should be true");
-      assertTrue(result.hasUnseenNotification());
-    }
-
     @Test
     void shouldMapStudentFieldsToProfileOverviewData() {
       BddLogger.given("a logged-in student with known field values");
@@ -75,12 +47,7 @@ class StudentServiceImplTest {
               .withLastName("Tessier")
               .withEmail("lucas@university.com")
               .toModel();
-      Student student =
-          StudentFixture.create()
-              .withUser(user)
-              .withBio("My student bio")
-              .withHasUnseenNotification(false)
-              .toModel();
+      Student student = StudentFixture.create().withUser(user).withBio("My student bio").toModel();
       when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
 
       BddLogger.when("getting the student profile");
@@ -92,7 +59,6 @@ class StudentServiceImplTest {
       assertEquals("Tessier", result.lastName());
       assertEquals("lucas@university.com", result.email());
       assertEquals("My student bio", result.bio());
-      assertFalse(result.hasUnseenNotification());
     }
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImplTest.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.user.domain.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -12,12 +13,15 @@ import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.common.user.application.adapter.dto.ExternalUserDTO;
 import fr.avenirsesr.portfolio.common.user.domain.exceptions.ExternalUserNotFoundException;
 import fr.avenirsesr.portfolio.common.user.domain.model.enums.EUserStatus;
+import fr.avenirsesr.portfolio.notification.domain.port.output.repository.NotificationRepository;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.user.domain.data.UserQuickLinksData;
 import fr.avenirsesr.portfolio.user.domain.port.input.StaffService;
 import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
 import fr.avenirsesr.portfolio.user.domain.port.output.client.ExternalUserClient;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.UserPrincipalRepository;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.UserRepository;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.StaffFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.util.Optional;
@@ -36,6 +40,7 @@ class UserServiceImplTest {
   @Mock private StudentService studentService;
   @Mock private ExternalUserClient externalUserClient;
   @Mock private LoggedInUserService loggedInUserService;
+  @Mock private NotificationRepository notificationRepository;
 
   private UserServiceImpl userService;
   private User loggedUser;
@@ -51,7 +56,8 @@ class UserServiceImplTest {
             staffService,
             studentService,
             externalUserClient,
-            loggedInUserService);
+            loggedInUserService,
+            notificationRepository);
   }
 
   @Nested
@@ -370,6 +376,103 @@ class UserServiceImplTest {
       verify(userRepository).save(userCaptor.capture());
 
       assertFalse(userCaptor.getValue().isNotificationEnabled());
+    }
+  }
+
+  @Nested
+  class GetQuickLinks {
+
+    @Test
+    void shouldReturnQuickLinksDataForStudent() {
+      var user =
+          UserFixture.create()
+              .withFirstName("Lucas")
+              .withLastName("Tessier")
+              .withNotificationEnabled(true)
+              .toModel();
+      var student =
+          StudentFixture.create()
+              .withId(user.getId())
+              .withUser(user)
+              .withHasUnseenNotification(true)
+              .toModel();
+
+      BddLogger.given("a logged student with unseen notifications and 3 unread messages");
+      when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+      when(notificationRepository.countUnreadByUserAndCategory(user.getId(), EUserCategory.STUDENT))
+          .thenReturn(3L);
+
+      BddLogger.when("getting quick links for STUDENT category");
+      UserQuickLinksData result = userService.getQuickLinks(EUserCategory.STUDENT);
+
+      BddLogger.then("it should return the correct quick links data");
+      assertThat(result.userId()).isEqualTo(user.getId());
+      assertThat(result.firstname()).isEqualTo("Lucas");
+      assertThat(result.lastname()).isEqualTo("Tessier");
+      assertThat(result.hasUnseenNotification()).isTrue();
+      assertThat(result.unreadNotifications()).isEqualTo(3);
+      assertThat(result.notificationEnabled()).isTrue();
+
+      verify(loggedInUserService).getLoggedInStudent();
+      verify(notificationRepository)
+          .countUnreadByUserAndCategory(user.getId(), EUserCategory.STUDENT);
+      verifyNoInteractions(staffService);
+    }
+
+    @Test
+    void shouldReturnQuickLinksDataForStaff() {
+      var user =
+          UserFixture.create()
+              .withFirstName("Marie")
+              .withLastName("Dupont")
+              .withNotificationEnabled(false)
+              .toModel();
+      var staff =
+          StaffFixture.create()
+              .withId(user.getId())
+              .withUser(user)
+              .withHasUnseenNotification(false)
+              .toModel();
+
+      BddLogger.given("a logged staff member with no unseen notifications and 0 unread messages");
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(notificationRepository.countUnreadByUserAndCategory(user.getId(), EUserCategory.STAFF))
+          .thenReturn(0L);
+
+      BddLogger.when("getting quick links for STAFF category");
+      UserQuickLinksData result = userService.getQuickLinks(EUserCategory.STAFF);
+
+      BddLogger.then("it should return the correct quick links data");
+      assertThat(result.userId()).isEqualTo(user.getId());
+      assertThat(result.firstname()).isEqualTo("Marie");
+      assertThat(result.lastname()).isEqualTo("Dupont");
+      assertThat(result.hasUnseenNotification()).isFalse();
+      assertThat(result.unreadNotifications()).isZero();
+      assertThat(result.notificationEnabled()).isFalse();
+
+      verify(loggedInUserService).getLoggedInStaff();
+      verify(notificationRepository)
+          .countUnreadByUserAndCategory(user.getId(), EUserCategory.STAFF);
+      verifyNoInteractions(studentService);
+    }
+
+    @Test
+    void shouldReturnZeroUnreadNotificationsWhenRepositoryReturnsZero() {
+      var student = StudentFixture.create().withHasUnseenNotification(false).toModel();
+      var user = UserFixture.create().withId(student.getId()).toModel();
+
+      BddLogger.given("a student with no unread notifications");
+      when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+      when(notificationRepository.countUnreadByUserAndCategory(user.getId(), EUserCategory.STUDENT))
+          .thenReturn(0L);
+
+      BddLogger.when("getting quick links for STUDENT");
+      UserQuickLinksData result = userService.getQuickLinks(EUserCategory.STUDENT);
+
+      BddLogger.then(
+          "unreadNotifications should be zero and hasUnseenNotification should be false");
+      assertThat(result.unreadNotifications()).isZero();
+      assertThat(result.hasUnseenNotification()).isFalse();
     }
   }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Extracts quick links data from the profile overview response into a dedicated `QuickLinksDTO`. A new endpoint `GET /users/{userCategory}/quick-links` is added to `UserController`, backed by `UserService`/`UserServiceImpl` and a new `UserQuickLinksData` domain object. Also includes a submit feedback endpoint added to `FeedbackController`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1922

---

### Documentation
> _Detail any updates made to documentation, configuration steps, or technical specs._

---

### Target Branch
> `develop`

---

### Additional Notes
> The quick links data is now served through a dedicated lightweight DTO and endpoint, decoupled from the full profile overview payload. Integration and unit tests have been added for all new service and controller logic.

---

### Known Limitations or Side Effects
> _List any limitations, known bugs, or side effects this PR may introduce._

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process