### PR TITLE
fix(1923): fix ODT file size limit from 510 Mo to 10 Mo

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/file/domain/model/enums/EFileType.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/domain/model/enums/EFileType.java
@@ -57,7 +57,7 @@ public enum EFileType {
   X_MSEXCEL(FileSize.of(10, FileSize.Unit.Mo), "application/x-msexcel"),
   XLS_VND(FileSize.of(10, FileSize.Unit.Mo), "application/vnd.ms-excel"),
   PPT_VND(FileSize.of(10, FileSize.Unit.Mo), "application/vnd.ms-powerpoint"),
-  ODT(FileSize.of(510, FileSize.Unit.Mo), "application/vnd.oasis.opendocument.text"),
+  ODT(FileSize.of(10, FileSize.Unit.Mo), "application/vnd.oasis.opendocument.text"),
   VSD(FileSize.of(10, FileSize.Unit.Mo), "application/vnd.visio"),
   RTF(FileSize.of(10, FileSize.Unit.Mo), "application/rtf"),
   X_RTF(FileSize.of(10, FileSize.Unit.Mo), "application/x-rtf"),


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Fixes an incorrect ODT file size limit that was set to 510 Mo instead of the expected 10 Mo, consistent with all other supported file types. The `avenirs-portfolio-common` submodule is also updated accordingly.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1923

---

### Documentation
> No documentation changes required.

---

### Target Branch
> `develop`

---

### Additional Notes
> The erroneous value (510 Mo) was likely a typo (5 prepended to 10). The fix aligns ODT with every other office document format in `EFileType`.

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process