### PR TITLE
feat(1951): add exhaustive feedback list endpoint by activity

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
@@ -6,15 +6,18 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.StudentFeedbackItemListDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.UpdateFeedbackRequest;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackDetailsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackStaffListItemDTOMapper;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.StudentFeedbackItemListDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.security.Principal;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +40,7 @@ public class FeedbackController {
   private final FeedbackService feedbackService;
   private final FeedbackDetailsDTOMapper feedbackDetailsDTOMapper;
   private final FeedbackStaffListItemDTOMapper feedbackStaffListItemDTOMapper;
+  private final StudentFeedbackItemListDTOMapper studentFeedbackItemListDTOMapper;
 
   @GetMapping
   public ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> getStaffFeedbacks(
@@ -61,6 +65,19 @@ public class FeedbackController {
         new PagedResponse<>(
             result.content().stream().map(feedbackStaffListItemDTOMapper::toDTO).toList(),
             PageInfoDTO.fromDomain(result.pageInfo())));
+  }
+
+  @GetMapping("/exhaustive-list/{activityId}")
+  public ResponseEntity<List<StudentFeedbackItemListDTO>> getFeedbacksByActivity(
+      Principal principal, @PathVariable UUID activityId) {
+    log.debug(
+        "Received request to get all feedbacks for activity [{}] by user [{}]",
+        activityId,
+        principal.getName());
+    return ResponseEntity.ok(
+        feedbackService.getFeedbacksByActivity(activityId).stream()
+            .map(studentFeedbackItemListDTOMapper::toDTO)
+            .toList());
   }
 
   @GetMapping("/{userCategory}/{feedbackId}")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/StudentFeedbackItemListDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/StudentFeedbackItemListDTO.java
@@ -1,0 +1,8 @@
+package fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto;
+
+import fr.avenirsesr.portfolio.user.application.adapter.dto.UserInfoDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(requiredProperties = {"id", "student"})
+public record StudentFeedbackItemListDTO(UUID feedbackId, UserInfoDTO student) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/StudentFeedbackItemListDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/StudentFeedbackItemListDTOMapper.java
@@ -1,0 +1,14 @@
+package fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper;
+
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.StudentFeedbackItemListDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface StudentFeedbackItemListDTOMapper {
+
+  @Mapping(source = "declaredActivity.student.user", target = "student")
+  @Mapping(source = "feedback.id", target = "feedbackId")
+  StudentFeedbackItemListDTO toDTO(Feedback feedback);
+}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
@@ -23,6 +23,8 @@ public interface FeedbackService {
   PagedResult<Feedback> getStaffFeedbacks(
       EFeedbackStatus statusFilter, UUID activityId, PageCriteria pageCriteria);
 
+  List<Feedback> getFeedbacksByActivity(UUID activityId);
+
   void submitFeedback(UUID feedbackId);
 
   Set<UUID> findAttachmentIdsUsedByTraceSnapshots(

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/FeedbackRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/FeedbackRepository.java
@@ -15,6 +15,8 @@ public interface FeedbackRepository extends GenericRepositoryPort<Feedback> {
   PagedResult<Feedback> findByStaff(
       UUID staffId, EFeedbackStatus statusFilter, UUID activityId, PageCriteria pageCriteria);
 
+  List<Feedback> findAllByStaffAndActivity(UUID staffId, UUID activityId);
+
   List<UUID> findDeclaredActivityIdsHavingActiveFeedbacks(List<UUID> declaredActivityIds);
 
   Set<UUID> findAttachmentIdsUsedByTraceSnapshots(

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -197,6 +197,12 @@ public class FeedbackServiceImpl implements FeedbackService {
   }
 
   @Override
+  public List<Feedback> getFeedbacksByActivity(UUID activityId) {
+    var staff = loggedInUserService.getLoggedInStaff();
+    return feedbackRepository.findAllByStaffAndActivity(staff.getId(), activityId);
+  }
+
+  @Override
   public void submitFeedback(UUID feedbackId) {
     Feedback feedback =
         feedbackRepository.findById(feedbackId).orElseThrow(FeedbackNotFoundException::new);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
@@ -130,6 +130,17 @@ public class FeedbackDatabaseRepository
   }
 
   @Override
+  public List<Feedback> findAllByStaffAndActivity(UUID staffId, UUID activityId) {
+    var specification =
+        FeedbackSpecification.hasStaffAuthor(staffId)
+            .and(FeedbackSpecification.hasActivityId(activityId));
+    var sort = Sort.by("status").ascending().and(Sort.by("createdAt").ascending());
+    return jpaRepository.findAll(specification, sort).stream()
+        .map(this::toDomainWithDependencies)
+        .toList();
+  }
+
+  @Override
   public List<UUID> findDeclaredActivityIdsHavingActiveFeedbacks(List<UUID> declaredActivityIds) {
     if (declaredActivityIds.isEmpty()) {
       return List.of();

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
@@ -561,6 +561,113 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
         .isForbidden();
   }
 
+  // ── GET /me/activity-progress/feedbacks/exhaustive-list/{activityId} ──
+
+  @Test
+  void shouldReturn401WhenNotAuthenticatedOnExhaustiveListEndpoint() {
+    BddLogger.given(
+        "the GET /me/activity-progress/feedbacks/exhaustive-list/{activityId} endpoint");
+    BddLogger.when("performing a GET without authentication headers");
+    BddLogger.then("401 Unauthorized is returned");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/exhaustive-list/" + ACTIVITY_ID)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+  }
+
+  @Test
+  void shouldReturn403WhenStudentTriesToAccessExhaustiveListEndpoint() {
+    BddLogger.given("a user who is not registered as staff");
+    BddLogger.when("performing a GET on the exhaustive list endpoint");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/exhaustive-list/" + ACTIVITY_ID)
+        .header("X-Signed-Context", otherStudentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", otherStudentSignature)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  void shouldReturnArrayStructureOnExhaustiveListEndpoint() {
+    BddLogger.given("a staff who has authored activities with seeded feedbacks");
+    BddLogger.when("performing a GET on the exhaustive list endpoint for the seeded activity");
+    BddLogger.then("200 OK is returned with a JSON array");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/exhaustive-list/" + ACTIVITY_ID)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$")
+        .isArray();
+  }
+
+  @Test
+  void shouldReturnFeedbacksWithCorrectShapeOnExhaustiveListEndpoint() {
+    BddLogger.given("a staff who has authored activities with seeded feedbacks");
+    BddLogger.when("performing a GET on the exhaustive list endpoint for the seeded activity");
+    BddLogger.then(
+        "each item in the response has an id and a student with id, firstName, lastName, email");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/exhaustive-list/" + ACTIVITY_ID)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$[0].feedbackId")
+        .isNotEmpty()
+        .jsonPath("$[0].student")
+        .isNotEmpty()
+        .jsonPath("$[0].student.id")
+        .isNotEmpty()
+        .jsonPath("$[0].student.firstName")
+        .isNotEmpty()
+        .jsonPath("$[0].student.lastName")
+        .isNotEmpty()
+        .jsonPath("$[0].student.email")
+        .isNotEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyArrayForUnknownActivityIdOnExhaustiveListEndpoint() {
+    BddLogger.given("a staff user and an activityId that has no associated feedbacks");
+    BddLogger.when("performing a GET on the exhaustive list endpoint for the unknown activity");
+    BddLogger.then("200 OK is returned with an empty array");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/exhaustive-list/" + notFoundId)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$")
+        .isArray()
+        .jsonPath("$.length()")
+        .isEqualTo(0);
+  }
+
   @Test
   @Transactional
   void shouldReturnOnlyFeedbacksMatchingActivityIdFilter() throws Exception {

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
@@ -13,9 +13,11 @@ import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.StudentFeedbackItemListDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.UpdateFeedbackRequest;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackDetailsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackStaffListItemDTOMapper;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.StudentFeedbackItemListDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
@@ -39,6 +41,7 @@ class FeedbackControllerTest {
   @Mock private FeedbackService feedbackService;
   @Mock private FeedbackDetailsDTOMapper feedbackDetailsDTOMapper;
   @Mock private FeedbackStaffListItemDTOMapper feedbackStaffListItemDTOMapper;
+  @Mock private StudentFeedbackItemListDTOMapper studentFeedbackItemListDTOMapper;
 
   @InjectMocks private FeedbackController controller;
 
@@ -321,5 +324,71 @@ class FeedbackControllerTest {
     BddLogger.then("The service is called exactly once with the correct feedback ID");
     verify(feedbackService, times(1)).submitFeedback(feedbackId);
     verifyNoMoreInteractions(feedbackService);
+  }
+
+  @Test
+  void getFeedbacksByActivity_should_return_200_with_mapped_list() {
+    BddLogger.given("A logged-in staff and an activity with two feedbacks");
+
+    UUID activityId = UUID.randomUUID();
+    Feedback feedback1 = mock(Feedback.class);
+    Feedback feedback2 = mock(Feedback.class);
+    StudentFeedbackItemListDTO dto1 = mock(StudentFeedbackItemListDTO.class);
+    StudentFeedbackItemListDTO dto2 = mock(StudentFeedbackItemListDTO.class);
+
+    when(feedbackService.getFeedbacksByActivity(activityId))
+        .thenReturn(List.of(feedback1, feedback2));
+    when(studentFeedbackItemListDTOMapper.toDTO(feedback1)).thenReturn(dto1);
+    when(studentFeedbackItemListDTOMapper.toDTO(feedback2)).thenReturn(dto2);
+
+    BddLogger.when("getFeedbacksByActivity is called");
+    ResponseEntity<List<StudentFeedbackItemListDTO>> response =
+        controller.getFeedbacksByActivity(principal, activityId);
+
+    BddLogger.then("200 OK is returned with 2 mapped items");
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).containsExactly(dto1, dto2);
+
+    verify(feedbackService).getFeedbacksByActivity(activityId);
+    verify(studentFeedbackItemListDTOMapper).toDTO(feedback1);
+    verify(studentFeedbackItemListDTOMapper).toDTO(feedback2);
+  }
+
+  @Test
+  void getFeedbacksByActivity_should_forward_activityId_to_service() {
+    BddLogger.given("A specific activity ID");
+
+    UUID activityId = UUID.randomUUID();
+    Feedback feedback = mock(Feedback.class);
+
+    when(feedbackService.getFeedbacksByActivity(activityId)).thenReturn(List.of(feedback));
+    when(studentFeedbackItemListDTOMapper.toDTO(feedback))
+        .thenReturn(mock(StudentFeedbackItemListDTO.class));
+
+    BddLogger.when("getFeedbacksByActivity is called");
+    controller.getFeedbacksByActivity(principal, activityId);
+
+    BddLogger.then("The service is called exactly once with the correct activityId");
+    verify(feedbackService, times(1)).getFeedbacksByActivity(activityId);
+    verifyNoMoreInteractions(feedbackService);
+  }
+
+  @Test
+  void getFeedbacksByActivity_should_return_empty_list_when_activity_has_no_feedbacks() {
+    BddLogger.given("An activity ID for which no feedbacks exist");
+
+    UUID activityId = UUID.randomUUID();
+
+    when(feedbackService.getFeedbacksByActivity(activityId)).thenReturn(List.of());
+
+    BddLogger.when("getFeedbacksByActivity is called");
+    ResponseEntity<List<StudentFeedbackItemListDTO>> response =
+        controller.getFeedbacksByActivity(principal, activityId);
+
+    BddLogger.then("200 OK is returned with an empty list");
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEmpty();
+
+    verifyNoInteractions(studentFeedbackItemListDTOMapper);
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/StudentFeedbackItemListDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/StudentFeedbackItemListDTOMapperTest.java
@@ -1,0 +1,79 @@
+package fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fr.avenirsesr.portfolio.activity.infrastructure.fixture.ActivityFixture;
+import fr.avenirsesr.portfolio.common.testutils.BddLogger;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.StudentFeedbackItemListDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
+import fr.avenirsesr.portfolio.user.domain.model.Student;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StudentFeedbackItemListDTOMapperTest {
+
+  @InjectMocks private StudentFeedbackItemListDTOMapperImpl mapper;
+
+  private Feedback buildFeedback(Student student) {
+    var activity = ActivityFixture.create().toModel();
+    DeclaredActivity declaredActivity =
+        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null);
+    return Feedback.toDomain(
+        UUID.randomUUID(),
+        Instant.now(),
+        Instant.now(),
+        declaredActivity,
+        null,
+        null,
+        EFeedbackStatus.NEW,
+        1,
+        List.of(),
+        List.of());
+  }
+
+  @Test
+  void should_map_id_and_student_from_feedback() {
+    BddLogger.given("A feedback linked to a declared activity with a student");
+    Student student = StudentFixture.create().toModel();
+    Feedback feedback = buildFeedback(student);
+
+    BddLogger.when("mapping to StudentFeedbackItemListDTO");
+    StudentFeedbackItemListDTO dto = mapper.toDTO(feedback);
+
+    BddLogger.then("id and all student fields are correctly mapped");
+    assertThat(dto).isNotNull();
+    assertThat(dto.feedbackId()).isEqualTo(feedback.getId());
+    assertThat(dto.student()).isNotNull();
+    assertThat(dto.student().id()).isEqualTo(student.getUser().getId());
+    assertThat(dto.student().firstName()).isEqualTo(student.getUser().getFirstName());
+    assertThat(dto.student().lastName()).isEqualTo(student.getUser().getLastName());
+    assertThat(dto.student().email()).isEqualTo(student.getUser().getEmail());
+  }
+
+  @Test
+  void should_map_student_independently_per_feedback() {
+    BddLogger.given("Two feedbacks belonging to two different students");
+    Student student1 = StudentFixture.create().toModel();
+    Student student2 = StudentFixture.create().toModel();
+    Feedback feedback1 = buildFeedback(student1);
+    Feedback feedback2 = buildFeedback(student2);
+
+    BddLogger.when("mapping both feedbacks independently");
+    StudentFeedbackItemListDTO dto1 = mapper.toDTO(feedback1);
+    StudentFeedbackItemListDTO dto2 = mapper.toDTO(feedback2);
+
+    BddLogger.then("each dto carries the correct student identity");
+    assertThat(dto1.student().id()).isEqualTo(student1.getUser().getId());
+    assertThat(dto2.student().id()).isEqualTo(student2.getUser().getId());
+    assertThat(dto1.feedbackId()).isNotEqualTo(dto2.feedbackId());
+  }
+}

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -1038,6 +1038,80 @@ class FeedbackServiceImplTest {
   }
 
   @Nested
+  class GetFeedbacksByActivity {
+
+    @Test
+    void should_return_feedbacks_from_repository_for_logged_in_staff_and_activity() {
+      BddLogger.given("A logged-in staff and an activityId with two existing feedbacks");
+      UUID activityId = UUID.randomUUID();
+      Staff staff = StaffFixture.create().toModel();
+      Feedback feedback1 = mock(Feedback.class);
+      Feedback feedback2 = mock(Feedback.class);
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(feedbackRepository.findAllByStaffAndActivity(staff.getId(), activityId))
+          .thenReturn(List.of(feedback1, feedback2));
+
+      BddLogger.when("getFeedbacksByActivity is called");
+      List<Feedback> result = service.getFeedbacksByActivity(activityId);
+
+      BddLogger.then("The full list from the repository is returned");
+      assertThat(result).containsExactly(feedback1, feedback2);
+      verify(feedbackRepository).findAllByStaffAndActivity(staff.getId(), activityId);
+    }
+
+    @Test
+    void should_return_empty_list_when_activity_has_no_feedbacks() {
+      BddLogger.given("A logged-in staff and an activityId with no feedbacks");
+      UUID activityId = UUID.randomUUID();
+      Staff staff = StaffFixture.create().toModel();
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(feedbackRepository.findAllByStaffAndActivity(staff.getId(), activityId))
+          .thenReturn(List.of());
+
+      BddLogger.when("getFeedbacksByActivity is called");
+      List<Feedback> result = service.getFeedbacksByActivity(activityId);
+
+      BddLogger.then("An empty list is returned");
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_pass_staff_id_to_repository_to_scope_results_to_logged_in_staff() {
+      BddLogger.given("Two distinct staff users and the same activityId");
+      UUID activityId = UUID.randomUUID();
+      Staff staff = StaffFixture.create().toModel();
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(feedbackRepository.findAllByStaffAndActivity(staff.getId(), activityId))
+          .thenReturn(List.of());
+
+      BddLogger.when("getFeedbacksByActivity is called");
+      service.getFeedbacksByActivity(activityId);
+
+      BddLogger.then("The repository is called with the logged-in staff's ID — not any other ID");
+      verify(feedbackRepository).findAllByStaffAndActivity(staff.getId(), activityId);
+    }
+
+    @Test
+    void should_throw_UserIsNotStaffException_when_logged_in_user_is_not_staff() {
+      BddLogger.given("A logged-in user who is not registered as staff");
+      UUID activityId = UUID.randomUUID();
+
+      when(loggedInUserService.getLoggedInStaff()).thenThrow(new UserIsNotStaffException());
+
+      BddLogger.when("getFeedbacksByActivity is called");
+
+      BddLogger.then("A UserIsNotStaffException is thrown and the repository is never called");
+      assertThatThrownBy(() -> service.getFeedbacksByActivity(activityId))
+          .isInstanceOf(UserIsNotStaffException.class);
+
+      verify(feedbackRepository, never()).findAllByStaffAndActivity(any(), any());
+    }
+  }
+
+  @Nested
   class FindAttachmentIdsUsedByTraceSnapshots {
 
     @Test


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a new non-paginated endpoint `GET /me/activity-progress/feedbacks/exhaustive-list/{activityId}` that returns the full list of feedbacks for a given activity, scoped to the logged-in staff. Each item exposes only the feedback `id` and the `student` (`UserInfoDTO`). The implementation follows the hexagonal architecture already in place: new DTO, MapStruct mapper, service method, and repository method reusing existing `FeedbackSpecification`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1951

---

### Documentation
> No documentation changes required. The endpoint is self-describing and follows the existing OpenAPI conventions on the controller.

---

### Target Branch
> `develop`

---

### Additional Notes
> - The result is intentionally non-paginated: the consumer needs the exhaustive list to work with all feedbacks for an activity at once.
> - Security is preserved: the repository query is scoped by `staffId` (logged-in staff must be the activity author) via the existing `FeedbackSpecification.hasStaffAuthor`.
> - Sort order matches `getStaffFeedbacks`: status ascending then createdAt ascending.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process