### PR TITLE
feat(feedback): add declaredActivityId field to FeedbackDetailsDTO

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/FeedbackDetailsDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/FeedbackDetailsDTO.java
@@ -10,9 +10,19 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-@Schema(requiredProperties = {"id", "activity", "student", "status", "createdAt", "updatedAt"})
+@Schema(
+    requiredProperties = {
+      "id",
+      "declaredActivityId",
+      "activity",
+      "student",
+      "status",
+      "createdAt",
+      "updatedAt"
+    })
 public record FeedbackDetailsDTO(
     UUID id,
+    UUID declaredActivityId,
     ActivityContentDTO activity,
     UserInfoDTO student,
     String reflexion,

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/FeedbackDetailsDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/FeedbackDetailsDTOMapper.java
@@ -22,10 +22,12 @@ import org.mapstruct.Mapping;
     })
 public interface FeedbackDetailsDTOMapper {
 
+  @Mapping(source = "declaredActivity.id", target = "declaredActivityId")
   @Mapping(source = "declaredActivity.activity", target = "activity")
   @Mapping(source = "declaredActivity.student.user", target = "student")
   FeedbackDetailsDTO toDTO(Feedback feedback);
 
+  @Mapping(source = "declaredActivity.id", target = "declaredActivityId")
   @Mapping(source = "declaredActivity.activity", target = "activity")
   @Mapping(source = "declaredActivity.student.user", target = "student")
   FeedbackDetailsDTO toDTO(FeedbackData feedbackData);

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerTest.java
@@ -71,6 +71,7 @@ class FeedbackControllerTest {
       FeedbackDetailsDTO expectedDto =
           new FeedbackDetailsDTO(
               UUID.randomUUID(),
+              UUID.randomUUID(),
               mock(ActivityContentDTO.class),
               null,
               "Ma réflexion",
@@ -131,6 +132,7 @@ class FeedbackControllerTest {
       FeedbackDetailsDTO expectedDto =
           new FeedbackDetailsDTO(
               feedbackId,
+              UUID.randomUUID(),
               mock(ActivityContentDTO.class),
               null,
               null,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a `declaredActivityId` (UUID) field to `FeedbackDetailsDTO` so that consumers of the feedback details endpoint can directly reference the associated declared activity without having to derive it from the nested `activity` object.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2028

---

### Documentation
> No documentation update required. The field is exposed in the OpenAPI spec via the existing `@Schema` annotation (added to `requiredProperties`).

---

### Target Branch
> `develop`

---

### Additional Notes
> - Mapper: `@Mapping(source = "declaredActivity.id", target = "declaredActivityId")` added to both `toDTO` overloads (`Feedback` and `FeedbackData`).
> - Controller tests updated to pass the new positional argument in the `FeedbackDetailsDTO` record constructor.

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process