### PR TITLE
feat(1761): add feedback dashboard endpoint with status counts

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
@@ -4,6 +4,7 @@ import fr.avenirsesr.portfolio.common.data.application.adapter.dto.PageInfoDTO;
 import fr.avenirsesr.portfolio.common.data.application.adapter.response.PagedResponse;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDashboardDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.StudentFeedbackItemListDTO;
@@ -115,6 +116,22 @@ public class FeedbackController {
         principal.getName());
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(feedbackDetailsDTOMapper.toDTO(feedbackService.createFeedback(declaredActivityId)));
+  }
+
+  @GetMapping("/dashboard")
+  public ResponseEntity<FeedbackDashboardDTO> getFeedbackDashboard(
+      Principal principal, @RequestParam(required = false) UUID activityId) {
+    log.debug(
+        "Received request to get feedback dashboard for user [{}] (activityId={})",
+        principal.getName(),
+        activityId);
+    var dashboard = feedbackService.getFeedbackDashboard(activityId);
+    return ResponseEntity.ok(
+        new FeedbackDashboardDTO(
+            dashboard.newFeedbacks(),
+            dashboard.pendingFeedbacks(),
+            dashboard.processedFeedbacks(),
+            dashboard.totalFeedbacks()));
   }
 
   @PostMapping("/{feedbackId}/submit")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/FeedbackDashboardDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/FeedbackDashboardDTO.java
@@ -1,0 +1,13 @@
+package fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    requiredProperties = {
+      "newFeedbacks",
+      "pendingFeedbacks",
+      "processedFeedbacks",
+      "totalFeedbacks"
+    })
+public record FeedbackDashboardDTO(
+    int newFeedbacks, int pendingFeedbacks, int processedFeedbacks, int totalFeedbacks) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/data/FeedbackDashboard.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/data/FeedbackDashboard.java
@@ -1,0 +1,4 @@
+package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data;
+
+public record FeedbackDashboard(
+    int newFeedbacks, int pendingFeedbacks, int processedFeedbacks, int totalFeedbacks) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
@@ -4,6 +4,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
@@ -29,4 +30,6 @@ public interface FeedbackService {
 
   Set<UUID> findAttachmentIdsUsedByTraceSnapshots(
       List<UUID> declaredActivityIds, List<UUID> traceIds);
+
+  FeedbackDashboard getFeedbackDashboard(UUID activityId);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/FeedbackRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/FeedbackRepository.java
@@ -3,6 +3,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.o
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.port.output.repository.GenericRepositoryPort;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import java.util.List;
@@ -21,4 +22,6 @@ public interface FeedbackRepository extends GenericRepositoryPort<Feedback> {
 
   Set<UUID> findAttachmentIdsUsedByTraceSnapshots(
       List<UUID> declaredActivityIds, List<UUID> traceIds);
+
+  FeedbackDashboard countDashboard(UUID staffId, UUID activityId);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -16,6 +16,7 @@ import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorize
 import fr.avenirsesr.portfolio.notification.domain.model.notification.AskForFeedbackNotification;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackInProcessException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackMaximumIterationReachedException;
@@ -228,5 +229,11 @@ public class FeedbackServiceImpl implements FeedbackService {
     }
 
     return feedbackRepository.findAttachmentIdsUsedByTraceSnapshots(declaredActivityIds, traceIds);
+  }
+
+  @Override
+  public FeedbackDashboard getFeedbackDashboard(UUID activityId) {
+    var staff = loggedInUserService.getLoggedInStaff();
+    return feedbackRepository.countDashboard(staff.getId(), activityId);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
@@ -13,6 +13,7 @@ import fr.avenirsesr.portfolio.declaredskill.infrastructure.adapter.repository.D
 import fr.avenirsesr.portfolio.file.domain.model.File;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.mapper.FileMapper;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.repository.FileJpaRepository;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
@@ -153,6 +154,29 @@ public class FeedbackDatabaseRepository
   public Set<UUID> findAttachmentIdsUsedByTraceSnapshots(
       List<UUID> declaredActivityIds, List<UUID> traceIds) {
     return jpaRepository.findAttachmentIdsUsedByTraceSnapshots(declaredActivityIds, traceIds);
+  }
+
+  @Override
+  public FeedbackDashboard countDashboard(UUID staffId, UUID activityId) {
+    var baseSpec =
+        FeedbackSpecification.hasStaffAuthor(staffId)
+            .and(FeedbackSpecification.hasActivityId(activityId));
+
+    long newCount =
+        jpaRepository.count(baseSpec.and(FeedbackSpecification.hasStatus(EFeedbackStatus.NEW)));
+    long inProcessCount =
+        jpaRepository.count(
+            baseSpec.and(FeedbackSpecification.hasStatus(EFeedbackStatus.IN_PROCESS)));
+    long processedCount =
+        jpaRepository.count(
+            baseSpec.and(FeedbackSpecification.hasStatus(EFeedbackStatus.SUBMITTED)));
+
+    long pendingCount = newCount + inProcessCount;
+    return new FeedbackDashboard(
+        (int) newCount,
+        (int) pendingCount,
+        (int) processedCount,
+        (int) (pendingCount + processedCount));
   }
 
   // ── private helpers ─────────────────────────────────────────────────

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
@@ -668,6 +668,149 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
         .isEqualTo(0);
   }
 
+  // ── GET /me/activity-progress/feedbacks/dashboard ───────────────────
+
+  @Test
+  void shouldReturn401WhenNotAuthenticatedOnDashboardEndpoint() {
+    BddLogger.given("the GET /me/activity-progress/feedbacks/dashboard endpoint");
+    BddLogger.when("performing a GET without authentication headers");
+    BddLogger.then("401 Unauthorized is returned");
+
+    webTestClient.get().uri(BASE_PATH + "/dashboard").exchange().expectStatus().isUnauthorized();
+  }
+
+  @Test
+  void shouldReturn403WhenStudentTriesToAccessDashboardEndpoint() {
+    BddLogger.given("a user who is not registered as staff");
+    BddLogger.when("performing a GET on the dashboard endpoint");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/dashboard")
+        .header("X-Signed-Context", otherStudentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", otherStudentSignature)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  void shouldReturnDashboardWithCorrectShapeForAuthenticatedStaff() {
+    BddLogger.given("a staff user who has authored activities with seeded feedbacks");
+    BddLogger.when("performing a GET on the dashboard endpoint");
+    BddLogger.then("200 OK is returned with the four expected numeric fields");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/dashboard")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.newFeedbacks")
+        .isNumber()
+        .jsonPath("$.pendingFeedbacks")
+        .isNumber()
+        .jsonPath("$.processedFeedbacks")
+        .isNumber()
+        .jsonPath("$.totalFeedbacks")
+        .isNumber();
+  }
+
+  @Test
+  void shouldReturnZeroCountsWhenStaffHasNoFeedbacks() {
+    BddLogger.given("a staff user who is not the author of any activity with feedbacks");
+    BddLogger.when("performing a GET on the dashboard endpoint");
+    BddLogger.then("200 OK is returned with all counts at zero");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/dashboard")
+        .header("X-Signed-Context", staffPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", staffSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.newFeedbacks")
+        .isEqualTo(0)
+        .jsonPath("$.pendingFeedbacks")
+        .isEqualTo(0)
+        .jsonPath("$.processedFeedbacks")
+        .isEqualTo(0)
+        .jsonPath("$.totalFeedbacks")
+        .isEqualTo(0);
+  }
+
+  @Test
+  void shouldReturnConsistentCountsOnDashboard() throws Exception {
+    BddLogger.given("a staff user with seeded feedbacks in various states");
+    BddLogger.when("performing a GET on the dashboard endpoint");
+    BddLogger.then(
+        "totalFeedbacks equals pendingFeedbacks + processedFeedbacks, and newFeedbacks <="
+            + " pendingFeedbacks");
+
+    String body =
+        webTestClient
+            .get()
+            .uri(BASE_PATH + "/dashboard")
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    JsonNode node = objectMapper.readTree(body);
+    int newFeedbacks = node.get("newFeedbacks").asInt();
+    int pendingFeedbacks = node.get("pendingFeedbacks").asInt();
+    int processedFeedbacks = node.get("processedFeedbacks").asInt();
+    int totalFeedbacks = node.get("totalFeedbacks").asInt();
+
+    assertThat(totalFeedbacks).isEqualTo(pendingFeedbacks + processedFeedbacks);
+    assertThat(newFeedbacks).isLessThanOrEqualTo(pendingFeedbacks);
+  }
+
+  @Test
+  void shouldReturnDashboardFilteredByActivityId() {
+    BddLogger.given("a staff user and a request filtered by the seeded activityId");
+    BddLogger.when("performing a GET on the dashboard endpoint with activityId=" + ACTIVITY_ID);
+    BddLogger.then("200 OK is returned with a valid dashboard structure");
+
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path(BASE_PATH + "/dashboard")
+                    .queryParam("activityId", ACTIVITY_ID)
+                    .build())
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.newFeedbacks")
+        .isNumber()
+        .jsonPath("$.pendingFeedbacks")
+        .isNumber()
+        .jsonPath("$.processedFeedbacks")
+        .isNumber()
+        .jsonPath("$.totalFeedbacks")
+        .isNumber();
+  }
+
   @Test
   @Transactional
   void shouldReturnOnlyFeedbacksMatchingActivityIdFilter() throws Exception {

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
@@ -11,6 +11,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDashboardDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.StudentFeedbackItemListDTO;
@@ -18,6 +19,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.activity.application.ad
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackDetailsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackStaffListItemDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.StudentFeedbackItemListDTOMapper;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
@@ -390,5 +392,76 @@ class FeedbackControllerTest {
     assertThat(response.getBody()).isEmpty();
 
     verifyNoInteractions(studentFeedbackItemListDTOMapper);
+  }
+
+  @Test
+  void getFeedbackDashboard_should_return_200_with_correct_counts() {
+    BddLogger.given("A logged-in staff and the service returning a dashboard with counts 2/5/3/8");
+
+    FeedbackDashboard dashboard = new FeedbackDashboard(2, 5, 3, 8);
+    when(feedbackService.getFeedbackDashboard(null)).thenReturn(dashboard);
+
+    BddLogger.when("getFeedbackDashboard is called without activityId");
+    ResponseEntity<FeedbackDashboardDTO> response =
+        controller.getFeedbackDashboard(principal, null);
+
+    BddLogger.then(
+        "200 OK is returned with newFeedbacks=2, pendingFeedbacks=5, processedFeedbacks=3,"
+            + " totalFeedbacks=8");
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().newFeedbacks()).isEqualTo(2);
+    assertThat(response.getBody().pendingFeedbacks()).isEqualTo(5);
+    assertThat(response.getBody().processedFeedbacks()).isEqualTo(3);
+    assertThat(response.getBody().totalFeedbacks()).isEqualTo(8);
+
+    verify(feedbackService).getFeedbackDashboard(null);
+  }
+
+  @Test
+  void getFeedbackDashboard_should_forward_activityId_to_service() {
+    BddLogger.given("A logged-in staff and a specific activityId");
+
+    UUID activityId = UUID.randomUUID();
+    when(feedbackService.getFeedbackDashboard(activityId))
+        .thenReturn(new FeedbackDashboard(1, 1, 0, 1));
+
+    BddLogger.when("getFeedbackDashboard is called with activityId");
+    controller.getFeedbackDashboard(principal, activityId);
+
+    BddLogger.then("The service is called exactly once with the provided activityId");
+    verify(feedbackService, times(1)).getFeedbackDashboard(activityId);
+    verifyNoMoreInteractions(feedbackService);
+  }
+
+  @Test
+  void getFeedbackDashboard_should_return_all_zeros_when_staff_has_no_feedbacks() {
+    BddLogger.given("A logged-in staff with no feedbacks");
+
+    when(feedbackService.getFeedbackDashboard(null)).thenReturn(new FeedbackDashboard(0, 0, 0, 0));
+
+    BddLogger.when("getFeedbackDashboard is called");
+    ResponseEntity<FeedbackDashboardDTO> response =
+        controller.getFeedbackDashboard(principal, null);
+
+    BddLogger.then("200 OK is returned with all counts at zero");
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().newFeedbacks()).isZero();
+    assertThat(response.getBody().pendingFeedbacks()).isZero();
+    assertThat(response.getBody().processedFeedbacks()).isZero();
+    assertThat(response.getBody().totalFeedbacks()).isZero();
+  }
+
+  @Test
+  void getFeedbackDashboard_should_forward_null_activityId_when_not_provided() {
+    BddLogger.given("A logged-in staff calling the dashboard endpoint without activityId");
+
+    when(feedbackService.getFeedbackDashboard(null)).thenReturn(new FeedbackDashboard(0, 0, 0, 0));
+
+    BddLogger.when("getFeedbackDashboard is called with activityId=null");
+    controller.getFeedbackDashboard(principal, null);
+
+    BddLogger.then("The service is called with null activityId");
+    verify(feedbackService).getFeedbackDashboard(null);
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -17,6 +17,7 @@ import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorize
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.DeclaredActivityNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackInProcessException;
@@ -1108,6 +1109,76 @@ class FeedbackServiceImplTest {
           .isInstanceOf(UserIsNotStaffException.class);
 
       verify(feedbackRepository, never()).findAllByStaffAndActivity(any(), any());
+    }
+  }
+
+  @Nested
+  class GetFeedbackDashboard {
+
+    @Test
+    void should_return_dashboard_from_repository_for_logged_in_staff() {
+      BddLogger.given("A logged-in staff and the repository returning a FeedbackDashboard");
+      Staff staff = StaffFixture.create().toModel();
+      FeedbackDashboard expected = new FeedbackDashboard(2, 5, 3, 8);
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(feedbackRepository.countDashboard(staff.getId(), null)).thenReturn(expected);
+
+      BddLogger.when("getFeedbackDashboard is called without activityId");
+      FeedbackDashboard result = service.getFeedbackDashboard(null);
+
+      BddLogger.then("The dashboard from the repository is returned as-is");
+      assertThat(result).isEqualTo(expected);
+      verify(feedbackRepository).countDashboard(staff.getId(), null);
+    }
+
+    @Test
+    void should_forward_activityId_to_repository() {
+      BddLogger.given("A logged-in staff and a specific activityId");
+      UUID activityId = UUID.randomUUID();
+      Staff staff = StaffFixture.create().toModel();
+      FeedbackDashboard expected = new FeedbackDashboard(1, 1, 0, 1);
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(feedbackRepository.countDashboard(staff.getId(), activityId)).thenReturn(expected);
+
+      BddLogger.when("getFeedbackDashboard is called with activityId");
+      FeedbackDashboard result = service.getFeedbackDashboard(activityId);
+
+      BddLogger.then("The repository is called with the activityId and the result is returned");
+      assertThat(result).isEqualTo(expected);
+      verify(feedbackRepository).countDashboard(staff.getId(), activityId);
+    }
+
+    @Test
+    void should_pass_staff_id_to_repository_to_scope_counts_to_logged_in_staff() {
+      BddLogger.given("A logged-in staff");
+      Staff staff = StaffFixture.create().toModel();
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(feedbackRepository.countDashboard(staff.getId(), null))
+          .thenReturn(new FeedbackDashboard(0, 0, 0, 0));
+
+      BddLogger.when("getFeedbackDashboard is called");
+      service.getFeedbackDashboard(null);
+
+      BddLogger.then("The repository is called with the logged-in staff's ID — not any other ID");
+      verify(feedbackRepository).countDashboard(staff.getId(), null);
+    }
+
+    @Test
+    void should_throw_UserIsNotStaffException_when_logged_in_user_is_not_staff() {
+      BddLogger.given("A logged-in user who is not registered as staff");
+
+      when(loggedInUserService.getLoggedInStaff()).thenThrow(new UserIsNotStaffException());
+
+      BddLogger.when("getFeedbackDashboard is called");
+
+      BddLogger.then("A UserIsNotStaffException is thrown and the repository is never called");
+      assertThatThrownBy(() -> service.getFeedbackDashboard(null))
+          .isInstanceOf(UserIsNotStaffException.class);
+
+      verify(feedbackRepository, never()).countDashboard(any(), any());
     }
   }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a new `GET /me/activity-progress/feedbacks/dashboard` endpoint returning a `FeedbackDashboardDTO` with four counters scoped to the logged-in staff:
> - `newFeedbacks` — feedbacks with status `NEW`
> - `pendingFeedbacks` — feedbacks with status `NEW` or `IN_PROCESS` (all non-submitted)
> - `processedFeedbacks` — feedbacks with status `SUBMITTED`
> - `totalFeedbacks` — sum of pending + processed
>
> An optional `activityId` query parameter filters all counts to a single activity.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1761

---

### Documentation
> No documentation update required. The endpoint is exposed via OpenAPI (Swagger) with `@Schema(requiredProperties = {...})` annotations on the response DTO.

---

### Target Branch
> `develop`

---

### Additional Notes
> - `pendingFeedbacks` intentionally includes both `NEW` and `IN_PROCESS` statuses to represent all feedbacks not yet submitted to the student.
> - Counts are computed with 3 JPA `count(Specification)` queries; the total is derived in memory to avoid a 4th query.
> - The `activityId` filter reuses the existing `FeedbackSpecification.hasActivityId` specification.

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process