### PR TITLE
refactor(feedback): replace countDashboard with granular countByStatus

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -140,7 +140,7 @@ public class ActivityServiceImpl implements ActivityService {
 
   @Override
   public Activity getActivityById(UUID id) {
-    return activityRepository.findById(id).orElseThrow(ActivityDraftNotFoundException::new);
+    return activityRepository.findById(id).orElseThrow(ActivityNotFoundException::new);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/data/FeedbackDashboardData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/data/FeedbackDashboardData.java
@@ -1,4 +1,4 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data;
 
-public record FeedbackDashboard(
+public record FeedbackDashboardData(
     int newFeedbacks, int pendingFeedbacks, int processedFeedbacks, int totalFeedbacks) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
@@ -4,7 +4,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboardData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
@@ -31,5 +31,5 @@ public interface FeedbackService {
   Set<UUID> findAttachmentIdsUsedByTraceSnapshots(
       List<UUID> declaredActivityIds, List<UUID> traceIds);
 
-  FeedbackDashboard getFeedbackDashboard(UUID activityId);
+  FeedbackDashboardData getFeedbackDashboard(UUID activityId);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/FeedbackRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/FeedbackRepository.java
@@ -1,11 +1,12 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository;
 
+import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.port.output.repository.GenericRepositoryPort;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
+import fr.avenirsesr.portfolio.user.domain.model.Staff;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -23,5 +24,5 @@ public interface FeedbackRepository extends GenericRepositoryPort<Feedback> {
   Set<UUID> findAttachmentIdsUsedByTraceSnapshots(
       List<UUID> declaredActivityIds, List<UUID> traceIds);
 
-  FeedbackDashboard countDashboard(UUID staffId, UUID activityId);
+  int countByStatus(Staff staff, Activity activity, EFeedbackStatus status);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -5,6 +5,7 @@ import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValida
 import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.validateOptionalEnrichedTextMaxLength;
 import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.validateOptionalTextMaxLength;
 
+import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.association.domain.utils.AssociationUtils;
@@ -16,7 +17,7 @@ import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorize
 import fr.avenirsesr.portfolio.notification.domain.model.notification.AskForFeedbackNotification;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboardData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackInProcessException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackMaximumIterationReachedException;
@@ -48,6 +49,7 @@ public class FeedbackServiceImpl implements FeedbackService {
   private final DeclaredSkillProgressService declaredSkillProgressService;
   private final LoggedInUserService loggedInUserService;
   private final NotificationService notificationService;
+  private final ActivityService activityService;
 
   @Override
   public Feedback createFeedback(UUID declaredActivityId) {
@@ -232,8 +234,24 @@ public class FeedbackServiceImpl implements FeedbackService {
   }
 
   @Override
-  public FeedbackDashboard getFeedbackDashboard(UUID activityId) {
-    var staff = loggedInUserService.getLoggedInStaff();
-    return feedbackRepository.countDashboard(staff.getId(), activityId);
+  public FeedbackDashboardData getFeedbackDashboard(UUID activityId) {
+    Staff staff = loggedInUserService.getLoggedInStaff();
+
+    var activity = activityId != null ? activityService.getActivityById(activityId) : null;
+    if (activity != null) {
+      if (!staff.equals(activity.getAuthor())) {
+        throw new UserNotAuthorizedException();
+      }
+    }
+
+    int newCount = feedbackRepository.countByStatus(staff, activity, EFeedbackStatus.NEW);
+    int inProcessCount =
+        feedbackRepository.countByStatus(staff, activity, EFeedbackStatus.IN_PROCESS);
+    int submittedCount =
+        feedbackRepository.countByStatus(staff, activity, EFeedbackStatus.SUBMITTED);
+
+    int pendingCount = newCount + inProcessCount;
+    return new FeedbackDashboardData(
+        newCount, pendingCount, submittedCount, pendingCount + submittedCount);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.infrastructure.adapter.repository;
 
+import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
@@ -13,7 +14,6 @@ import fr.avenirsesr.portfolio.declaredskill.infrastructure.adapter.repository.D
 import fr.avenirsesr.portfolio.file.domain.model.File;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.mapper.FileMapper;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.repository.FileJpaRepository;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
@@ -21,6 +21,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.activity.infrastructure
 import fr.avenirsesr.portfolio.student.progress.declared.activity.infrastructure.adapter.model.AssociationsJson;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.infrastructure.adapter.model.FeedbackEntity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.infrastructure.adapter.specification.FeedbackSpecification;
+import fr.avenirsesr.portfolio.user.domain.model.Staff;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
@@ -157,26 +158,12 @@ public class FeedbackDatabaseRepository
   }
 
   @Override
-  public FeedbackDashboard countDashboard(UUID staffId, UUID activityId) {
-    var baseSpec =
-        FeedbackSpecification.hasStaffAuthor(staffId)
-            .and(FeedbackSpecification.hasActivityId(activityId));
-
-    long newCount =
-        jpaRepository.count(baseSpec.and(FeedbackSpecification.hasStatus(EFeedbackStatus.NEW)));
-    long inProcessCount =
-        jpaRepository.count(
-            baseSpec.and(FeedbackSpecification.hasStatus(EFeedbackStatus.IN_PROCESS)));
-    long processedCount =
-        jpaRepository.count(
-            baseSpec.and(FeedbackSpecification.hasStatus(EFeedbackStatus.SUBMITTED)));
-
-    long pendingCount = newCount + inProcessCount;
-    return new FeedbackDashboard(
-        (int) newCount,
-        (int) pendingCount,
-        (int) processedCount,
-        (int) (pendingCount + processedCount));
+  public int countByStatus(Staff staff, Activity activity, EFeedbackStatus status) {
+    var spec =
+        FeedbackSpecification.hasStaffAuthor(staff.getId())
+            .and(FeedbackSpecification.hasActivityId(activity != null ? activity.getId() : null))
+            .and(FeedbackSpecification.hasStatus(status));
+    return (int) jpaRepository.count(spec);
   }
 
   // ── private helpers ─────────────────────────────────────────────────

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/service/FeedbackServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/service/FeedbackServiceConfig.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.infrastructure.adapter.service;
 
+import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
@@ -24,6 +25,7 @@ public class FeedbackServiceConfig {
   private final DeclaredSkillProgressService declaredSkillProgressService;
   private final LoggedInUserService loggedInUserService;
   private final NotificationService notificationService;
+  private final ActivityService activityService;
 
   @Bean
   public FeedbackService feedbackService(
@@ -35,6 +37,7 @@ public class FeedbackServiceConfig {
         traceService,
         declaredSkillProgressService,
         loggedInUserService,
-        notificationService);
+        notificationService,
+        activityService);
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
@@ -19,7 +19,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.activity.application.ad
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackDetailsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackStaffListItemDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.StudentFeedbackItemListDTOMapper;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboardData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
@@ -398,7 +398,7 @@ class FeedbackControllerTest {
   void getFeedbackDashboard_should_return_200_with_correct_counts() {
     BddLogger.given("A logged-in staff and the service returning a dashboard with counts 2/5/3/8");
 
-    FeedbackDashboard dashboard = new FeedbackDashboard(2, 5, 3, 8);
+    FeedbackDashboardData dashboard = new FeedbackDashboardData(2, 5, 3, 8);
     when(feedbackService.getFeedbackDashboard(null)).thenReturn(dashboard);
 
     BddLogger.when("getFeedbackDashboard is called without activityId");
@@ -424,7 +424,7 @@ class FeedbackControllerTest {
 
     UUID activityId = UUID.randomUUID();
     when(feedbackService.getFeedbackDashboard(activityId))
-        .thenReturn(new FeedbackDashboard(1, 1, 0, 1));
+        .thenReturn(new FeedbackDashboardData(1, 1, 0, 1));
 
     BddLogger.when("getFeedbackDashboard is called with activityId");
     controller.getFeedbackDashboard(principal, activityId);
@@ -438,7 +438,8 @@ class FeedbackControllerTest {
   void getFeedbackDashboard_should_return_all_zeros_when_staff_has_no_feedbacks() {
     BddLogger.given("A logged-in staff with no feedbacks");
 
-    when(feedbackService.getFeedbackDashboard(null)).thenReturn(new FeedbackDashboard(0, 0, 0, 0));
+    when(feedbackService.getFeedbackDashboard(null))
+        .thenReturn(new FeedbackDashboardData(0, 0, 0, 0));
 
     BddLogger.when("getFeedbackDashboard is called");
     ResponseEntity<FeedbackDashboardDTO> response =
@@ -456,7 +457,8 @@ class FeedbackControllerTest {
   void getFeedbackDashboard_should_forward_null_activityId_when_not_provided() {
     BddLogger.given("A logged-in staff calling the dashboard endpoint without activityId");
 
-    when(feedbackService.getFeedbackDashboard(null)).thenReturn(new FeedbackDashboard(0, 0, 0, 0));
+    when(feedbackService.getFeedbackDashboard(null))
+        .thenReturn(new FeedbackDashboardData(0, 0, 0, 0));
 
     BddLogger.when("getFeedbackDashboard is called with activityId=null");
     controller.getFeedbackDashboard(principal, null);

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import fr.avenirsesr.portfolio.activity.domain.model.Activity;
+import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
 import fr.avenirsesr.portfolio.activity.infrastructure.fixture.ActivityFixture;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
@@ -17,7 +18,7 @@ import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorize
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboard;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboardData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.DeclaredActivityNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackInProcessException;
@@ -58,6 +59,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class FeedbackServiceImplTest {
 
   @Mock private FeedbackRepository feedbackRepository;
+  @Mock private ActivityService activityService;
   @Mock private DeclaredActivityService declaredActivityService;
   @Mock private AssociationService associationService;
   @Mock private TraceService traceService;
@@ -1113,57 +1115,69 @@ class FeedbackServiceImplTest {
   }
 
   @Nested
-  class GetFeedbackDashboard {
+  class GetFeedbackDashboardData {
 
     @Test
-    void should_return_dashboard_from_repository_for_logged_in_staff() {
-      BddLogger.given("A logged-in staff and the repository returning a FeedbackDashboard");
+    void should_aggregate_counts_per_status_when_no_activityId() {
+      BddLogger.given("A logged-in staff and countByStatus returning counts per status");
       Staff staff = StaffFixture.create().toModel();
-      FeedbackDashboard expected = new FeedbackDashboard(2, 5, 3, 8);
 
       when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
-      when(feedbackRepository.countDashboard(staff.getId(), null)).thenReturn(expected);
+      when(feedbackRepository.countByStatus(staff, null, EFeedbackStatus.NEW)).thenReturn(2);
+      when(feedbackRepository.countByStatus(staff, null, EFeedbackStatus.IN_PROCESS)).thenReturn(3);
+      when(feedbackRepository.countByStatus(staff, null, EFeedbackStatus.SUBMITTED)).thenReturn(3);
 
       BddLogger.when("getFeedbackDashboard is called without activityId");
-      FeedbackDashboard result = service.getFeedbackDashboard(null);
+      FeedbackDashboardData result = service.getFeedbackDashboard(null);
 
-      BddLogger.then("The dashboard from the repository is returned as-is");
-      assertThat(result).isEqualTo(expected);
-      verify(feedbackRepository).countDashboard(staff.getId(), null);
+      BddLogger.then(
+          "FeedbackDashboardData is assembled: new=2, pending=5(2+3), processed=3, total=8");
+      assertThat(result).isEqualTo(new FeedbackDashboardData(2, 5, 3, 8));
     }
 
     @Test
-    void should_forward_activityId_to_repository() {
-      BddLogger.given("A logged-in staff and a specific activityId");
+    void should_check_authorship_and_scope_counts_to_activity_when_activityId_provided() {
+      BddLogger.given(
+          "A logged-in staff who is the author of the activity and a specific activityId");
       UUID activityId = UUID.randomUUID();
-      Staff staff = StaffFixture.create().toModel();
-      FeedbackDashboard expected = new FeedbackDashboard(1, 1, 0, 1);
+      Activity activity = ActivityFixture.create().toModel();
+      Staff staff = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
 
       when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
-      when(feedbackRepository.countDashboard(staff.getId(), activityId)).thenReturn(expected);
+      when(activityService.getActivityById(activityId)).thenReturn(activity);
+      when(feedbackRepository.countByStatus(staff, activity, EFeedbackStatus.NEW)).thenReturn(1);
+      when(feedbackRepository.countByStatus(staff, activity, EFeedbackStatus.IN_PROCESS))
+          .thenReturn(0);
+      when(feedbackRepository.countByStatus(staff, activity, EFeedbackStatus.SUBMITTED))
+          .thenReturn(0);
 
       BddLogger.when("getFeedbackDashboard is called with activityId");
-      FeedbackDashboard result = service.getFeedbackDashboard(activityId);
+      FeedbackDashboardData result = service.getFeedbackDashboard(activityId);
 
-      BddLogger.then("The repository is called with the activityId and the result is returned");
-      assertThat(result).isEqualTo(expected);
-      verify(feedbackRepository).countDashboard(staff.getId(), activityId);
+      BddLogger.then("countByStatus is called with the resolved activity and the result assembled");
+      assertThat(result).isEqualTo(new FeedbackDashboardData(1, 1, 0, 1));
+      verify(feedbackRepository).countByStatus(staff, activity, EFeedbackStatus.NEW);
+      verify(feedbackRepository).countByStatus(staff, activity, EFeedbackStatus.IN_PROCESS);
+      verify(feedbackRepository).countByStatus(staff, activity, EFeedbackStatus.SUBMITTED);
     }
 
     @Test
-    void should_pass_staff_id_to_repository_to_scope_counts_to_logged_in_staff() {
-      BddLogger.given("A logged-in staff");
-      Staff staff = StaffFixture.create().toModel();
+    void should_throw_UserNotAuthorizedException_when_staff_is_not_the_activity_author() {
+      BddLogger.given("A logged-in staff who is NOT the author of the requested activity");
+      UUID activityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff differentStaff = StaffFixture.create().toModel();
 
-      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
-      when(feedbackRepository.countDashboard(staff.getId(), null))
-          .thenReturn(new FeedbackDashboard(0, 0, 0, 0));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(differentStaff);
+      when(activityService.getActivityById(activityId)).thenReturn(activity);
 
-      BddLogger.when("getFeedbackDashboard is called");
-      service.getFeedbackDashboard(null);
+      BddLogger.when("getFeedbackDashboard is called with the activityId");
 
-      BddLogger.then("The repository is called with the logged-in staff's ID — not any other ID");
-      verify(feedbackRepository).countDashboard(staff.getId(), null);
+      BddLogger.then("A UserNotAuthorizedException is thrown and no counts are fetched");
+      assertThatThrownBy(() -> service.getFeedbackDashboard(activityId))
+          .isInstanceOf(UserNotAuthorizedException.class);
+
+      verify(feedbackRepository, never()).countByStatus(any(), any(), any());
     }
 
     @Test
@@ -1178,7 +1192,7 @@ class FeedbackServiceImplTest {
       assertThatThrownBy(() -> service.getFeedbackDashboard(null))
           .isInstanceOf(UserIsNotStaffException.class);
 
-      verify(feedbackRepository, never()).countDashboard(any(), any());
+      verify(feedbackRepository, never()).countByStatus(any(), any(), any());
     }
   }
 


### PR DESCRIPTION


### Brief description of changes applied
Repository now exposes countByStatus(Staff, Activity, EFeedbackStatus) -> int instead of assembling the full dashboard internally. FeedbackServiceImpl aggregates three calls to build FeedbackDashboardData and checks that the logged-in staff is the author of the requested activity before counting.

refs: #361


---

### Reference to an Issue, Feature, Task, User Story or another PR
fixes PR #361 
