### PR TITLE
feat(1760): add feedback history endpoint

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackController.java
@@ -6,10 +6,12 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDashboardDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackOverviewDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.StudentFeedbackItemListDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.UpdateFeedbackRequest;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackDetailsDTOMapper;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackOverviewDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackStaffListItemDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.StudentFeedbackItemListDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
@@ -42,6 +44,7 @@ public class FeedbackController {
   private final FeedbackDetailsDTOMapper feedbackDetailsDTOMapper;
   private final FeedbackStaffListItemDTOMapper feedbackStaffListItemDTOMapper;
   private final StudentFeedbackItemListDTOMapper studentFeedbackItemListDTOMapper;
+  private final FeedbackOverviewDTOMapper feedbackOverviewDTOMapper;
 
   @GetMapping
   public ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> getStaffFeedbacks(
@@ -132,6 +135,19 @@ public class FeedbackController {
             dashboard.pendingFeedbacks(),
             dashboard.processedFeedbacks(),
             dashboard.totalFeedbacks()));
+  }
+
+  @GetMapping("/{declaredActivityId}/history")
+  public ResponseEntity<List<FeedbackOverviewDTO>> getFeedbackHistory(
+      Principal principal, @PathVariable UUID declaredActivityId) {
+    log.debug(
+        "Received request to get feedback history for declared activity [{}] by user [{}]",
+        declaredActivityId,
+        principal.getName());
+    return ResponseEntity.ok(
+        feedbackService.getFeedbackHistory(declaredActivityId).stream()
+            .map(feedbackOverviewDTOMapper::toDTO)
+            .toList());
   }
 
   @PostMapping("/{feedbackId}/submit")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/FeedbackService.java
@@ -26,6 +26,8 @@ public interface FeedbackService {
 
   List<Feedback> getFeedbacksByActivity(UUID activityId);
 
+  List<Feedback> getFeedbackHistory(UUID declaredActivityId);
+
   void submitFeedback(UUID feedbackId);
 
   Set<UUID> findAttachmentIdsUsedByTraceSnapshots(

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -19,6 +19,7 @@ import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationServic
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboardData;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackData;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.DeclaredActivityNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackInProcessException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackMaximumIterationReachedException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.FeedbackNotFoundException;
@@ -27,6 +28,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.F
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input.DeclaredSkillProgressService;
@@ -41,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class FeedbackServiceImpl implements FeedbackService {
   private final FeedbackRepository feedbackRepository;
+  private final DeclaredActivityRepository declaredActivityRepository;
   private final DeclaredActivityService declaredActivityService;
   private final AssociationService associationService;
   private final TraceService traceService;
@@ -203,6 +206,20 @@ public class FeedbackServiceImpl implements FeedbackService {
 
     return feedbackRepository.findLatestFeedbacksByStaffAndActivityForEachStudent(
         staff.getId(), activityId);
+  }
+
+  @Override
+  public List<Feedback> getFeedbackHistory(UUID declaredActivityId) {
+    Staff loggedInStaff = loggedInUserService.getLoggedInStaff();
+    DeclaredActivity declaredActivity =
+        declaredActivityRepository
+            .findById(declaredActivityId)
+            .orElseThrow(DeclaredActivityNotFoundException::new);
+
+    if (!loggedInStaff.equals(declaredActivity.getActivity().getAuthor())) {
+      throw new UserNotAuthorizedException();
+    }
+    return feedbackRepository.findAllByDeclaredActivityId(declaredActivityId);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/service/FeedbackServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/service/FeedbackServiceConfig.java
@@ -6,6 +6,7 @@ import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationServic
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.FeedbackService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.service.FeedbackServiceImpl;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input.DeclaredSkillProgressService;
@@ -21,6 +22,7 @@ import org.springframework.context.annotation.Lazy;
 @RequiredArgsConstructor
 public class FeedbackServiceConfig {
   private final FeedbackRepository feedbackRepository;
+  private final DeclaredActivityRepository declaredActivityRepository;
   private final AssociationService associationService;
   private final DeclaredSkillProgressService declaredSkillProgressService;
   private final LoggedInUserService loggedInUserService;
@@ -32,6 +34,7 @@ public class FeedbackServiceConfig {
       @Lazy TraceService traceService, @Lazy DeclaredActivityService declaredActivityService) {
     return new FeedbackServiceImpl(
         feedbackRepository,
+        declaredActivityRepository,
         declaredActivityService,
         associationService,
         traceService,

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
@@ -865,4 +865,91 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
       assertThat(item.get("activity").get("id").asText()).isNotBlank();
     }
   }
+
+  // ── GET /{declaredActivityId}/history ───────────────────────────────
+
+  @Test
+  @Transactional
+  void shouldReturnFeedbackHistoryWhenStaffIsAuthorAndFeedbacksExist() throws Exception {
+    BddLogger.given(
+        "a staff who is the author of the activity and a student who asked for feedback");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+
+    BddLogger.when("the staff author requests the feedback history for the declared activity");
+    BddLogger.then(
+        "200 OK is returned with a list containing the feedback, with required fields present");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/" + declaredActivityId + "/history")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$")
+        .isArray()
+        .jsonPath("$[0].id")
+        .isEqualTo(feedbackId)
+        .jsonPath("$[0].status")
+        .isEqualTo("NEW")
+        .jsonPath("$[0].staff")
+        .exists()
+        .jsonPath("$[0].student")
+        .exists();
+  }
+
+  @Test
+  void shouldReturn404WhenDeclaredActivityDoesNotExistOnHistory() {
+    BddLogger.given("a non-existent declared activity ID");
+
+    BddLogger.when("the staff requests the feedback history");
+    BddLogger.then("404 Not Found is returned");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/" + notFoundId + "/history")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn403WhenUserIsNotTheStaffAuthorOnHistory() {
+    BddLogger.given("a declared activity whose activity is not authored by the requesting user");
+
+    BddLogger.when("a non-author staff requests the feedback history");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/" + declaredActivityId + "/history")
+        .header("X-Signed-Context", otherStudentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", otherStudentSignature)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  void shouldReturn401WhenNotAuthenticatedOnHistoryEndpoint() {
+    BddLogger.given(
+        "the GET /me/activity-progress/feedbacks/{declaredActivityId}/history endpoint");
+    BddLogger.when("performing a GET without authentication headers");
+    BddLogger.then("401 Unauthorized is returned");
+
+    webTestClient
+        .get()
+        .uri(BASE_PATH + "/" + notFoundId + "/history")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+  }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
@@ -14,10 +14,12 @@ import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDashboardDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackDetailsDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackOverviewDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.FeedbackStaffListItemDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.StudentFeedbackItemListDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.UpdateFeedbackRequest;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackDetailsDTOMapper;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackOverviewDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.FeedbackStaffListItemDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.StudentFeedbackItemListDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.FeedbackDashboardData;
@@ -30,6 +32,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,6 +48,7 @@ class FeedbackControllerTest {
   @Mock private FeedbackDetailsDTOMapper feedbackDetailsDTOMapper;
   @Mock private FeedbackStaffListItemDTOMapper feedbackStaffListItemDTOMapper;
   @Mock private StudentFeedbackItemListDTOMapper studentFeedbackItemListDTOMapper;
+  @Mock private FeedbackOverviewDTOMapper feedbackOverviewDTOMapper;
 
   @InjectMocks private FeedbackController controller;
 
@@ -55,416 +59,518 @@ class FeedbackControllerTest {
     principal = () -> "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d";
   }
 
-  @Test
-  void askForFeedback_should_return_201_with_feedback_details_dto() {
-    BddLogger.given("A logged-in student and a valid declared activity ID");
+  @Nested
+  class AskForFeedback {
 
-    UUID declaredActivityId = UUID.randomUUID();
-    Feedback feedback = mock(Feedback.class);
-    FeedbackDetailsDTO expectedDto =
-        new FeedbackDetailsDTO(
-            UUID.randomUUID(),
-            mock(ActivityContentDTO.class),
-            null,
-            "Ma réflexion",
-            null,
-            EFeedbackStatus.NEW,
-            List.of(),
-            List.of(),
-            Instant.now(),
-            Instant.now());
+    @Test
+    void should_return_201_with_feedback_details_dto() {
+      BddLogger.given("A logged-in student and a valid declared activity ID");
 
-    when(feedbackService.createFeedback(declaredActivityId)).thenReturn(feedback);
-    when(feedbackDetailsDTOMapper.toDTO(feedback)).thenReturn(expectedDto);
+      UUID declaredActivityId = UUID.randomUUID();
+      Feedback feedback = mock(Feedback.class);
+      FeedbackDetailsDTO expectedDto =
+          new FeedbackDetailsDTO(
+              UUID.randomUUID(),
+              mock(ActivityContentDTO.class),
+              null,
+              "Ma réflexion",
+              null,
+              EFeedbackStatus.NEW,
+              List.of(),
+              List.of(),
+              Instant.now(),
+              Instant.now());
 
-    BddLogger.when("askForFeedback is called");
-    ResponseEntity<FeedbackDetailsDTO> response =
-        controller.askForFeedback(principal, declaredActivityId);
+      when(feedbackService.createFeedback(declaredActivityId)).thenReturn(feedback);
+      when(feedbackDetailsDTOMapper.toDTO(feedback)).thenReturn(expectedDto);
 
-    BddLogger.then("201 CREATED is returned with the mapped FeedbackDetailsDTO");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-    assertThat(response.getBody()).isEqualTo(expectedDto);
-    assertThat(response.getBody().status()).isEqualTo(EFeedbackStatus.NEW);
-    assertThat(response.getBody().activity()).isNotNull();
+      BddLogger.when("askForFeedback is called");
+      ResponseEntity<FeedbackDetailsDTO> response =
+          controller.askForFeedback(principal, declaredActivityId);
 
-    verify(feedbackService).createFeedback(declaredActivityId);
-    verify(feedbackDetailsDTOMapper).toDTO(feedback);
+      BddLogger.then("201 CREATED is returned with the mapped FeedbackDetailsDTO");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+      assertThat(response.getBody()).isEqualTo(expectedDto);
+      assertThat(response.getBody().status()).isEqualTo(EFeedbackStatus.NEW);
+      assertThat(response.getBody().activity()).isNotNull();
+
+      verify(feedbackService).createFeedback(declaredActivityId);
+      verify(feedbackDetailsDTOMapper).toDTO(feedback);
+    }
+
+    @Test
+    void should_delegate_to_service_with_correct_declared_activity_id() {
+      BddLogger.given("A declared activity ID");
+
+      UUID declaredActivityId = UUID.randomUUID();
+      Feedback feedback = mock(Feedback.class);
+
+      when(feedbackService.createFeedback(declaredActivityId)).thenReturn(feedback);
+      when(feedbackDetailsDTOMapper.toDTO(feedback)).thenReturn(mock(FeedbackDetailsDTO.class));
+
+      BddLogger.when("askForFeedback is called");
+      controller.askForFeedback(principal, declaredActivityId);
+
+      BddLogger.then("The service is called exactly once with the right ID");
+      verify(feedbackService, times(1)).createFeedback(declaredActivityId);
+      verifyNoMoreInteractions(feedbackService);
+    }
   }
 
-  @Test
-  void askForFeedback_should_delegate_to_service_with_correct_declared_activity_id() {
-    BddLogger.given("A declared activity ID");
+  @Nested
+  class GetFeedbackDetails {
 
-    UUID declaredActivityId = UUID.randomUUID();
-    Feedback feedback = mock(Feedback.class);
+    @Test
+    void should_return_200_with_mapped_dto() {
+      BddLogger.given(
+          "A feedback ID, a user category STUDENT and a service returning FeedbackData");
 
-    when(feedbackService.createFeedback(declaredActivityId)).thenReturn(feedback);
-    when(feedbackDetailsDTOMapper.toDTO(feedback)).thenReturn(mock(FeedbackDetailsDTO.class));
+      UUID feedbackId = UUID.randomUUID();
+      EUserCategory userCategory = EUserCategory.STUDENT;
+      FeedbackData feedbackData = mock(FeedbackData.class);
+      FeedbackDetailsDTO expectedDto =
+          new FeedbackDetailsDTO(
+              feedbackId,
+              mock(ActivityContentDTO.class),
+              null,
+              null,
+              null,
+              EFeedbackStatus.NEW,
+              List.of(),
+              List.of(),
+              Instant.now(),
+              Instant.now());
 
-    BddLogger.when("askForFeedback is called");
-    controller.askForFeedback(principal, declaredActivityId);
+      when(feedbackService.getFeedbackDetails(feedbackId, userCategory)).thenReturn(feedbackData);
+      when(feedbackDetailsDTOMapper.toDTO(feedbackData)).thenReturn(expectedDto);
 
-    BddLogger.then("The service is called exactly once with the right ID");
-    verify(feedbackService, times(1)).createFeedback(declaredActivityId);
-    verifyNoMoreInteractions(feedbackService);
+      BddLogger.when("getFeedbackDetails is called with STUDENT category");
+      ResponseEntity<FeedbackDetailsDTO> response =
+          controller.getFeedbackDetails(principal, feedbackId, userCategory);
+
+      BddLogger.then("200 OK is returned with the mapped FeedbackDetailsDTO");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).isSameAs(expectedDto);
+
+      verify(feedbackService).getFeedbackDetails(feedbackId, userCategory);
+      verify(feedbackDetailsDTOMapper).toDTO(feedbackData);
+    }
+
+    @Test
+    void should_delegate_to_service_with_correct_id_and_category() {
+      BddLogger.given("A feedback ID and a STAFF user category");
+
+      UUID feedbackId = UUID.randomUUID();
+      EUserCategory userCategory = EUserCategory.STAFF;
+      FeedbackData feedbackData = mock(FeedbackData.class);
+
+      when(feedbackService.getFeedbackDetails(feedbackId, userCategory)).thenReturn(feedbackData);
+      when(feedbackDetailsDTOMapper.toDTO(feedbackData)).thenReturn(mock(FeedbackDetailsDTO.class));
+
+      BddLogger.when("getFeedbackDetails is called with STAFF category");
+      controller.getFeedbackDetails(principal, feedbackId, userCategory);
+
+      BddLogger.then(
+          "The service is called exactly once with the correct feedback ID and category");
+      verify(feedbackService, times(1)).getFeedbackDetails(feedbackId, userCategory);
+      verifyNoMoreInteractions(feedbackService);
+    }
   }
 
-  @Test
-  void getFeedbackDetails_should_return_200_with_mapped_dto() {
-    BddLogger.given("A feedback ID, a user category STUDENT and a service returning FeedbackData");
+  @Nested
+  class GetStaffFeedbacks {
 
-    UUID feedbackId = UUID.randomUUID();
-    EUserCategory userCategory = EUserCategory.STUDENT;
-    FeedbackData feedbackData = mock(FeedbackData.class);
-    FeedbackDetailsDTO expectedDto =
-        new FeedbackDetailsDTO(
-            feedbackId,
-            mock(ActivityContentDTO.class),
-            null,
-            null,
-            null,
-            EFeedbackStatus.NEW,
-            List.of(),
-            List.of(),
-            Instant.now(),
-            Instant.now());
+    @Test
+    void should_return_200_with_paged_result_when_no_filters() {
+      BddLogger.given("A logged-in staff with two feedbacks and no filter applied");
 
-    when(feedbackService.getFeedbackDetails(feedbackId, userCategory)).thenReturn(feedbackData);
-    when(feedbackDetailsDTOMapper.toDTO(feedbackData)).thenReturn(expectedDto);
+      Feedback feedback1 = mock(Feedback.class);
+      Feedback feedback2 = mock(Feedback.class);
+      FeedbackStaffListItemDTO dto1 = mock(FeedbackStaffListItemDTO.class);
+      FeedbackStaffListItemDTO dto2 = mock(FeedbackStaffListItemDTO.class);
 
-    BddLogger.when("getFeedbackDetails is called with STUDENT category");
-    ResponseEntity<FeedbackDetailsDTO> response =
-        controller.getFeedbackDetails(principal, feedbackId, userCategory);
+      PagedResult<Feedback> pagedResult =
+          new PagedResult<>(List.of(feedback1, feedback2), new PageInfo(0, 8, 2));
 
-    BddLogger.then("200 OK is returned with the mapped FeedbackDetailsDTO");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).isSameAs(expectedDto);
+      when(feedbackService.getStaffFeedbacks(isNull(), isNull(), any())).thenReturn(pagedResult);
+      when(feedbackStaffListItemDTOMapper.toDTO(feedback1)).thenReturn(dto1);
+      when(feedbackStaffListItemDTOMapper.toDTO(feedback2)).thenReturn(dto2);
 
-    verify(feedbackService).getFeedbackDetails(feedbackId, userCategory);
-    verify(feedbackDetailsDTOMapper).toDTO(feedbackData);
+      BddLogger.when("getStaffFeedbacks is called without any filter");
+      ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> response =
+          controller.getStaffFeedbacks(principal, null, null, null, null);
+
+      BddLogger.then("200 OK is returned with 2 items and pagination info");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody().data()).containsExactly(dto1, dto2);
+      assertThat(response.getBody().page().totalElements()).isEqualTo(2);
+
+      verify(feedbackService).getStaffFeedbacks(isNull(), isNull(), any());
+      verify(feedbackStaffListItemDTOMapper).toDTO(feedback1);
+      verify(feedbackStaffListItemDTOMapper).toDTO(feedback2);
+    }
+
+    @Test
+    void should_forward_status_filter_to_service() {
+      BddLogger.given("A logged-in staff requesting only IN_PROCESS feedbacks");
+
+      Feedback feedback = mock(Feedback.class);
+      FeedbackStaffListItemDTO dto = mock(FeedbackStaffListItemDTO.class);
+
+      PagedResult<Feedback> pagedResult =
+          new PagedResult<>(List.of(feedback), new PageInfo(0, 8, 1));
+
+      when(feedbackService.getStaffFeedbacks(eq(EFeedbackStatus.IN_PROCESS), isNull(), any()))
+          .thenReturn(pagedResult);
+      when(feedbackStaffListItemDTOMapper.toDTO(feedback)).thenReturn(dto);
+
+      BddLogger.when("getStaffFeedbacks is called with status=IN_PROCESS");
+      ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> response =
+          controller.getStaffFeedbacks(principal, EFeedbackStatus.IN_PROCESS, null, 0, 8);
+
+      BddLogger.then("service is called with IN_PROCESS and result has 1 item");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().data()).hasSize(1);
+
+      verify(feedbackService).getStaffFeedbacks(eq(EFeedbackStatus.IN_PROCESS), isNull(), any());
+    }
+
+    @Test
+    void should_forward_activity_id_filter_to_service() {
+      BddLogger.given("A logged-in staff requesting feedbacks for a specific activity");
+
+      UUID activityId = UUID.randomUUID();
+      Feedback feedback = mock(Feedback.class);
+      FeedbackStaffListItemDTO dto = mock(FeedbackStaffListItemDTO.class);
+
+      PagedResult<Feedback> pagedResult =
+          new PagedResult<>(List.of(feedback), new PageInfo(0, 8, 1));
+
+      when(feedbackService.getStaffFeedbacks(isNull(), eq(activityId), any()))
+          .thenReturn(pagedResult);
+      when(feedbackStaffListItemDTOMapper.toDTO(feedback)).thenReturn(dto);
+
+      BddLogger.when("getStaffFeedbacks is called with activityId");
+      ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> response =
+          controller.getStaffFeedbacks(principal, null, activityId, null, null);
+
+      BddLogger.then("service is called with the activityId and result has 1 item");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().data()).hasSize(1);
+
+      verify(feedbackService).getStaffFeedbacks(isNull(), eq(activityId), any());
+    }
+
+    @Test
+    void should_return_empty_list_when_staff_has_no_feedbacks() {
+      BddLogger.given("A logged-in staff with no feedbacks");
+
+      PagedResult<Feedback> emptyResult = new PagedResult<>(List.of(), new PageInfo(0, 8, 0));
+
+      when(feedbackService.getStaffFeedbacks(isNull(), isNull(), any())).thenReturn(emptyResult);
+
+      BddLogger.when("getStaffFeedbacks is called");
+      ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> response =
+          controller.getStaffFeedbacks(principal, null, null, 0, 8);
+
+      BddLogger.then("200 OK is returned with empty data and totalElements=0");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().data()).isEmpty();
+      assertThat(response.getBody().page().totalElements()).isZero();
+
+      verifyNoInteractions(feedbackStaffListItemDTOMapper);
+    }
   }
 
-  @Test
-  void getFeedbackDetails_should_delegate_to_service_with_correct_id_and_category() {
-    BddLogger.given("A feedback ID and a STAFF user category");
+  @Nested
+  class UpdateFeedback {
 
-    UUID feedbackId = UUID.randomUUID();
-    EUserCategory userCategory = EUserCategory.STAFF;
-    FeedbackData feedbackData = mock(FeedbackData.class);
+    @Test
+    void should_return_204_no_content() {
+      BddLogger.given("A valid feedback ID and a staff writing their feedback text");
 
-    when(feedbackService.getFeedbackDetails(feedbackId, userCategory)).thenReturn(feedbackData);
-    when(feedbackDetailsDTOMapper.toDTO(feedbackData)).thenReturn(mock(FeedbackDetailsDTO.class));
+      UUID feedbackId = UUID.randomUUID();
+      UpdateFeedbackRequest request = new UpdateFeedbackRequest("Excellent travail, bravo !");
 
-    BddLogger.when("getFeedbackDetails is called with STAFF category");
-    controller.getFeedbackDetails(principal, feedbackId, userCategory);
+      doNothing().when(feedbackService).updateFeedback(feedbackId, request.feedback());
 
-    BddLogger.then("The service is called exactly once with the correct feedback ID and category");
-    verify(feedbackService, times(1)).getFeedbackDetails(feedbackId, userCategory);
-    verifyNoMoreInteractions(feedbackService);
+      BddLogger.when("updateFeedback is called");
+      ResponseEntity<Void> response = controller.updateFeedback(principal, feedbackId, request);
+
+      BddLogger.then("204 No Content is returned with no body");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+      assertThat(response.getBody()).isNull();
+
+      verify(feedbackService).updateFeedback(feedbackId, request.feedback());
+    }
+
+    @Test
+    void should_delegate_to_service_with_correct_feedback_id_and_text() {
+      BddLogger.given("A feedback ID and a request with a specific feedback text");
+
+      UUID feedbackId = UUID.randomUUID();
+      String feedbackText = "Très bon travail sur cette activité.";
+      UpdateFeedbackRequest request = new UpdateFeedbackRequest(feedbackText);
+
+      BddLogger.when("updateFeedback is called");
+      controller.updateFeedback(principal, feedbackId, request);
+
+      BddLogger.then("The service is called exactly once with the correct feedback ID and text");
+      verify(feedbackService, times(1)).updateFeedback(feedbackId, feedbackText);
+      verifyNoMoreInteractions(feedbackService);
+    }
   }
 
-  @Test
-  void getStaffFeedbacks_should_return_200_with_paged_result_when_no_filters() {
-    BddLogger.given("A logged-in staff with two feedbacks and no filter applied");
+  @Nested
+  class SubmitFeedback {
 
-    Feedback feedback1 = mock(Feedback.class);
-    Feedback feedback2 = mock(Feedback.class);
-    FeedbackStaffListItemDTO dto1 = mock(FeedbackStaffListItemDTO.class);
-    FeedbackStaffListItemDTO dto2 = mock(FeedbackStaffListItemDTO.class);
+    @Test
+    void should_return_204_no_content() {
+      BddLogger.given("A valid feedback ID and a staff ready to submit");
 
-    PagedResult<Feedback> pagedResult =
-        new PagedResult<>(List.of(feedback1, feedback2), new PageInfo(0, 8, 2));
+      UUID feedbackId = UUID.randomUUID();
+      doNothing().when(feedbackService).submitFeedback(feedbackId);
 
-    when(feedbackService.getStaffFeedbacks(isNull(), isNull(), any())).thenReturn(pagedResult);
-    when(feedbackStaffListItemDTOMapper.toDTO(feedback1)).thenReturn(dto1);
-    when(feedbackStaffListItemDTOMapper.toDTO(feedback2)).thenReturn(dto2);
+      BddLogger.when("submitFeedback is called");
+      ResponseEntity<Void> response = controller.submitFeedback(principal, feedbackId);
 
-    BddLogger.when("getStaffFeedbacks is called without any filter");
-    ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> response =
-        controller.getStaffFeedbacks(principal, null, null, null, null);
+      BddLogger.then("204 No Content is returned with no body");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+      assertThat(response.getBody()).isNull();
 
-    BddLogger.then("200 OK is returned with 2 items and pagination info");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).isNotNull();
-    assertThat(response.getBody().data()).containsExactly(dto1, dto2);
-    assertThat(response.getBody().page().totalElements()).isEqualTo(2);
+      verify(feedbackService).submitFeedback(feedbackId);
+    }
 
-    verify(feedbackService).getStaffFeedbacks(isNull(), isNull(), any());
-    verify(feedbackStaffListItemDTOMapper).toDTO(feedback1);
-    verify(feedbackStaffListItemDTOMapper).toDTO(feedback2);
+    @Test
+    void should_delegate_to_service_with_correct_feedback_id() {
+      BddLogger.given("A feedback ID");
+
+      UUID feedbackId = UUID.randomUUID();
+
+      BddLogger.when("submitFeedback is called");
+      controller.submitFeedback(principal, feedbackId);
+
+      BddLogger.then("The service is called exactly once with the correct feedback ID");
+      verify(feedbackService, times(1)).submitFeedback(feedbackId);
+      verifyNoMoreInteractions(feedbackService);
+    }
   }
 
-  @Test
-  void getStaffFeedbacks_should_forward_status_filter_to_service() {
-    BddLogger.given("A logged-in staff requesting only IN_PROCESS feedbacks");
+  @Nested
+  class GetFeedbacksByActivity {
 
-    Feedback feedback = mock(Feedback.class);
-    FeedbackStaffListItemDTO dto = mock(FeedbackStaffListItemDTO.class);
+    @Test
+    void should_return_200_with_mapped_list() {
+      BddLogger.given("A logged-in staff and an activity with two feedbacks");
 
-    PagedResult<Feedback> pagedResult = new PagedResult<>(List.of(feedback), new PageInfo(0, 8, 1));
+      UUID activityId = UUID.randomUUID();
+      Feedback feedback1 = mock(Feedback.class);
+      Feedback feedback2 = mock(Feedback.class);
+      StudentFeedbackItemListDTO dto1 = mock(StudentFeedbackItemListDTO.class);
+      StudentFeedbackItemListDTO dto2 = mock(StudentFeedbackItemListDTO.class);
 
-    when(feedbackService.getStaffFeedbacks(eq(EFeedbackStatus.IN_PROCESS), isNull(), any()))
-        .thenReturn(pagedResult);
-    when(feedbackStaffListItemDTOMapper.toDTO(feedback)).thenReturn(dto);
+      when(feedbackService.getFeedbacksByActivity(activityId))
+          .thenReturn(List.of(feedback1, feedback2));
+      when(studentFeedbackItemListDTOMapper.toDTO(feedback1)).thenReturn(dto1);
+      when(studentFeedbackItemListDTOMapper.toDTO(feedback2)).thenReturn(dto2);
 
-    BddLogger.when("getStaffFeedbacks is called with status=IN_PROCESS");
-    ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> response =
-        controller.getStaffFeedbacks(principal, EFeedbackStatus.IN_PROCESS, null, 0, 8);
+      BddLogger.when("getFeedbacksByActivity is called");
+      ResponseEntity<List<StudentFeedbackItemListDTO>> response =
+          controller.getFeedbacksByActivity(principal, activityId);
 
-    BddLogger.then("service is called with IN_PROCESS and result has 1 item");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().data()).hasSize(1);
+      BddLogger.then("200 OK is returned with 2 mapped items");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).containsExactly(dto1, dto2);
 
-    verify(feedbackService).getStaffFeedbacks(eq(EFeedbackStatus.IN_PROCESS), isNull(), any());
+      verify(feedbackService).getFeedbacksByActivity(activityId);
+      verify(studentFeedbackItemListDTOMapper).toDTO(feedback1);
+      verify(studentFeedbackItemListDTOMapper).toDTO(feedback2);
+    }
+
+    @Test
+    void should_forward_activityId_to_service() {
+      BddLogger.given("A specific activity ID");
+
+      UUID activityId = UUID.randomUUID();
+      Feedback feedback = mock(Feedback.class);
+
+      when(feedbackService.getFeedbacksByActivity(activityId)).thenReturn(List.of(feedback));
+      when(studentFeedbackItemListDTOMapper.toDTO(feedback))
+          .thenReturn(mock(StudentFeedbackItemListDTO.class));
+
+      BddLogger.when("getFeedbacksByActivity is called");
+      controller.getFeedbacksByActivity(principal, activityId);
+
+      BddLogger.then("The service is called exactly once with the correct activityId");
+      verify(feedbackService, times(1)).getFeedbacksByActivity(activityId);
+      verifyNoMoreInteractions(feedbackService);
+    }
+
+    @Test
+    void should_return_empty_list_when_activity_has_no_feedbacks() {
+      BddLogger.given("An activity ID for which no feedbacks exist");
+
+      UUID activityId = UUID.randomUUID();
+
+      when(feedbackService.getFeedbacksByActivity(activityId)).thenReturn(List.of());
+
+      BddLogger.when("getFeedbacksByActivity is called");
+      ResponseEntity<List<StudentFeedbackItemListDTO>> response =
+          controller.getFeedbacksByActivity(principal, activityId);
+
+      BddLogger.then("200 OK is returned with an empty list");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).isEmpty();
+
+      verifyNoInteractions(studentFeedbackItemListDTOMapper);
+    }
   }
 
-  @Test
-  void getStaffFeedbacks_should_forward_activity_id_filter_to_service() {
-    BddLogger.given("A logged-in staff requesting feedbacks for a specific activity");
+  @Nested
+  class GetFeedbackDashboard {
 
-    UUID activityId = UUID.randomUUID();
-    Feedback feedback = mock(Feedback.class);
-    FeedbackStaffListItemDTO dto = mock(FeedbackStaffListItemDTO.class);
+    @Test
+    void should_return_200_with_correct_counts() {
+      BddLogger.given(
+          "A logged-in staff and the service returning a dashboard with counts 2/5/3/8");
 
-    PagedResult<Feedback> pagedResult = new PagedResult<>(List.of(feedback), new PageInfo(0, 8, 1));
+      FeedbackDashboardData dashboard = new FeedbackDashboardData(2, 5, 3, 8);
+      when(feedbackService.getFeedbackDashboard(null)).thenReturn(dashboard);
 
-    when(feedbackService.getStaffFeedbacks(isNull(), eq(activityId), any()))
-        .thenReturn(pagedResult);
-    when(feedbackStaffListItemDTOMapper.toDTO(feedback)).thenReturn(dto);
+      BddLogger.when("getFeedbackDashboard is called without activityId");
+      ResponseEntity<FeedbackDashboardDTO> response =
+          controller.getFeedbackDashboard(principal, null);
 
-    BddLogger.when("getStaffFeedbacks is called with activityId");
-    ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> response =
-        controller.getStaffFeedbacks(principal, null, activityId, null, null);
+      BddLogger.then(
+          "200 OK is returned with newFeedbacks=2, pendingFeedbacks=5, processedFeedbacks=3,"
+              + " totalFeedbacks=8");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody().newFeedbacks()).isEqualTo(2);
+      assertThat(response.getBody().pendingFeedbacks()).isEqualTo(5);
+      assertThat(response.getBody().processedFeedbacks()).isEqualTo(3);
+      assertThat(response.getBody().totalFeedbacks()).isEqualTo(8);
 
-    BddLogger.then("service is called with the activityId and result has 1 item");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().data()).hasSize(1);
+      verify(feedbackService).getFeedbackDashboard(null);
+    }
 
-    verify(feedbackService).getStaffFeedbacks(isNull(), eq(activityId), any());
+    @Test
+    void should_forward_activityId_to_service() {
+      BddLogger.given("A logged-in staff and a specific activityId");
+
+      UUID activityId = UUID.randomUUID();
+      when(feedbackService.getFeedbackDashboard(activityId))
+          .thenReturn(new FeedbackDashboardData(1, 1, 0, 1));
+
+      BddLogger.when("getFeedbackDashboard is called with activityId");
+      controller.getFeedbackDashboard(principal, activityId);
+
+      BddLogger.then("The service is called exactly once with the provided activityId");
+      verify(feedbackService, times(1)).getFeedbackDashboard(activityId);
+      verifyNoMoreInteractions(feedbackService);
+    }
+
+    @Test
+    void should_return_all_zeros_when_staff_has_no_feedbacks() {
+      BddLogger.given("A logged-in staff with no feedbacks");
+
+      when(feedbackService.getFeedbackDashboard(null))
+          .thenReturn(new FeedbackDashboardData(0, 0, 0, 0));
+
+      BddLogger.when("getFeedbackDashboard is called");
+      ResponseEntity<FeedbackDashboardDTO> response =
+          controller.getFeedbackDashboard(principal, null);
+
+      BddLogger.then("200 OK is returned with all counts at zero");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().newFeedbacks()).isZero();
+      assertThat(response.getBody().pendingFeedbacks()).isZero();
+      assertThat(response.getBody().processedFeedbacks()).isZero();
+      assertThat(response.getBody().totalFeedbacks()).isZero();
+    }
+
+    @Test
+    void should_forward_null_activityId_when_not_provided() {
+      BddLogger.given("A logged-in staff calling the dashboard endpoint without activityId");
+
+      when(feedbackService.getFeedbackDashboard(null))
+          .thenReturn(new FeedbackDashboardData(0, 0, 0, 0));
+
+      BddLogger.when("getFeedbackDashboard is called with activityId=null");
+      controller.getFeedbackDashboard(principal, null);
+
+      BddLogger.then("The service is called with null activityId");
+      verify(feedbackService).getFeedbackDashboard(null);
+    }
   }
 
-  @Test
-  void getStaffFeedbacks_should_return_empty_list_when_staff_has_no_feedbacks() {
-    BddLogger.given("A logged-in staff with no feedbacks");
+  @Nested
+  class GetFeedbackHistory {
 
-    PagedResult<Feedback> emptyResult = new PagedResult<>(List.of(), new PageInfo(0, 8, 0));
+    @Test
+    void should_return_200_with_mapped_list() {
+      BddLogger.given("A logged-in staff and a declared activity with two feedbacks");
 
-    when(feedbackService.getStaffFeedbacks(isNull(), isNull(), any())).thenReturn(emptyResult);
+      UUID declaredActivityId = UUID.randomUUID();
+      Feedback feedback1 = mock(Feedback.class);
+      Feedback feedback2 = mock(Feedback.class);
+      FeedbackOverviewDTO dto1 = mock(FeedbackOverviewDTO.class);
+      FeedbackOverviewDTO dto2 = mock(FeedbackOverviewDTO.class);
 
-    BddLogger.when("getStaffFeedbacks is called");
-    ResponseEntity<PagedResponse<FeedbackStaffListItemDTO>> response =
-        controller.getStaffFeedbacks(principal, null, null, 0, 8);
+      when(feedbackService.getFeedbackHistory(declaredActivityId))
+          .thenReturn(List.of(feedback1, feedback2));
+      when(feedbackOverviewDTOMapper.toDTO(feedback1)).thenReturn(dto1);
+      when(feedbackOverviewDTOMapper.toDTO(feedback2)).thenReturn(dto2);
 
-    BddLogger.then("200 OK is returned with empty data and totalElements=0");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().data()).isEmpty();
-    assertThat(response.getBody().page().totalElements()).isZero();
+      BddLogger.when("getFeedbackHistory is called");
+      ResponseEntity<List<FeedbackOverviewDTO>> response =
+          controller.getFeedbackHistory(principal, declaredActivityId);
 
-    verifyNoInteractions(feedbackStaffListItemDTOMapper);
-  }
+      BddLogger.then("200 OK is returned with 2 mapped FeedbackOverviewDTOs");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).containsExactly(dto1, dto2);
 
-  @Test
-  void updateFeedback_should_return_204_no_content() {
-    BddLogger.given("A valid feedback ID and a staff writing their feedback text");
+      verify(feedbackService).getFeedbackHistory(declaredActivityId);
+      verify(feedbackOverviewDTOMapper).toDTO(feedback1);
+      verify(feedbackOverviewDTOMapper).toDTO(feedback2);
+    }
 
-    UUID feedbackId = UUID.randomUUID();
-    UpdateFeedbackRequest request = new UpdateFeedbackRequest("Excellent travail, bravo !");
+    @Test
+    void should_return_empty_list_when_no_feedbacks_exist() {
+      BddLogger.given("A logged-in staff and a declared activity with no feedbacks");
 
-    doNothing().when(feedbackService).updateFeedback(feedbackId, request.feedback());
+      UUID declaredActivityId = UUID.randomUUID();
 
-    BddLogger.when("updateFeedback is called");
-    ResponseEntity<Void> response = controller.updateFeedback(principal, feedbackId, request);
+      when(feedbackService.getFeedbackHistory(declaredActivityId)).thenReturn(List.of());
 
-    BddLogger.then("204 No Content is returned with no body");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-    assertThat(response.getBody()).isNull();
+      BddLogger.when("getFeedbackHistory is called");
+      ResponseEntity<List<FeedbackOverviewDTO>> response =
+          controller.getFeedbackHistory(principal, declaredActivityId);
 
-    verify(feedbackService).updateFeedback(feedbackId, request.feedback());
-  }
+      BddLogger.then("200 OK is returned with an empty list");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).isEmpty();
 
-  @Test
-  void updateFeedback_should_delegate_to_service_with_correct_feedback_id_and_text() {
-    BddLogger.given("A feedback ID and a request with a specific feedback text");
+      verifyNoInteractions(feedbackOverviewDTOMapper);
+    }
 
-    UUID feedbackId = UUID.randomUUID();
-    String feedbackText = "Très bon travail sur cette activité.";
-    UpdateFeedbackRequest request = new UpdateFeedbackRequest(feedbackText);
+    @Test
+    void should_delegate_to_service_with_correct_declared_activity_id() {
+      BddLogger.given("A declared activity ID");
 
-    BddLogger.when("updateFeedback is called");
-    controller.updateFeedback(principal, feedbackId, request);
+      UUID declaredActivityId = UUID.randomUUID();
+      Feedback feedback = mock(Feedback.class);
 
-    BddLogger.then("The service is called exactly once with the correct feedback ID and text");
-    verify(feedbackService, times(1)).updateFeedback(feedbackId, feedbackText);
-    verifyNoMoreInteractions(feedbackService);
-  }
+      when(feedbackService.getFeedbackHistory(declaredActivityId)).thenReturn(List.of(feedback));
+      when(feedbackOverviewDTOMapper.toDTO(feedback)).thenReturn(mock(FeedbackOverviewDTO.class));
 
-  @Test
-  void submitFeedback_should_return_204_no_content() {
-    BddLogger.given("A valid feedback ID and a staff ready to submit");
+      BddLogger.when("getFeedbackHistory is called");
+      controller.getFeedbackHistory(principal, declaredActivityId);
 
-    UUID feedbackId = UUID.randomUUID();
-    doNothing().when(feedbackService).submitFeedback(feedbackId);
-
-    BddLogger.when("submitFeedback is called");
-    ResponseEntity<Void> response = controller.submitFeedback(principal, feedbackId);
-
-    BddLogger.then("204 No Content is returned with no body");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-    assertThat(response.getBody()).isNull();
-
-    verify(feedbackService).submitFeedback(feedbackId);
-  }
-
-  @Test
-  void submitFeedback_should_delegate_to_service_with_correct_feedback_id() {
-    BddLogger.given("A feedback ID");
-
-    UUID feedbackId = UUID.randomUUID();
-
-    BddLogger.when("submitFeedback is called");
-    controller.submitFeedback(principal, feedbackId);
-
-    BddLogger.then("The service is called exactly once with the correct feedback ID");
-    verify(feedbackService, times(1)).submitFeedback(feedbackId);
-    verifyNoMoreInteractions(feedbackService);
-  }
-
-  @Test
-  void getFeedbacksByActivity_should_return_200_with_mapped_list() {
-    BddLogger.given("A logged-in staff and an activity with two feedbacks");
-
-    UUID activityId = UUID.randomUUID();
-    Feedback feedback1 = mock(Feedback.class);
-    Feedback feedback2 = mock(Feedback.class);
-    StudentFeedbackItemListDTO dto1 = mock(StudentFeedbackItemListDTO.class);
-    StudentFeedbackItemListDTO dto2 = mock(StudentFeedbackItemListDTO.class);
-
-    when(feedbackService.getFeedbacksByActivity(activityId))
-        .thenReturn(List.of(feedback1, feedback2));
-    when(studentFeedbackItemListDTOMapper.toDTO(feedback1)).thenReturn(dto1);
-    when(studentFeedbackItemListDTOMapper.toDTO(feedback2)).thenReturn(dto2);
-
-    BddLogger.when("getFeedbacksByActivity is called");
-    ResponseEntity<List<StudentFeedbackItemListDTO>> response =
-        controller.getFeedbacksByActivity(principal, activityId);
-
-    BddLogger.then("200 OK is returned with 2 mapped items");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).containsExactly(dto1, dto2);
-
-    verify(feedbackService).getFeedbacksByActivity(activityId);
-    verify(studentFeedbackItemListDTOMapper).toDTO(feedback1);
-    verify(studentFeedbackItemListDTOMapper).toDTO(feedback2);
-  }
-
-  @Test
-  void getFeedbacksByActivity_should_forward_activityId_to_service() {
-    BddLogger.given("A specific activity ID");
-
-    UUID activityId = UUID.randomUUID();
-    Feedback feedback = mock(Feedback.class);
-
-    when(feedbackService.getFeedbacksByActivity(activityId)).thenReturn(List.of(feedback));
-    when(studentFeedbackItemListDTOMapper.toDTO(feedback))
-        .thenReturn(mock(StudentFeedbackItemListDTO.class));
-
-    BddLogger.when("getFeedbacksByActivity is called");
-    controller.getFeedbacksByActivity(principal, activityId);
-
-    BddLogger.then("The service is called exactly once with the correct activityId");
-    verify(feedbackService, times(1)).getFeedbacksByActivity(activityId);
-    verifyNoMoreInteractions(feedbackService);
-  }
-
-  @Test
-  void getFeedbacksByActivity_should_return_empty_list_when_activity_has_no_feedbacks() {
-    BddLogger.given("An activity ID for which no feedbacks exist");
-
-    UUID activityId = UUID.randomUUID();
-
-    when(feedbackService.getFeedbacksByActivity(activityId)).thenReturn(List.of());
-
-    BddLogger.when("getFeedbacksByActivity is called");
-    ResponseEntity<List<StudentFeedbackItemListDTO>> response =
-        controller.getFeedbacksByActivity(principal, activityId);
-
-    BddLogger.then("200 OK is returned with an empty list");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).isEmpty();
-
-    verifyNoInteractions(studentFeedbackItemListDTOMapper);
-  }
-
-  @Test
-  void getFeedbackDashboard_should_return_200_with_correct_counts() {
-    BddLogger.given("A logged-in staff and the service returning a dashboard with counts 2/5/3/8");
-
-    FeedbackDashboardData dashboard = new FeedbackDashboardData(2, 5, 3, 8);
-    when(feedbackService.getFeedbackDashboard(null)).thenReturn(dashboard);
-
-    BddLogger.when("getFeedbackDashboard is called without activityId");
-    ResponseEntity<FeedbackDashboardDTO> response =
-        controller.getFeedbackDashboard(principal, null);
-
-    BddLogger.then(
-        "200 OK is returned with newFeedbacks=2, pendingFeedbacks=5, processedFeedbacks=3,"
-            + " totalFeedbacks=8");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).isNotNull();
-    assertThat(response.getBody().newFeedbacks()).isEqualTo(2);
-    assertThat(response.getBody().pendingFeedbacks()).isEqualTo(5);
-    assertThat(response.getBody().processedFeedbacks()).isEqualTo(3);
-    assertThat(response.getBody().totalFeedbacks()).isEqualTo(8);
-
-    verify(feedbackService).getFeedbackDashboard(null);
-  }
-
-  @Test
-  void getFeedbackDashboard_should_forward_activityId_to_service() {
-    BddLogger.given("A logged-in staff and a specific activityId");
-
-    UUID activityId = UUID.randomUUID();
-    when(feedbackService.getFeedbackDashboard(activityId))
-        .thenReturn(new FeedbackDashboardData(1, 1, 0, 1));
-
-    BddLogger.when("getFeedbackDashboard is called with activityId");
-    controller.getFeedbackDashboard(principal, activityId);
-
-    BddLogger.then("The service is called exactly once with the provided activityId");
-    verify(feedbackService, times(1)).getFeedbackDashboard(activityId);
-    verifyNoMoreInteractions(feedbackService);
-  }
-
-  @Test
-  void getFeedbackDashboard_should_return_all_zeros_when_staff_has_no_feedbacks() {
-    BddLogger.given("A logged-in staff with no feedbacks");
-
-    when(feedbackService.getFeedbackDashboard(null))
-        .thenReturn(new FeedbackDashboardData(0, 0, 0, 0));
-
-    BddLogger.when("getFeedbackDashboard is called");
-    ResponseEntity<FeedbackDashboardDTO> response =
-        controller.getFeedbackDashboard(principal, null);
-
-    BddLogger.then("200 OK is returned with all counts at zero");
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().newFeedbacks()).isZero();
-    assertThat(response.getBody().pendingFeedbacks()).isZero();
-    assertThat(response.getBody().processedFeedbacks()).isZero();
-    assertThat(response.getBody().totalFeedbacks()).isZero();
-  }
-
-  @Test
-  void getFeedbackDashboard_should_forward_null_activityId_when_not_provided() {
-    BddLogger.given("A logged-in staff calling the dashboard endpoint without activityId");
-
-    when(feedbackService.getFeedbackDashboard(null))
-        .thenReturn(new FeedbackDashboardData(0, 0, 0, 0));
-
-    BddLogger.when("getFeedbackDashboard is called with activityId=null");
-    controller.getFeedbackDashboard(principal, null);
-
-    BddLogger.then("The service is called with null activityId");
-    verify(feedbackService).getFeedbackDashboard(null);
+      BddLogger.then("The service is called exactly once with the correct declaredActivityId");
+      verify(feedbackService, times(1)).getFeedbackHistory(declaredActivityId);
+      verifyNoMoreInteractions(feedbackService);
+    }
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -28,6 +28,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.D
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.DeclaredActivityRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.output.repository.FeedbackRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.port.input.DeclaredSkillProgressService;
@@ -59,6 +60,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class FeedbackServiceImplTest {
 
   @Mock private FeedbackRepository feedbackRepository;
+  @Mock private DeclaredActivityRepository declaredActivityRepository;
   @Mock private ActivityService activityService;
   @Mock private DeclaredActivityService declaredActivityService;
   @Mock private AssociationService associationService;
@@ -1200,6 +1202,118 @@ class FeedbackServiceImplTest {
           .isInstanceOf(UserIsNotStaffException.class);
 
       verify(feedbackRepository, never()).countByStatus(any(), any(), any());
+    }
+  }
+
+  @Nested
+  class GetFeedbackHistory {
+
+    @Test
+    void should_return_feedbacks_ordered_by_repository_when_staff_is_author() {
+      BddLogger.given("A logged-in staff who is the author of the declared activity's activity");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff staff = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+      Feedback feedback1 = mock(Feedback.class);
+      Feedback feedback2 = mock(Feedback.class);
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(declaredActivityRepository.findById(declaredActivityId))
+          .thenReturn(Optional.of(declaredActivity));
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of(feedback1, feedback2));
+
+      BddLogger.when("getFeedbackHistory is called");
+      List<Feedback> result = service.getFeedbackHistory(declaredActivityId);
+
+      BddLogger.then("The repository result is returned as-is");
+      assertThat(result).containsExactly(feedback1, feedback2);
+      verify(feedbackRepository).findAllByDeclaredActivityId(declaredActivityId);
+    }
+
+    @Test
+    void should_return_empty_list_when_declared_activity_has_no_feedbacks() {
+      BddLogger.given(
+          "A logged-in staff who is the author and a declared activity with no feedbacks");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff staff = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(declaredActivityRepository.findById(declaredActivityId))
+          .thenReturn(Optional.of(declaredActivity));
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of());
+
+      BddLogger.when("getFeedbackHistory is called");
+      List<Feedback> result = service.getFeedbackHistory(declaredActivityId);
+
+      BddLogger.then("An empty list is returned");
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_throw_DeclaredActivityNotFoundException_when_activity_not_found() {
+      BddLogger.given("A non-existent declared activity ID");
+      UUID declaredActivityId = UUID.randomUUID();
+      Staff staff = StaffFixture.create().toModel();
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(declaredActivityRepository.findById(declaredActivityId)).thenReturn(Optional.empty());
+
+      BddLogger.when("getFeedbackHistory is called");
+
+      BddLogger.then("A DeclaredActivityNotFoundException is thrown");
+      assertThatThrownBy(() -> service.getFeedbackHistory(declaredActivityId))
+          .isInstanceOf(DeclaredActivityNotFoundException.class);
+
+      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any());
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_staff_is_not_the_author() {
+      BddLogger.given("A logged-in staff who is NOT the author of the activity");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff differentStaff = StaffFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(differentStaff);
+      when(declaredActivityRepository.findById(declaredActivityId))
+          .thenReturn(Optional.of(declaredActivity));
+
+      BddLogger.when("getFeedbackHistory is called");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown");
+      assertThatThrownBy(() -> service.getFeedbackHistory(declaredActivityId))
+          .isInstanceOf(UserNotAuthorizedException.class);
+
+      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any());
+    }
+
+    @Test
+    void should_throw_UserIsNotStaffException_when_logged_in_user_is_not_staff() {
+      BddLogger.given("A logged-in user who is not registered as staff");
+      UUID declaredActivityId = UUID.randomUUID();
+
+      when(loggedInUserService.getLoggedInStaff()).thenThrow(new UserIsNotStaffException());
+
+      BddLogger.when("getFeedbackHistory is called");
+
+      BddLogger.then("A UserIsNotStaffException is thrown");
+      assertThatThrownBy(() -> service.getFeedbackHistory(declaredActivityId))
+          .isInstanceOf(UserIsNotStaffException.class);
+
+      verify(declaredActivityRepository, never()).findById(any());
+      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any());
     }
   }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a new `GET /{declaredActivityId}/history` endpoint that returns the full list of feedbacks for a given declared activity. Access is restricted to the staff member who is the author of the activity. Returns 403 if the requester is not the author, and 404 if the declared activity does not exist.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1760

---

### Documentation
> No documentation or configuration changes required.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Injected `DeclaredActivityRepository` into `FeedbackServiceImpl` (and its config) to perform the ownership check directly without going through the higher-level `DeclaredActivityService`.
> - Authorization check: only the staff who authored the activity can retrieve its feedback history.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process