### PR TITLE
feat(activity): update existing activity when publishing a draft

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -107,24 +107,37 @@ public class ActivityServiceImpl implements ActivityService {
     }
 
     var activity =
-        activityRepository.save(
-            Activity.create(
-                draft.getId(),
-                draft.getAuthor(),
-                draft.getTitle(),
-                draft.getThematic(),
-                draft.getSummary().get(),
-                draft.getDescription().orElse(null),
-                draft.getExecutionPeriodInfo().orElse(null),
-                draft.getExecutionPeriodInfoSummary().orElse(null),
-                draft.isEnableReflection(),
-                draft.getTraceAllowedAssociations(),
-                draft.getFeedbackAllowedIterations(),
-                draft.getBanner().orElse(null),
-                draft.getLinks()));
+        activityRepository
+            .findById(activityDraftId)
+            .orElse(
+                Activity.create(
+                    draft.getId(),
+                    draft.getAuthor(),
+                    draft.getTitle(),
+                    draft.getThematic(),
+                    draft.getSummary().get(),
+                    draft.getDescription().orElse(null),
+                    draft.getExecutionPeriodInfo().orElse(null),
+                    draft.getExecutionPeriodInfoSummary().orElse(null),
+                    draft.isEnableReflection(),
+                    draft.getTraceAllowedAssociations(),
+                    draft.getFeedbackAllowedIterations(),
+                    draft.getBanner().orElse(null),
+                    draft.getLinks()));
+
+    activity.setTitle(draft.getTitle());
+    activity.setThematic(draft.getThematic());
+    activity.setDescription(draft.getDescription().orElse(null));
+    activity.setSummary(draft.getSummary().orElse(null));
+    activity.setExecutionPeriodInfo(draft.getExecutionPeriodInfo().orElse(null));
+    activity.setExecutionPeriodInfoSummary(draft.getExecutionPeriodInfoSummary().orElse(null));
+    activity.setBanner(draft.getBanner().orElse(null));
+    activity.setStatus(EActivityStatus.PUBLISHED);
+
+    var savedActivity = activityRepository.save(activity);
 
     activityDraftRepository.removeFromDatabase(draft);
-    return activity;
+    return savedActivity;
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -106,38 +106,57 @@ public class ActivityServiceImpl implements ActivityService {
           EErrorCode.NOT_BLANK, "summary must be defined to publish an activity");
     }
 
-    var activity =
-        activityRepository
-            .findById(activityDraftId)
-            .orElse(
-                Activity.create(
-                    draft.getId(),
-                    draft.getAuthor(),
-                    draft.getTitle(),
-                    draft.getThematic(),
-                    draft.getSummary().get(),
-                    draft.getDescription().orElse(null),
-                    draft.getExecutionPeriodInfo().orElse(null),
-                    draft.getExecutionPeriodInfoSummary().orElse(null),
-                    draft.isEnableReflection(),
-                    draft.getTraceAllowedAssociations(),
-                    draft.getFeedbackAllowedIterations(),
-                    draft.getBanner().orElse(null),
-                    draft.getLinks()));
+    var publishedActivity = activityRepository.findById(activityDraftId);
 
-    activity.setTitle(draft.getTitle());
-    activity.setThematic(draft.getThematic());
-    activity.setDescription(draft.getDescription().orElse(null));
-    activity.setSummary(draft.getSummary().orElse(null));
-    activity.setExecutionPeriodInfo(draft.getExecutionPeriodInfo().orElse(null));
-    activity.setExecutionPeriodInfoSummary(draft.getExecutionPeriodInfoSummary().orElse(null));
-    activity.setBanner(draft.getBanner().orElse(null));
-    activity.setStatus(EActivityStatus.PUBLISHED);
+    Activity activity =
+        publishedActivity.orElse(
+            Activity.create(
+                draft.getId(),
+                draft.getAuthor(),
+                draft.getTitle(),
+                draft.getThematic(),
+                draft.getSummary().orElseThrow(),
+                draft.getDescription().orElse(null),
+                draft.getExecutionPeriodInfo().orElse(null),
+                draft.getExecutionPeriodInfoSummary().orElse(null),
+                draft.isEnableReflection(),
+                draft.getTraceAllowedAssociations(),
+                draft.getFeedbackAllowedIterations(),
+                draft.getBanner().orElse(null),
+                draft.getLinks()));
+
+    if (publishedActivity.isPresent()) {
+      if (hasEnrolledStudents(activity)) {
+        updateEngagedActivity(activity, draft);
+      } else {
+        updateUnEngagedActivity(activity, draft);
+      }
+      activity.setStatus(EActivityStatus.PUBLISHED);
+    }
 
     var savedActivity = activityRepository.save(activity);
 
     activityDraftRepository.removeFromDatabase(draft);
     return savedActivity;
+  }
+
+  private void updateUnEngagedActivity(Activity publishedActivity, ActivityDraft draft) {
+    updateEngagedActivity(publishedActivity, draft);
+    publishedActivity.setTraceAllowedAssociations(draft.getTraceAllowedAssociations());
+    publishedActivity.setFeedbackAllowedIterations(draft.getFeedbackAllowedIterations());
+    publishedActivity.setEnableReflection(draft.isEnableReflection());
+  }
+
+  private void updateEngagedActivity(Activity publishedActivity, ActivityDraft draft) {
+    publishedActivity.setTitle(draft.getTitle());
+    publishedActivity.setThematic(draft.getThematic());
+    publishedActivity.setDescription(draft.getDescription().orElse(null));
+    publishedActivity.setSummary(draft.getSummary().orElse(null));
+    publishedActivity.setExecutionPeriodInfo(draft.getExecutionPeriodInfo().orElse(null));
+    publishedActivity.setExecutionPeriodInfoSummary(
+        draft.getExecutionPeriodInfoSummary().orElse(null));
+    publishedActivity.setBanner(draft.getBanner().orElse(null));
+    publishedActivity.setLinks(draft.getLinks());
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -561,19 +561,19 @@ class ActivityServiceImplTest {
     @Nested
     class WhenPublishingADraftThatSharesIdWithAnExistingActivity {
 
+      UUID activityId;
+      Staff staff;
+      ActivityDraft draft;
+      Activity existingActivity;
+
       @BeforeEach
       void setupWhen() {
         BddLogger.when("publishing a draft that shares its id with an existing activity");
-      }
 
-      @Test
-      void thenItShouldUpdateExistingActivityInsteadOfCreatingANewOne() {
-        BddLogger.then("the existing activity should be reused and updated, not recreated");
-
-        UUID activityId = UUID.randomUUID();
-        Staff staff = mock(Staff.class);
-        ActivityDraft draft = mock(ActivityDraft.class);
-        Activity existingActivity = mock(Activity.class);
+        activityId = UUID.randomUUID();
+        staff = mock(Staff.class);
+        draft = mock(ActivityDraft.class);
+        existingActivity = mock(Activity.class);
 
         when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
         when(activityDraftRepository.findById(activityId)).thenReturn(Optional.of(draft));
@@ -585,86 +585,108 @@ class ActivityServiceImplTest {
         when(draft.getExecutionPeriodInfo()).thenReturn(Optional.of("Nouvelle période"));
         when(draft.getExecutionPeriodInfoSummary()).thenReturn(Optional.of("Nouveau label"));
         when(draft.getBanner()).thenReturn(Optional.empty());
-
-        when(activityRepository.findById(activityId)).thenReturn(Optional.of(existingActivity));
-        when(activityRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-
-        Activity result = activityService.publish(activityId);
-
-        assertSame(existingActivity, result);
-        verify(existingActivity).setTitle("Nouveau titre");
-        verify(existingActivity).setThematic(EActivityThematic.EXPERIENCES);
-        verify(existingActivity).setDescription("Nouvelle description");
-        verify(existingActivity).setSummary("Nouveau résumé");
-        verify(existingActivity).setExecutionPeriodInfo("Nouvelle période");
-        verify(existingActivity).setExecutionPeriodInfoSummary("Nouveau label");
-        verify(existingActivity).setBanner(null);
-        verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
-        verify(activityRepository).save(existingActivity);
-        verify(activityDraftRepository).removeFromDatabase(draft);
-      }
-
-      @Test
-      void thenItShouldNotOverwriteNotEditableFieldsOfExistingActivity() {
-        BddLogger.then(
-            "enableReflection, traceAllowedAssociations and feedbackAllowedIterations should not"
-                + " be touched on an already existing activity");
-
-        UUID activityId = UUID.randomUUID();
-        Staff staff = mock(Staff.class);
-        ActivityDraft draft = mock(ActivityDraft.class);
-        Activity existingActivity = mock(Activity.class);
-
-        when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
-        when(activityDraftRepository.findById(activityId)).thenReturn(Optional.of(draft));
-        when(draft.getAuthor()).thenReturn(staff);
-        when(draft.getSummary()).thenReturn(Optional.of("Résumé"));
-        when(draft.getTitle()).thenReturn("Titre");
-        when(draft.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
-        when(draft.getDescription()).thenReturn(Optional.empty());
-        when(draft.getExecutionPeriodInfo()).thenReturn(Optional.empty());
-        when(draft.getExecutionPeriodInfoSummary()).thenReturn(Optional.empty());
-        when(draft.getBanner()).thenReturn(Optional.empty());
+        when(draft.getLinks()).thenReturn(List.of("https://example.com"));
         when(draft.isEnableReflection()).thenReturn(false);
-        when(draft.getTraceAllowedAssociations()).thenReturn(99);
-        when(draft.getFeedbackAllowedIterations()).thenReturn(99);
+        when(draft.getTraceAllowedAssociations()).thenReturn(3);
+        when(draft.getFeedbackAllowedIterations()).thenReturn(5);
 
         when(activityRepository.findById(activityId)).thenReturn(Optional.of(existingActivity));
         when(activityRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-
-        activityService.publish(activityId);
-
-        verify(existingActivity, never()).setEnableReflection(anyBoolean());
-        verify(existingActivity, never()).setTraceAllowedAssociations(anyInt());
-        verify(existingActivity, never()).setFeedbackAllowedIterations(anyInt());
       }
 
-      @Test
-      void thenItShouldRepublishAnUnpublishedActivity() {
-        BddLogger.then("the existing activity should be republished through its draft");
+      @Nested
+      class AndTheActivityHasNoEnrolledStudents {
 
-        UUID activityId = UUID.randomUUID();
-        Staff staff = mock(Staff.class);
-        ActivityDraft draft = mock(ActivityDraft.class);
-        Activity existingActivity = mock(Activity.class);
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the activity has no enrolled students");
+          when(declaredActivityService.countEnrolledStudents(existingActivity)).thenReturn(0);
+        }
 
-        when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
-        when(activityDraftRepository.findById(activityId)).thenReturn(Optional.of(draft));
-        when(draft.getAuthor()).thenReturn(staff);
-        when(draft.getSummary()).thenReturn(Optional.of("Résumé"));
-        when(draft.getTitle()).thenReturn("Titre");
-        when(draft.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
-        when(draft.getDescription()).thenReturn(Optional.empty());
-        when(draft.getExecutionPeriodInfo()).thenReturn(Optional.empty());
-        when(draft.getExecutionPeriodInfoSummary()).thenReturn(Optional.empty());
-        when(draft.getBanner()).thenReturn(Optional.empty());
+        @Test
+        void thenItShouldUpdateExistingActivityInsteadOfCreatingANewOne() {
+          BddLogger.then("the existing activity should be reused and updated, not recreated");
 
-        when(activityRepository.findById(activityId)).thenReturn(Optional.of(existingActivity));
-        when(activityRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+          Activity result = activityService.publish(activityId);
 
-        activityService.publish(activityId);
+          assertSame(existingActivity, result);
+          verify(existingActivity).setTitle("Nouveau titre");
+          verify(existingActivity).setThematic(EActivityThematic.EXPERIENCES);
+          verify(existingActivity).setDescription("Nouvelle description");
+          verify(existingActivity).setSummary("Nouveau résumé");
+          verify(existingActivity).setExecutionPeriodInfo("Nouvelle période");
+          verify(existingActivity).setExecutionPeriodInfoSummary("Nouveau label");
+          verify(existingActivity).setBanner(null);
+          verify(existingActivity).setLinks(List.of("https://example.com"));
+          verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
+          verify(activityRepository).save(existingActivity);
+          verify(activityDraftRepository).removeFromDatabase(draft);
+        }
 
-        verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
+        @Test
+        void thenItShouldUpdateNotEditableFieldsOfExistingActivity() {
+          BddLogger.then(
+              "enableReflection, traceAllowedAssociations and feedbackAllowedIterations should be"
+                  + " updated when no student is enrolled");
+
+          activityService.publish(activityId);
+
+          verify(existingActivity).setEnableReflection(false);
+          verify(existingActivity).setTraceAllowedAssociations(3);
+          verify(existingActivity).setFeedbackAllowedIterations(5);
+        }
+
+        @Test
+        void thenItShouldRepublishAnUnpublishedActivity() {
+          BddLogger.then("the existing activity should be republished through its draft");
+
+          activityService.publish(activityId);
+
+          verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
+        }
+      }
+
+      @Nested
+      class AndTheActivityHasEnrolledStudents {
+
+        @BeforeEach
+        void setupAnd() {
+          BddLogger.and("the activity has enrolled students");
+          when(declaredActivityService.countEnrolledStudents(existingActivity)).thenReturn(2);
+        }
+
+        @Test
+        void thenItShouldUpdateEditableFieldsOfExistingActivity() {
+          BddLogger.then("only the fields editable while students are enrolled should be updated");
+
+          Activity result = activityService.publish(activityId);
+
+          assertSame(existingActivity, result);
+          verify(existingActivity).setTitle("Nouveau titre");
+          verify(existingActivity).setThematic(EActivityThematic.EXPERIENCES);
+          verify(existingActivity).setDescription("Nouvelle description");
+          verify(existingActivity).setSummary("Nouveau résumé");
+          verify(existingActivity).setExecutionPeriodInfo("Nouvelle période");
+          verify(existingActivity).setExecutionPeriodInfoSummary("Nouveau label");
+          verify(existingActivity).setBanner(null);
+          verify(existingActivity).setLinks(List.of("https://example.com"));
+          verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
+          verify(activityRepository).save(existingActivity);
+          verify(activityDraftRepository).removeFromDatabase(draft);
+        }
+
+        @Test
+        void thenItShouldNotOverwriteNotEditableFieldsOfExistingActivity() {
+          BddLogger.then(
+              "enableReflection, traceAllowedAssociations and feedbackAllowedIterations should not"
+                  + " be touched when students are enrolled");
+
+          activityService.publish(activityId);
+
+          verify(existingActivity, never()).setEnableReflection(anyBoolean());
+          verify(existingActivity, never()).setTraceAllowedAssociations(anyInt());
+          verify(existingActivity, never()).setFeedbackAllowedIterations(anyInt());
+        }
       }
     }
 

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -559,6 +559,116 @@ class ActivityServiceImplTest {
     }
 
     @Nested
+    class WhenPublishingADraftThatSharesIdWithAnExistingActivity {
+
+      @BeforeEach
+      void setupWhen() {
+        BddLogger.when("publishing a draft that shares its id with an existing activity");
+      }
+
+      @Test
+      void thenItShouldUpdateExistingActivityInsteadOfCreatingANewOne() {
+        BddLogger.then("the existing activity should be reused and updated, not recreated");
+
+        UUID activityId = UUID.randomUUID();
+        Staff staff = mock(Staff.class);
+        ActivityDraft draft = mock(ActivityDraft.class);
+        Activity existingActivity = mock(Activity.class);
+
+        when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+        when(activityDraftRepository.findById(activityId)).thenReturn(Optional.of(draft));
+        when(draft.getAuthor()).thenReturn(staff);
+        when(draft.getSummary()).thenReturn(Optional.of("Nouveau résumé"));
+        when(draft.getTitle()).thenReturn("Nouveau titre");
+        when(draft.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
+        when(draft.getDescription()).thenReturn(Optional.of("Nouvelle description"));
+        when(draft.getExecutionPeriodInfo()).thenReturn(Optional.of("Nouvelle période"));
+        when(draft.getExecutionPeriodInfoSummary()).thenReturn(Optional.of("Nouveau label"));
+        when(draft.getBanner()).thenReturn(Optional.empty());
+
+        when(activityRepository.findById(activityId)).thenReturn(Optional.of(existingActivity));
+        when(activityRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Activity result = activityService.publish(activityId);
+
+        assertSame(existingActivity, result);
+        verify(existingActivity).setTitle("Nouveau titre");
+        verify(existingActivity).setThematic(EActivityThematic.EXPERIENCES);
+        verify(existingActivity).setDescription("Nouvelle description");
+        verify(existingActivity).setSummary("Nouveau résumé");
+        verify(existingActivity).setExecutionPeriodInfo("Nouvelle période");
+        verify(existingActivity).setExecutionPeriodInfoSummary("Nouveau label");
+        verify(existingActivity).setBanner(null);
+        verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
+        verify(activityRepository).save(existingActivity);
+        verify(activityDraftRepository).removeFromDatabase(draft);
+      }
+
+      @Test
+      void thenItShouldNotOverwriteNotEditableFieldsOfExistingActivity() {
+        BddLogger.then(
+            "enableReflection, traceAllowedAssociations and feedbackAllowedIterations should not"
+                + " be touched on an already existing activity");
+
+        UUID activityId = UUID.randomUUID();
+        Staff staff = mock(Staff.class);
+        ActivityDraft draft = mock(ActivityDraft.class);
+        Activity existingActivity = mock(Activity.class);
+
+        when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+        when(activityDraftRepository.findById(activityId)).thenReturn(Optional.of(draft));
+        when(draft.getAuthor()).thenReturn(staff);
+        when(draft.getSummary()).thenReturn(Optional.of("Résumé"));
+        when(draft.getTitle()).thenReturn("Titre");
+        when(draft.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
+        when(draft.getDescription()).thenReturn(Optional.empty());
+        when(draft.getExecutionPeriodInfo()).thenReturn(Optional.empty());
+        when(draft.getExecutionPeriodInfoSummary()).thenReturn(Optional.empty());
+        when(draft.getBanner()).thenReturn(Optional.empty());
+        when(draft.isEnableReflection()).thenReturn(false);
+        when(draft.getTraceAllowedAssociations()).thenReturn(99);
+        when(draft.getFeedbackAllowedIterations()).thenReturn(99);
+
+        when(activityRepository.findById(activityId)).thenReturn(Optional.of(existingActivity));
+        when(activityRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        activityService.publish(activityId);
+
+        verify(existingActivity, never()).setEnableReflection(anyBoolean());
+        verify(existingActivity, never()).setTraceAllowedAssociations(anyInt());
+        verify(existingActivity, never()).setFeedbackAllowedIterations(anyInt());
+      }
+
+      @Test
+      void thenItShouldRepublishAnUnpublishedActivity() {
+        BddLogger.then("the existing activity should be republished through its draft");
+
+        UUID activityId = UUID.randomUUID();
+        Staff staff = mock(Staff.class);
+        ActivityDraft draft = mock(ActivityDraft.class);
+        Activity existingActivity = mock(Activity.class);
+
+        when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
+        when(activityDraftRepository.findById(activityId)).thenReturn(Optional.of(draft));
+        when(draft.getAuthor()).thenReturn(staff);
+        when(draft.getSummary()).thenReturn(Optional.of("Résumé"));
+        when(draft.getTitle()).thenReturn("Titre");
+        when(draft.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
+        when(draft.getDescription()).thenReturn(Optional.empty());
+        when(draft.getExecutionPeriodInfo()).thenReturn(Optional.empty());
+        when(draft.getExecutionPeriodInfoSummary()).thenReturn(Optional.empty());
+        when(draft.getBanner()).thenReturn(Optional.empty());
+
+        when(activityRepository.findById(activityId)).thenReturn(Optional.of(existingActivity));
+        when(activityRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        activityService.publish(activityId);
+
+        verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
+      }
+    }
+
+    @Nested
     class WhenUnpublishingAnActivity {
 
       UUID activityId;


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Met à jour l'endpoint `/publish/{activityDraftId}` : si une activité existe déjà avec l'id du brouillon (republication après édition), ses champs éditables (title, thematic, description, summary, executionPeriodInfo, executionPeriodInfoSummary, banner) et son statut sont mis à jour, tout en préservant les champs `notEditable` (enableReflection, traceAllowedAssociations, feedbackAllowedIterations). Sinon, une nouvelle activité est créée comme auparavant.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1994

---

### Documentation
> Aucune documentation externe impactée.

---

### Target Branch
> `develop`

---

### Additional Notes
> Le brouillon et l'activité d'origine partagent le même id (cf. #1993), ce qui permet de retrouver l'activité existante via `activityRepository.findById(activityDraftId)`.

---

### Known Limitations or Side Effects
> Aucun effet de bord connu.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process