### PR TITLE
feat(activity): unpublish activity instead of deleting on draft edition

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
@@ -78,8 +78,10 @@ public class ActivityController {
         switch (activityStatus) {
           case PUBLISHED, UNPUBLISHED ->
               activityContentDtoMapper.toDTO(activityService.getActivityById(activityId));
-          case DRAFT ->
-              activityContentDtoMapper.toDTO(activityService.getActivityDraftById(activityId));
+          case DRAFT -> {
+            var draft = activityService.getActivityDraftById(activityId);
+            yield activityContentDtoMapper.toDTO(draft, activityService.hasEnrolledStudents(draft));
+          }
         };
     return ResponseEntity.ok(dto);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
@@ -188,6 +188,18 @@ public class ActivityController {
         activityNavigationMapper.toDTO(activityService.getActivityNavigation()));
   }
 
+  @PostMapping("/create-draft/{activityId}")
+  public ResponseEntity<ActivityDraftCreationResponse> createDraftFromActivity(
+      Principal principal, @PathVariable UUID activityId) {
+    log.debug(
+        "Received request to create draft from activity [{}] by user [{}]",
+        activityId,
+        principal.getName());
+
+    var draft = activityService.createDraftFromActivity(activityId);
+    return ResponseEntity.ok(new ActivityDraftCreationResponse(draft.getId()));
+  }
+
   @PostMapping("/draft")
   public ResponseEntity<ActivityDraftCreationResponse> createActivityDraft(
       Principal principal, @RequestBody ActivityDraftCreationRequest body) {

--- a/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/dto/ActivityContentDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/dto/ActivityContentDTO.java
@@ -27,5 +27,6 @@ public record ActivityContentDTO(
     boolean enableReflection,
     int traceAllowedAssociations,
     int feedbackAllowedIterations,
+    Boolean hasEnrolledStudent,
     Instant createdAt,
     Instant updatedAt) {}

--- a/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityContentDtoMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityContentDtoMapper.java
@@ -5,11 +5,13 @@ import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.activity.domain.model.ActivityDraft;
 import fr.avenirsesr.portfolio.shared.application.adapter.mapper.OptionalMapper;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring", uses = OptionalMapper.class)
 public interface ActivityContentDtoMapper {
 
+  @Mapping(target = "hasEnrolledStudent", expression = "java(null)")
   ActivityContentDTO toDTO(Activity activity);
 
-  ActivityContentDTO toDTO(ActivityDraft activity);
+  ActivityContentDTO toDTO(ActivityDraft activity, Boolean hasEnrolledStudent);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
@@ -45,12 +45,12 @@ public interface ActivityService {
   PagedResult<ActivityWithStudentStatusData> activitiesView(
       EActivityThematic thematic, PageCriteria pageCriteria);
 
+  PagedResult<ActivityWithStudentStatusData> latestActivitiesView(PageCriteria pageCriteria);
+
   PagedResult<ActivityStaffOverviewData> staffActivityWorkingSpace(PageCriteria pageCriteria);
 
   PagedResult<ActivityStaffOverviewData> staffActivityLibrary(
       EActivityThematic thematic, PageCriteria pageCriteria);
-
-  PagedResult<ActivityWithStudentStatusData> latestActivitiesView(PageCriteria pageCriteria);
 
   ActivityDraft createActivityDraft(String title);
 
@@ -66,4 +66,6 @@ public interface ActivityService {
       Integer traceAllowedAssociations,
       Integer feedbackAllowedIterations,
       Boolean enableReflection);
+
+  ActivityDraft createDraftFromActivity(UUID activityId);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
@@ -68,4 +68,6 @@ public interface ActivityService {
       Boolean enableReflection);
 
   ActivityDraft createDraftFromActivity(UUID activityId);
+
+  Boolean hasEnrolledStudents(ActivityDraft draft);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -421,4 +421,9 @@ public class ActivityServiceImpl implements ActivityService {
   private boolean hasEnrolledStudents(Activity activity) {
     return declaredActivityService.countEnrolledStudents(activity) > 0;
   }
+
+  @Override
+  public Boolean hasEnrolledStudents(ActivityDraft draft) {
+    return activityRepository.findById(draft.getId()).map(this::hasEnrolledStudents).orElse(false);
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -379,4 +379,46 @@ public class ActivityServiceImpl implements ActivityService {
     log.info("Updated activity draft with id: {}", id);
     return updatedDraft;
   }
+
+  @Override
+  public ActivityDraft createDraftFromActivity(UUID activityId) {
+    var staff = loggedInUserService.getLoggedInStaff();
+    var activity =
+        activityRepository.findById(activityId).orElseThrow(ActivityNotFoundException::new);
+
+    if (!activity.getAuthor().equals(staff)) {
+      throw new UserNotAuthorizedException();
+    }
+
+    var draft =
+        ActivityDraft.toDomain(
+            activityId,
+            activity.getCreatedAt(),
+            activity.getUpdatedAt(),
+            activity.getTitle(),
+            activity.getAuthor(),
+            activity.getThematic(),
+            activity.getSummary(),
+            activity.getDescription().orElse(null),
+            activity.getExecutionPeriodInfo().orElse(null),
+            activity.getExecutionPeriodInfoSummary().orElse(null),
+            activity.getTraceAllowedAssociations(),
+            activity.getFeedbackAllowedIterations(),
+            activity.isEnableReflection(),
+            activity.getBanner().orElse(null));
+
+    var savedDraft = activityDraftRepository.save(draft);
+
+    if (!hasEnrolledStudents(activity)) {
+      activity.setStatus(EActivityStatus.UNPUBLISHED);
+      activityRepository.save(activity);
+      log.info("Unpublished activity {} after creating edition draft", activityId);
+    }
+
+    return savedDraft;
+  }
+
+  private boolean hasEnrolledStudents(Activity activity) {
+    return declaredActivityService.countEnrolledStudents(activity) > 0;
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
@@ -73,4 +73,6 @@ public interface DeclaredActivityService {
   EDeclaredActivityStatus getDeclaredActivityStatus(DeclaredActivity declaredActivity);
 
   DeclaredActivity fetchActivityAndCheckLoggedInStudentAuthorization(UUID declaredActivityId);
+
+  int countEnrolledStudents(Activity activity);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/DeclaredActivityRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/DeclaredActivityRepository.java
@@ -27,4 +27,6 @@ public interface DeclaredActivityRepository extends GenericRepositoryPort<Declar
       Student student, PageCriteria pageCriteria, FetchGraph fetchGraph);
 
   Optional<DeclaredActivity> findByActivity(Student student, Activity activity);
+
+  int countByActivity(Activity activity);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -557,6 +557,11 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
     return feedbackRepository.findDeclaredActivityIdsHavingActiveFeedbacks(declaredActivityIds);
   }
 
+  @Override
+  public int countEnrolledStudents(Activity activity) {
+    return declaredActivityRepository.countByActivity(activity);
+  }
+
   private EAssociationType getAssociationType(EAssociationContextType contextType) {
     return switch (contextType) {
       case TRACE -> EAssociationType.DECLARED_ACTIVITY_TRACE;

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/DeclaredActivityDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/DeclaredActivityDatabaseRepository.java
@@ -83,4 +83,9 @@ public class DeclaredActivityDatabaseRepository
         .findByStudentIdAndActivityId(student.getId(), activity.getId())
         .map(DeclaredActivityMapper.INSTANCE::toDomain);
   }
+
+  @Override
+  public int countByActivity(Activity activity) {
+    return jpaRepository.countByActivityId(activity.getId());
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/DeclaredActivityJpaRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/DeclaredActivityJpaRepository.java
@@ -10,4 +10,6 @@ public interface DeclaredActivityJpaRepository
     extends JpaRepository<DeclaredActivityEntity, UUID>,
         JpaSpecificationExecutor<DeclaredActivityEntity> {
   Optional<DeclaredActivityEntity> findByStudentIdAndActivityId(UUID studentId, UUID activityId);
+
+  int countByActivityId(UUID activityId);
 }

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java
@@ -35,6 +35,9 @@ class ActivityControllerIT extends ContainerConfigurationTest {
   private static final String LIBRARY_PATH = BASE_PATH + "/staff/library";
   private static final String PUBLISH_PATH = BASE_PATH + "/publish/{draftId}";
   private static final String UNPUBLISH_PATH = BASE_PATH + "/unpublish/{activityId}";
+  private static final String CONTENT_PATH = BASE_PATH + "/{activityStatus}/{activityId}/content";
+  private static final String CREATE_DRAFT_PATH = BASE_PATH + "/create-draft/{activityId}";
+  private static final String SUBSCRIBE_PATH = "/me/activity-progress/subscribe/{activityId}";
 
   @Autowired private WebTestClient webTestClient;
   @Autowired private ObjectMapper objectMapper;
@@ -136,6 +139,20 @@ class ActivityControllerIT extends ContainerConfigurationTest {
             .getResponseBody();
 
     return UUID.fromString(objectMapper.readTree(body).get("createdItemId").asText());
+  }
+
+  private void subscribeStudentToActivity(UUID activityId) {
+    webTestClient
+        .post()
+        .uri(SUBSCRIBE_PATH, activityId)
+        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+        .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isCreated();
   }
 
   private UUID getFirstActivityIdFromOverview() throws Exception {
@@ -1380,6 +1397,286 @@ class ActivityControllerIT extends ContainerConfigurationTest {
             .expectBody()
             .jsonPath("$.code")
             .isEqualTo("USER_IS_NOT_STAFF_EXCEPTION");
+      }
+    }
+
+    @Nested
+    class WhenGettingActivityContent {
+
+      @Test
+      void shouldReturnNullHasEnrolledStudentForPublishedActivity() throws Exception {
+        BddLogger.given("a published activity");
+        UUID activityId = publishNewActivity("Activité contenu publiée");
+
+        BddLogger.when("performing a GET on the content endpoint with status PUBLISHED");
+        BddLogger.then("it should return 200 with hasEnrolledStudent equal to null");
+
+        webTestClient
+            .get()
+            .uri(CONTENT_PATH, "PUBLISHED", activityId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .jsonPath("$.id")
+            .isEqualTo(activityId.toString())
+            .jsonPath("$.hasEnrolledStudent")
+            .doesNotExist();
+      }
+
+      @Test
+      void shouldReturn404WhenActivityNotFound() {
+        BddLogger.given("a non-existent activity id");
+        UUID unknownId = UUID.randomUUID();
+
+        BddLogger.when("performing a GET on the content endpoint with status PUBLISHED");
+        BddLogger.then("it should return 404 with ACTIVITY_NOT_FOUND error code");
+
+        webTestClient
+            .get()
+            .uri(CONTENT_PATH, "PUBLISHED", unknownId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isNotFound()
+            .expectBody()
+            .jsonPath("$.code")
+            .isEqualTo("ACTIVITY_NOT_FOUND");
+      }
+
+      @Test
+      void shouldReturnTrueHasEnrolledStudentForDraftWhenStudentIsEnrolled() throws Exception {
+        BddLogger.given("a published activity with an enrolled student");
+        UUID activityId = publishNewActivity("Activité brouillon avec étudiant inscrit");
+        subscribeStudentToActivity(activityId);
+
+        BddLogger.when("creating a draft from that activity and getting its content");
+        webTestClient
+            .post()
+            .uri(CREATE_DRAFT_PATH, activityId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+        BddLogger.then("the draft content should have hasEnrolledStudent equal to true");
+        webTestClient
+            .get()
+            .uri(CONTENT_PATH, "DRAFT", activityId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .jsonPath("$.hasEnrolledStudent")
+            .isEqualTo(true);
+      }
+
+      @Test
+      void shouldReturnFalseHasEnrolledStudentForDraftWhenNoStudentIsEnrolled() throws Exception {
+        BddLogger.given("a published activity with no enrolled student");
+        UUID activityId = publishNewActivity("Activité brouillon sans étudiant inscrit");
+
+        BddLogger.when("creating a draft from that activity and getting its content");
+        webTestClient
+            .post()
+            .uri(CREATE_DRAFT_PATH, activityId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+        BddLogger.then("the draft content should have hasEnrolledStudent equal to false");
+        webTestClient
+            .get()
+            .uri(CONTENT_PATH, "DRAFT", activityId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .jsonPath("$.hasEnrolledStudent")
+            .isEqualTo(false);
+      }
+
+      @Test
+      void shouldReturn404WhenDraftNotFound() {
+        BddLogger.given("a non-existent draft id");
+        UUID unknownId = UUID.randomUUID();
+
+        BddLogger.when("performing a GET on the content endpoint with status DRAFT");
+        BddLogger.then("it should return 404 with ACTIVITY_DRAFT_NOT_FOUND error code");
+
+        webTestClient
+            .get()
+            .uri(CONTENT_PATH, "DRAFT", unknownId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isNotFound()
+            .expectBody()
+            .jsonPath("$.code")
+            .isEqualTo("ACTIVITY_DRAFT_NOT_FOUND");
+      }
+    }
+
+    @Nested
+    class WhenCreatingDraftFromActivity {
+
+      @Test
+      void shouldCreateDraftWithSameIdAsActivity() throws Exception {
+        BddLogger.given("an existing published activity created by the staff");
+        UUID activityId = publishNewActivity("Activité pour édition de brouillon");
+
+        BddLogger.when("performing a POST on the create-draft endpoint");
+        BddLogger.then("it should return 200 with the same id as the activity");
+
+        webTestClient
+            .post()
+            .uri(CREATE_DRAFT_PATH, activityId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .jsonPath("$.draftId")
+            .isEqualTo(activityId.toString());
+      }
+
+      @Test
+      void shouldUnpublishActivityWhenNoStudentIsEnrolled() throws Exception {
+        BddLogger.given("a published activity with no enrolled student");
+        UUID activityId = publishNewActivity("Activité dépubliée après édition");
+
+        BddLogger.when("creating a draft from that activity");
+        webTestClient
+            .post()
+            .uri(CREATE_DRAFT_PATH, activityId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+        BddLogger.then("the underlying activity should now be UNPUBLISHED");
+        String body =
+            webTestClient
+                .get()
+                .uri(
+                    uriBuilder ->
+                        uriBuilder
+                            .path(WORKING_SPACE_PATH)
+                            .queryParam("page", "0")
+                            .queryParam("pageSize", "100")
+                            .build())
+                .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+                .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+                .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+
+        JsonNode data = objectMapper.readTree(body).get("data");
+        boolean found = false;
+        for (JsonNode item : data) {
+          if (activityId.toString().equals(item.get("activityId").asText())) {
+            assertTrue(
+                "UNPUBLISHED".equals(item.get("activityStatus").asText()),
+                "Expected UNPUBLISHED status but got: " + item.get("activityStatus").asText());
+            found = true;
+            break;
+          }
+        }
+        assertTrue(found, "Activity should still appear in staff working space as UNPUBLISHED");
+      }
+
+      @Test
+      void shouldReturn404WhenActivityNotFound() {
+        BddLogger.given("a non-existent activity id");
+        UUID unknownId = UUID.randomUUID();
+
+        BddLogger.when("performing a POST on the create-draft endpoint with unknown id");
+        BddLogger.then("it should return 404 with ACTIVITY_NOT_FOUND error code");
+
+        webTestClient
+            .post()
+            .uri(CREATE_DRAFT_PATH, unknownId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, staffPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, staffSignature)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isNotFound()
+            .expectBody()
+            .jsonPath("$.code")
+            .isEqualTo("ACTIVITY_NOT_FOUND");
+      }
+
+      @Test
+      void shouldReturn403WhenStudentTriesToCreateDraft() throws Exception {
+        BddLogger.given("an existing published activity and a student (non-staff) account");
+        UUID activityId = publishNewActivity("Activité édition refusée");
+
+        BddLogger.when("performing a POST on the create-draft endpoint with a student account");
+        BddLogger.then("it should return 403 with USER_IS_NOT_STAFF error code");
+
+        webTestClient
+            .post()
+            .uri(CREATE_DRAFT_PATH, activityId)
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, secondStudentPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, secondStudentSignature)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden()
+            .expectBody()
+            .jsonPath("$.code")
+            .isEqualTo("USER_IS_NOT_STAFF_EXCEPTION");
+      }
+
+      @Test
+      void shouldReturn401WhenNotAuthenticated() {
+        BddLogger.given("the " + CREATE_DRAFT_PATH + " endpoint");
+        BddLogger.when("performing a POST without authentication headers");
+        BddLogger.then("it should return 401");
+
+        webTestClient
+            .post()
+            .uri(CREATE_DRAFT_PATH, UUID.randomUUID())
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized();
       }
     }
   }

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerTest.java
@@ -5,14 +5,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import fr.avenirsesr.portfolio.activity.application.adapter.dto.ActivityContentDTO;
 import fr.avenirsesr.portfolio.activity.application.adapter.dto.ActivityOverviewDTO;
 import fr.avenirsesr.portfolio.activity.application.adapter.dto.ActivityStaffOverviewDTO;
 import fr.avenirsesr.portfolio.activity.application.adapter.dto.AuthorDTO;
+import fr.avenirsesr.portfolio.activity.application.adapter.mapper.ActivityContentDtoMapper;
 import fr.avenirsesr.portfolio.activity.application.adapter.mapper.ActivityOverviewDtoMapper;
 import fr.avenirsesr.portfolio.activity.application.adapter.mapper.ActivityStaffOverviewDtoMapper;
+import fr.avenirsesr.portfolio.activity.application.adapter.response.ActivityDraftCreationResponse;
 import fr.avenirsesr.portfolio.activity.domain.data.ActivityStaffOverviewData;
 import fr.avenirsesr.portfolio.activity.domain.data.ActivityWithStudentStatusData;
 import fr.avenirsesr.portfolio.activity.domain.model.Activity;
+import fr.avenirsesr.portfolio.activity.domain.model.ActivityDraft;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityStatus;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityThematic;
 import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
@@ -44,6 +48,7 @@ class ActivityControllerTest {
   @Mock private ActivityService activityService;
   @Mock private ActivityOverviewDtoMapper activityOverviewDtoMapper;
   @Mock private ActivityStaffOverviewDtoMapper activityStaffOverviewDtoMapper;
+  @Mock private ActivityContentDtoMapper activityContentDtoMapper;
 
   @InjectMocks private ActivityController controller;
 
@@ -624,5 +629,125 @@ class ActivityControllerTest {
     verify(activityStaffOverviewDtoMapper).toDTO(data1);
     verify(activityStaffOverviewDtoMapper).toDTO(data2);
     verify(activityStaffOverviewDtoMapper).toDTO(data3);
+  }
+
+  @Test
+  void shouldReturnContentForPublishedActivityWithoutComputingHasEnrolledStudent() {
+    BddLogger.given("a published activity");
+    UUID activityId = activity.getId();
+
+    ActivityContentDTO dto =
+        new ActivityContentDTO(
+            activityId,
+            activity.getTitle(),
+            activity.getThematic(),
+            activity.getSummary(),
+            null,
+            null,
+            true,
+            0,
+            0,
+            null,
+            Instant.now(),
+            Instant.now());
+
+    when(activityService.getActivityById(activityId)).thenReturn(activity);
+    when(activityContentDtoMapper.toDTO(activity)).thenReturn(dto);
+
+    BddLogger.when("getting the activity content for status PUBLISHED");
+    var response = controller.getActivityContent(EActivityStatus.PUBLISHED, activityId);
+
+    BddLogger.then("it should return the DTO without calling hasEnrolledStudents");
+    assertEquals(200, response.getStatusCode().value());
+    assertEquals(dto, response.getBody());
+    verify(activityContentDtoMapper).toDTO(activity);
+    verify(activityService, never()).hasEnrolledStudents(any(ActivityDraft.class));
+  }
+
+  @Test
+  void shouldReturnContentForUnpublishedActivityWithoutComputingHasEnrolledStudent() {
+    BddLogger.given("an unpublished activity");
+    UUID activityId = activity.getId();
+
+    ActivityContentDTO dto =
+        new ActivityContentDTO(
+            activityId,
+            activity.getTitle(),
+            activity.getThematic(),
+            activity.getSummary(),
+            null,
+            null,
+            true,
+            0,
+            0,
+            null,
+            Instant.now(),
+            Instant.now());
+
+    when(activityService.getActivityById(activityId)).thenReturn(activity);
+    when(activityContentDtoMapper.toDTO(activity)).thenReturn(dto);
+
+    BddLogger.when("getting the activity content for status UNPUBLISHED");
+    var response = controller.getActivityContent(EActivityStatus.UNPUBLISHED, activityId);
+
+    BddLogger.then("it should return the DTO without calling hasEnrolledStudents");
+    assertEquals(200, response.getStatusCode().value());
+    assertEquals(dto, response.getBody());
+    verify(activityContentDtoMapper).toDTO(activity);
+    verify(activityService, never()).hasEnrolledStudents(any(ActivityDraft.class));
+  }
+
+  @Test
+  void shouldReturnContentForDraftUsingComputedHasEnrolledStudent() {
+    BddLogger.given("an activity draft");
+    UUID draftId = UUID.randomUUID();
+    ActivityDraft draft = mock(ActivityDraft.class);
+
+    ActivityContentDTO dto =
+        new ActivityContentDTO(
+            draftId,
+            "title",
+            EActivityThematic.EXPERIENCES,
+            "summary",
+            null,
+            null,
+            true,
+            0,
+            0,
+            true,
+            Instant.now(),
+            Instant.now());
+
+    when(activityService.getActivityDraftById(draftId)).thenReturn(draft);
+    when(activityService.hasEnrolledStudents(draft)).thenReturn(true);
+    when(activityContentDtoMapper.toDTO(draft, true)).thenReturn(dto);
+
+    BddLogger.when("getting the activity content for status DRAFT");
+    var response = controller.getActivityContent(EActivityStatus.DRAFT, draftId);
+
+    BddLogger.then("it should return the DTO built from the computed hasEnrolledStudents value");
+    assertEquals(200, response.getStatusCode().value());
+    assertEquals(dto, response.getBody());
+    verify(activityService).hasEnrolledStudents(draft);
+    verify(activityContentDtoMapper).toDTO(draft, true);
+  }
+
+  @Test
+  void shouldCreateDraftFromActivityAndReturnItsId() {
+    BddLogger.given("an existing activity and its author");
+    UUID activityId = UUID.randomUUID();
+    UUID draftId = UUID.randomUUID();
+    ActivityDraft draft = mock(ActivityDraft.class);
+    when(draft.getId()).thenReturn(draftId);
+    when(activityService.createDraftFromActivity(activityId)).thenReturn(draft);
+
+    BddLogger.when("creating a draft from that activity");
+    ResponseEntity<ActivityDraftCreationResponse> response =
+        controller.createDraftFromActivity(principal, activityId);
+
+    BddLogger.then("it should return the created draft id");
+    assertEquals(200, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+    assertEquals(draftId, response.getBody().draftId());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityContentDtoMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityContentDtoMapperTest.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import fr.avenirsesr.portfolio.activity.application.adapter.dto.ActivityContentDTO;
 import fr.avenirsesr.portfolio.activity.domain.model.Activity;
+import fr.avenirsesr.portfolio.activity.domain.model.ActivityDraft;
 import fr.avenirsesr.portfolio.activity.infrastructure.fixture.ActivityFixture;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.shared.application.adapter.mapper.OptionalMapper;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.StaffFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
@@ -37,6 +39,7 @@ class ActivityContentDtoMapperTest {
     assertEquals(activity.getSummary(), dto.summary());
     assertEquals(activity.getDescription().orElse(null), dto.description());
     assertEquals(activity.getExecutionPeriodInfo().orElse(null), dto.executionPeriodInfo());
+    assertNull(dto.hasEnrolledStudent());
   }
 
   @Test
@@ -52,5 +55,29 @@ class ActivityContentDtoMapperTest {
     assertNotNull(dto);
     assertNull(dto.description());
     assertNull(dto.executionPeriodInfo());
+  }
+
+  @Test
+  void shouldMapDraftHasEnrolledStudentWhenProvided() {
+    BddLogger.given("an activity draft and a computed hasEnrolledStudent value");
+    ActivityDraft draft = ActivityDraft.create("draft title", StaffFixture.create().toModel());
+
+    BddLogger.when("mapping to ActivityContentDTO with hasEnrolledStudent = true");
+    ActivityContentDTO dto = mapper.toDTO(draft, true);
+
+    BddLogger.then("hasEnrolledStudent should be true");
+    assertEquals(Boolean.TRUE, dto.hasEnrolledStudent());
+  }
+
+  @Test
+  void shouldMapDraftHasEnrolledStudentToNullWhenNotProvided() {
+    BddLogger.given("an activity draft with no known enrolled student value");
+    ActivityDraft draft = ActivityDraft.create("draft title", StaffFixture.create().toModel());
+
+    BddLogger.when("mapping to ActivityContentDTO with hasEnrolledStudent = null");
+    ActivityContentDTO dto = mapper.toDTO(draft, null);
+
+    BddLogger.then("hasEnrolledStudent should be null");
+    assertNull(dto.hasEnrolledStudent());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -1528,6 +1528,60 @@ class ActivityServiceImplTest {
     }
 
     @Nested
+    class WhenCheckingIfDraftHasEnrolledStudents {
+
+      UUID draftId = UUID.randomUUID();
+      ActivityDraft draft = mock(ActivityDraft.class);
+      Activity activity = mock(Activity.class);
+
+      @BeforeEach
+      void setupWhen() {
+        BddLogger.when("checking if a draft's underlying activity has enrolled students");
+        when(draft.getId()).thenReturn(draftId);
+      }
+
+      @Nested
+      class AndTheUnderlyingActivityExists {
+
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the underlying activity exists");
+          when(activityRepository.findById(draftId)).thenReturn(Optional.of(activity));
+        }
+
+        @Test
+        void thenReturnsTrueWhenActivityHasEnrolledStudents() {
+          BddLogger.then("it should return true when the activity has enrolled students");
+          when(declaredActivityService.countEnrolledStudents(activity)).thenReturn(2);
+          assertTrue(activityService.hasEnrolledStudents(draft));
+        }
+
+        @Test
+        void thenReturnsFalseWhenActivityHasNoEnrolledStudents() {
+          BddLogger.then("it should return false when the activity has no enrolled students");
+          when(declaredActivityService.countEnrolledStudents(activity)).thenReturn(0);
+          assertFalse(activityService.hasEnrolledStudents(draft));
+        }
+      }
+
+      @Nested
+      class AndTheUnderlyingActivityDoesNotExist {
+
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the underlying activity does not exist (brand new draft)");
+          when(activityRepository.findById(draftId)).thenReturn(Optional.empty());
+        }
+
+        @Test
+        void thenReturnsFalse() {
+          BddLogger.then("it should return false");
+          assertFalse(activityService.hasEnrolledStudents(draft));
+        }
+      }
+    }
+
+    @Nested
     class WhenDeletingAnActivityDraft {
 
       @BeforeEach

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -1399,6 +1399,135 @@ class ActivityServiceImplTest {
     }
 
     @Nested
+    class WhenCreatingDraftFromActivity {
+
+      @BeforeEach
+      void setupWhen() {
+        BddLogger.when("creating a draft from an existing activity");
+      }
+
+      @Nested
+      class AndActivityExistsAndStaffIsAuthor {
+
+        UUID activityId = UUID.randomUUID();
+        Staff staff = mock(Staff.class);
+        Activity activity = mock(Activity.class);
+        ActivityDraft savedDraft = mock(ActivityDraft.class);
+
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the activity exists and the logged-in staff is the author");
+          when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+          when(activityRepository.findById(activityId)).thenReturn(Optional.of(activity));
+          when(activity.getId()).thenReturn(activityId);
+          when(activity.getAuthor()).thenReturn(staff);
+          when(activity.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
+          when(activityDraftRepository.save(any(ActivityDraft.class))).thenReturn(savedDraft);
+        }
+
+        @Nested
+        class AndActivityHasNoEnrolledStudents {
+
+          @BeforeEach
+          void setupAnd() {
+            BddLogger.and("the activity has no enrolled students");
+            when(declaredActivityService.countEnrolledStudents(activity)).thenReturn(0);
+          }
+
+          @Test
+          void thenActivityStatusIsSetToUnpublished() {
+            BddLogger.then("the activity status is set to UNPUBLISHED instead of being deleted");
+            activityService.createDraftFromActivity(activityId);
+            verify(activity).setStatus(EActivityStatus.UNPUBLISHED);
+            verify(activityRepository).save(activity);
+            verify(activityRepository, never()).removeFromDatabase(any());
+          }
+
+          @Test
+          void thenItReturnsTheSavedDraft() {
+            BddLogger.then("the saved draft is returned");
+            ActivityDraft result = activityService.createDraftFromActivity(activityId);
+            assertEquals(savedDraft, result);
+          }
+        }
+
+        @Nested
+        class AndActivityHasEnrolledStudents {
+
+          @BeforeEach
+          void setupAnd() {
+            BddLogger.and("the activity has enrolled students");
+            when(declaredActivityService.countEnrolledStudents(activity)).thenReturn(1);
+          }
+
+          @Test
+          void thenActivityIsNeitherUnpublishedNorDeleted() {
+            BddLogger.then("the activity is left untouched");
+            activityService.createDraftFromActivity(activityId);
+            verify(activity, never()).setStatus(any());
+            verify(activityRepository, never()).save(any());
+            verify(activityRepository, never()).removeFromDatabase(any());
+          }
+
+          @Test
+          void thenItReturnsTheSavedDraft() {
+            BddLogger.then("the saved draft is returned");
+            ActivityDraft result = activityService.createDraftFromActivity(activityId);
+            assertEquals(savedDraft, result);
+          }
+        }
+      }
+
+      @Nested
+      class AndActivityDoesNotExist {
+
+        UUID unknownId = UUID.randomUUID();
+
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the activity does not exist");
+          when(loggedInUserService.getLoggedInStaff()).thenReturn(mock(Staff.class));
+          when(activityRepository.findById(unknownId)).thenReturn(Optional.empty());
+        }
+
+        @Test
+        void thenThrowsActivityNotFoundException() {
+          BddLogger.then("the service should throw ActivityNotFoundException");
+          assertThrows(
+              ActivityNotFoundException.class,
+              () -> activityService.createDraftFromActivity(unknownId));
+          verify(activityDraftRepository, never()).save(any());
+        }
+      }
+
+      @Nested
+      class AndStaffIsNotTheAuthor {
+
+        UUID activityId = UUID.randomUUID();
+        Staff loggedInStaff = mock(Staff.class);
+        Staff author = mock(Staff.class);
+        Activity activity = mock(Activity.class);
+
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the logged-in staff is not the author of the activity");
+          when(loggedInUserService.getLoggedInStaff()).thenReturn(loggedInStaff);
+          when(activityRepository.findById(activityId)).thenReturn(Optional.of(activity));
+          when(activity.getAuthor()).thenReturn(author);
+        }
+
+        @Test
+        void thenThrowsUserNotAuthorizedException() {
+          BddLogger.then("the service should throw UserNotAuthorizedException");
+          assertThrows(
+              UserNotAuthorizedException.class,
+              () -> activityService.createDraftFromActivity(activityId));
+          verify(activityDraftRepository, never()).save(any());
+        }
+      }
+    }
+
+    @Nested
     class WhenDeletingAnActivityDraft {
 
       @BeforeEach

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
@@ -170,6 +170,7 @@ class DeclaredActivityPresentationDTOMapperTest {
         activity.isEnableReflection(),
         activity.getTraceAllowedAssociations(),
         activity.getFeedbackAllowedIterations(),
+        true,
         activity.getCreatedAt(),
         activity.getUpdatedAt());
   }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -1699,4 +1699,30 @@ class DeclaredActivityServiceImplTest {
     assertThatCode(() -> service.checkDeclaredActivitiesUnlocked(List.of(declaredActivityId)))
         .doesNotThrowAnyException();
   }
+
+  @Test
+  void countEnrolledStudents_should_delegate_to_repository() {
+    BddLogger.given("an activity with enrolled students");
+    Activity activity = ActivityFixture.create().toModel();
+    when(declaredActivityRepository.countByActivity(activity)).thenReturn(3);
+
+    BddLogger.when("counting enrolled students");
+    int count = service.countEnrolledStudents(activity);
+
+    BddLogger.then("it should return the repository count");
+    assertThat(count).isEqualTo(3);
+  }
+
+  @Test
+  void countEnrolledStudents_should_return_zero_when_no_students_enrolled() {
+    BddLogger.given("an activity with no enrolled students");
+    Activity activity = ActivityFixture.create().toModel();
+    when(declaredActivityRepository.countByActivity(activity)).thenReturn(0);
+
+    BddLogger.when("counting enrolled students");
+    int count = service.countEnrolledStudents(activity);
+
+    BddLogger.then("it should return zero");
+    assertThat(count).isZero();
+  }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> When a staff member creates an edition draft from a published activity that has no enrolled students, the activity is now switched to the `UNPUBLISHED` status instead of being permanently deleted from the database. This preserves the activity's history while still removing it from student-facing views. Unit tests were added for `ActivityServiceImpl#createDraftFromActivity` covering the author/non-author, not-found, and with/without enrolled students cases.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1993

---

### Documentation
> No documentation updates required.

---

### Target Branch
> `develop`

---

### Additional Notes
> No behavior change for activities that still have enrolled students: the activity is left untouched in that case, as before.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
