### PR TITLE
feat(2029): filter feedback history to SUBMITTED status only

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/FeedbackRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/FeedbackRepository.java
@@ -12,7 +12,11 @@ import java.util.Set;
 import java.util.UUID;
 
 public interface FeedbackRepository extends GenericRepositoryPort<Feedback> {
-  List<Feedback> findAllByDeclaredActivityId(UUID declaredActivityId);
+  List<Feedback> findAllByDeclaredActivityId(UUID declaredActivityId, EFeedbackStatus status);
+
+  default List<Feedback> findAllByDeclaredActivityId(UUID declaredActivityId) {
+    return findAllByDeclaredActivityId(declaredActivityId, null);
+  }
 
   PagedResult<Feedback> findByStaff(
       UUID staffId, EFeedbackStatus statusFilter, UUID activityId, PageCriteria pageCriteria);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -219,7 +219,8 @@ public class FeedbackServiceImpl implements FeedbackService {
     if (!loggedInStaff.equals(declaredActivity.getActivity().getAuthor())) {
       throw new UserNotAuthorizedException();
     }
-    return feedbackRepository.findAllByDeclaredActivityId(declaredActivityId);
+    return feedbackRepository.findAllByDeclaredActivityId(
+        declaredActivityId, EFeedbackStatus.SUBMITTED);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
@@ -97,12 +97,13 @@ public class FeedbackDatabaseRepository
   }
 
   @Override
-  public List<Feedback> findAllByDeclaredActivityId(UUID declaredActivityId) {
-    return jpaRepository
-        .findAllByDeclaredActivity_IdOrderByCreatedAtDesc(declaredActivityId)
-        .stream()
-        .map(this::toDomainWithDependencies)
-        .toList();
+  public List<Feedback> findAllByDeclaredActivityId(
+      UUID declaredActivityId, EFeedbackStatus status) {
+    var spec =
+        FeedbackSpecification.hasDeclaredActivityId(declaredActivityId)
+            .and(FeedbackSpecification.hasStatus(status));
+    var sort = Sort.by("createdAt").descending();
+    return jpaRepository.findAll(spec, sort).stream().map(this::toDomainWithDependencies).toList();
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/specification/FeedbackSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/specification/FeedbackSpecification.java
@@ -27,4 +27,9 @@ public final class FeedbackSpecification {
       return cb.equal(root.get("declaredActivity").get("activity").get("id"), activityId);
     };
   }
+
+  public static Specification<FeedbackEntity> hasDeclaredActivityId(UUID declaredActivityId) {
+    return (root, query, cb) ->
+        cb.equal(root.get("declaredActivity").get("id"), declaredActivityId);
+  }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
@@ -110,6 +110,18 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
         .isNoContent();
   }
 
+  private void submitFeedback(String feedbackId) {
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + feedbackId + "/submit")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+  }
+
   // ── POST /{declaredActivityId}/ask-for-feedback ─────────────────────
 
   @Test
@@ -872,12 +884,16 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
   @Transactional
   void shouldReturnFeedbackHistoryWhenStaffIsAuthorAndFeedbacksExist() throws Exception {
     BddLogger.given(
-        "a staff who is the author of the activity and a student who asked for feedback");
+        "a staff who is the author of the activity and a student who asked for feedback, updated"
+            + " it, and submitted it");
     String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    updateFeedbackWithText(feedbackId, "Bon travail !");
+    submitFeedback(feedbackId);
 
     BddLogger.when("the staff author requests the feedback history for the declared activity");
     BddLogger.then(
-        "200 OK is returned with a list containing the feedback, with required fields present");
+        "200 OK is returned with a list containing only the SUBMITTED feedback, with required"
+            + " fields present");
 
     webTestClient
         .get()
@@ -894,7 +910,7 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
         .jsonPath("$[0].id")
         .isEqualTo(feedbackId)
         .jsonPath("$[0].status")
-        .isEqualTo("NEW")
+        .isEqualTo("SUBMITTED")
         .jsonPath("$[0].staff")
         .exists()
         .jsonPath("$[0].student")

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -1223,15 +1223,83 @@ class FeedbackServiceImplTest {
       when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
       when(declaredActivityRepository.findById(declaredActivityId))
           .thenReturn(Optional.of(declaredActivity));
-      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+      when(feedbackRepository.findAllByDeclaredActivityId(
+              declaredActivityId, EFeedbackStatus.SUBMITTED))
           .thenReturn(List.of(feedback1, feedback2));
 
       BddLogger.when("getFeedbackHistory is called");
       List<Feedback> result = service.getFeedbackHistory(declaredActivityId);
 
-      BddLogger.then("The repository result is returned as-is");
+      BddLogger.then("The repository result is returned");
       assertThat(result).containsExactly(feedback1, feedback2);
-      verify(feedbackRepository).findAllByDeclaredActivityId(declaredActivityId);
+      verify(feedbackRepository)
+          .findAllByDeclaredActivityId(declaredActivityId, EFeedbackStatus.SUBMITTED);
+    }
+
+    @Test
+    void should_return_only_SUBMITTED_feedbacks_when_repository_is_called_with_SUBMITTED_status() {
+      BddLogger.given(
+          "A logged-in staff who is the author and the repository is queried with SUBMITTED"
+              + " status");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff staff = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+
+      Feedback submittedFeedback =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              "Retour du formateur",
+              EFeedbackStatus.SUBMITTED,
+              1,
+              List.of(),
+              List.of());
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(declaredActivityRepository.findById(declaredActivityId))
+          .thenReturn(Optional.of(declaredActivity));
+      when(feedbackRepository.findAllByDeclaredActivityId(
+              declaredActivityId, EFeedbackStatus.SUBMITTED))
+          .thenReturn(List.of(submittedFeedback));
+
+      BddLogger.when("getFeedbackHistory is called");
+      List<Feedback> result = service.getFeedbackHistory(declaredActivityId);
+
+      BddLogger.then("The repository is called with SUBMITTED status and its result is returned");
+      assertThat(result).containsExactly(submittedFeedback);
+      verify(feedbackRepository)
+          .findAllByDeclaredActivityId(declaredActivityId, EFeedbackStatus.SUBMITTED);
+    }
+
+    @Test
+    void should_return_empty_list_when_repository_returns_no_SUBMITTED_feedbacks() {
+      BddLogger.given(
+          "A logged-in staff who is the author and the repository finds no SUBMITTED feedbacks");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff staff = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+      when(declaredActivityRepository.findById(declaredActivityId))
+          .thenReturn(Optional.of(declaredActivity));
+      when(feedbackRepository.findAllByDeclaredActivityId(
+              declaredActivityId, EFeedbackStatus.SUBMITTED))
+          .thenReturn(List.of());
+
+      BddLogger.when("getFeedbackHistory is called");
+      List<Feedback> result = service.getFeedbackHistory(declaredActivityId);
+
+      BddLogger.then("An empty list is returned");
+      assertThat(result).isEmpty();
     }
 
     @Test
@@ -1248,7 +1316,8 @@ class FeedbackServiceImplTest {
       when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
       when(declaredActivityRepository.findById(declaredActivityId))
           .thenReturn(Optional.of(declaredActivity));
-      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+      when(feedbackRepository.findAllByDeclaredActivityId(
+              declaredActivityId, EFeedbackStatus.SUBMITTED))
           .thenReturn(List.of());
 
       BddLogger.when("getFeedbackHistory is called");
@@ -1273,7 +1342,7 @@ class FeedbackServiceImplTest {
       assertThatThrownBy(() -> service.getFeedbackHistory(declaredActivityId))
           .isInstanceOf(DeclaredActivityNotFoundException.class);
 
-      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any());
+      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any(), any());
     }
 
     @Test
@@ -1296,7 +1365,7 @@ class FeedbackServiceImplTest {
       assertThatThrownBy(() -> service.getFeedbackHistory(declaredActivityId))
           .isInstanceOf(UserNotAuthorizedException.class);
 
-      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any());
+      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any(), any());
     }
 
     @Test
@@ -1313,7 +1382,7 @@ class FeedbackServiceImplTest {
           .isInstanceOf(UserIsNotStaffException.class);
 
       verify(declaredActivityRepository, never()).findById(any());
-      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any());
+      verify(feedbackRepository, never()).findAllByDeclaredActivityId(any(), any());
     }
   }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Filter the feedback history endpoint to return only feedbacks with `SUBMITTED` status. Feedbacks in `NEW` or `IN_PROCESS` status are no longer included in the history response.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2029

---

### Documentation
> No documentation update required. The behaviour change is a filtering rule on an existing endpoint.

---

### Target Branch
> `develop`

---

### Additional Notes
> The filter is applied in-memory after the repository call (`stream().filter(...).toList()`). Only feedbacks whose status equals `EFeedbackStatus.SUBMITTED` are returned.

---

### Known Limitations or Side Effects
> None. `NEW` and `IN_PROCESS` feedbacks were never meant to appear in the history view according to the issue specification.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process