### PR TITLE
fix(2076): fix feedback max iteration check when iterations set to infinity

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -97,8 +97,8 @@ public class FeedbackServiceImpl implements FeedbackService {
           return feedbackRepository.save(lastFeedback);
         }
         case SUBMITTED -> {
-          if (existingFeedbacks.size()
-              >= declaredActivity.getActivity().getFeedbackAllowedIterations()) {
+          int maxIterations = declaredActivity.getActivity().getFeedbackAllowedIterations();
+          if (maxIterations != -1 && existingFeedbacks.size() >= maxIterations) {
             throw new FeedbackMaximumIterationReachedException();
           }
         }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix feedback max iteration check when `feedbackAllowedIterations` is set to `-1` (infinity). Previously, the condition `existingFeedbacks.size() >= -1` was always true, preventing any new feedback request after a first SUBMITTED feedback.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Related to https://github.com/avenirs-esr/AVENIRS-Project/issues/2076

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process
