### PR TITLE
fix(1942): add required properties on FeedbackOverviewDTO schema

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/FeedbackOverviewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/FeedbackOverviewDTO.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.UUID;
 
+@Schema(requiredProperties = {"id", "staff", "student", "status", "createdAt", "updatedAt"})
 public record FeedbackOverviewDTO(
     UUID id,
     UserInfoDTO staff,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Add `@Schema(requiredProperties = {...})` annotation to `FeedbackOverviewDTO` to declare `id`, `staff`, `student`, `status`, `createdAt`, and `updatedAt` as required fields in the OpenAPI specification.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1942

---

### Documentation
> No documentation update needed. The change only affects the OpenAPI schema metadata generated for `FeedbackOverviewDTO`.

---

### Target Branch
> `develop`

---

### Additional Notes
> Without `requiredProperties`, the OpenAPI spec was not marking these fields as required, which could lead to incorrect client code generation.

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process