### PR TITLE
fix(1946): pass feedback status to in process when fetched

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -130,6 +130,8 @@ public class FeedbackServiceImpl implements FeedbackService {
       throw new UserNotAuthorizedException();
     }
 
+    if (feedback.getStatus() == EFeedbackStatus.NEW) feedback.setStatus(EFeedbackStatus.IN_PROCESS);
+
     return new FeedbackData(
         feedback.getId(),
         feedback.getCreatedAt(),

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -563,6 +563,68 @@ class FeedbackServiceImplTest {
     }
 
     @Test
+    void should_set_status_to_IN_PROCESS_when_staff_fetches_NEW_feedback() {
+      BddLogger.given(
+          "A logged-in staff who is the author of the activity fetching a NEW feedback");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              "Réflexion",
+              null,
+              EFeedbackStatus.NEW,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+
+      BddLogger.when("getFeedbackDetails is called with STAFF category");
+      FeedbackData result = service.getFeedbackDetails(feedbackId, EUserCategory.STAFF);
+
+      BddLogger.then("The returned FeedbackData has status IN_PROCESS");
+      assertThat(result.status()).isEqualTo(EFeedbackStatus.IN_PROCESS);
+    }
+
+    @Test
+    void should_not_change_status_when_staff_fetches_feedback_already_IN_PROCESS() {
+      BddLogger.given(
+          "A logged-in staff who is the author of the activity fetching an IN_PROCESS feedback");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
+      Feedback feedback =
+          Feedback.toDomain(
+              feedbackId,
+              Instant.now(),
+              Instant.now(),
+              DeclaredActivity.create(
+                  UUID.randomUUID(), student, activity, null, null, null, null, null),
+              "Réflexion",
+              null,
+              EFeedbackStatus.IN_PROCESS,
+              1,
+              List.of(),
+              List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+
+      BddLogger.when("getFeedbackDetails is called with STAFF category");
+      FeedbackData result = service.getFeedbackDetails(feedbackId, EUserCategory.STAFF);
+
+      BddLogger.then("The returned FeedbackData still has status IN_PROCESS");
+      assertThat(result.status()).isEqualTo(EFeedbackStatus.IN_PROCESS);
+    }
+
+    @Test
     void should_throw_UserNotAuthorizedException_when_staff_is_not_author() {
       BddLogger.given("A logged-in user who is NOT the author of the activity");
       UUID feedbackId = UUID.randomUUID();


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> When a staff member fetches a feedback with status `NEW`, the status is automatically transitioned to `IN_PROCESS`. This ensures the feedback lifecycle is correctly reflected as soon as the staff opens it.
> Two unit tests were added to cover: the NEW → IN_PROCESS transition and the case where the status is already IN_PROCESS (no change).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1946

---

### Documentation
> No documentation update required.

---

### Target Branch
> `develop`

---

### Additional Notes
> The status transition is applied in `getStaffFeedbackDetails` before building the `FeedbackData` response.

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process