### PR TITLE
refactor(activity): restrict update endpoint to activity drafts

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityController.java
@@ -249,28 +249,20 @@ public class ActivityController {
     return ResponseEntity.ok("Activity draft successfully deleted");
   }
 
-  @PatchMapping("/{activityStatus}/{activityId}")
-  public ResponseEntity<ActivityDraftUpdateResponse> updateActivity(
+  @PatchMapping("/{activityDraftId}")
+  public ResponseEntity<ActivityDraftUpdateResponse> updateActivityDraft(
       Principal principal,
-      @PathVariable
-          @Parameter(
-              name = "activityStatus",
-              in = ParameterIn.PATH,
-              required = true,
-              schema = @Schema(ref = "#/components/schemas/EActivityStatus"))
-          EActivityStatus activityStatus,
-      @PathVariable UUID activityId,
+      @PathVariable UUID activityDraftId,
       @RequestBody ActivityDraftUpdateRequest body) {
     log.debug(
-        "Received request to update activity by user [{}] for activity {} body : {}",
+        "Received request to update activity draft by user [{}] for draft {} body : {}",
         principal.getName(),
-        activityId,
+        activityDraftId,
         body);
 
     var draft =
-        activityService.updateActivity(
-            activityStatus,
-            activityId,
+        activityService.updateActivityDraft(
+            activityDraftId,
             body.title(),
             body.thematic(),
             body.summary(),

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/port/input/ActivityService.java
@@ -55,8 +55,7 @@ public interface ActivityService {
 
   ActivityDraft createActivityDraft(String title);
 
-  ActivityDraft updateActivity(
-      EActivityStatus status,
+  ActivityDraft updateActivityDraft(
       UUID id,
       String title,
       EActivityThematic thematic,

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -339,38 +339,7 @@ public class ActivityServiceImpl implements ActivityService {
   }
 
   @Override
-  public ActivityDraft updateActivity(
-      EActivityStatus status,
-      UUID id,
-      String title,
-      EActivityThematic thematic,
-      String summary,
-      String description,
-      String executionPeriodInfo,
-      String executionPeriodInfoSummary,
-      Integer traceAllowedAssociations,
-      Integer feedbackAllowedIterations,
-      Boolean enableReflection,
-      List<String> links) {
-    return switch (status) {
-      case DRAFT ->
-          updateActivityDraft(
-              id,
-              title,
-              thematic,
-              summary,
-              description,
-              executionPeriodInfo,
-              executionPeriodInfoSummary,
-              traceAllowedAssociations,
-              feedbackAllowedIterations,
-              enableReflection,
-              links);
-      case PUBLISHED, UNPUBLISHED -> throw new UnsupportedOperationException();
-    };
-  }
-
-  private ActivityDraft updateActivityDraft(
+  public ActivityDraft updateActivityDraft(
       UUID id,
       String title,
       EActivityThematic thematic,
@@ -407,11 +376,14 @@ public class ActivityServiceImpl implements ActivityService {
     if (executionPeriodInfo != null) draft.setExecutionPeriodInfo(executionPeriodInfo);
     if (executionPeriodInfoSummary != null)
       draft.setExecutionPeriodInfoSummary(executionPeriodInfoSummary);
-    if (traceAllowedAssociations != null)
-      draft.setTraceAllowedAssociations(traceAllowedAssociations);
-    if (feedbackAllowedIterations != null)
-      draft.setFeedbackAllowedIterations(feedbackAllowedIterations);
-    if (enableReflection != null) draft.setEnableReflection(enableReflection);
+
+    if (!hasEnrolledStudents(draft)) {
+      if (traceAllowedAssociations != null)
+        draft.setTraceAllowedAssociations(traceAllowedAssociations);
+      if (feedbackAllowedIterations != null)
+        draft.setFeedbackAllowedIterations(feedbackAllowedIterations);
+      if (enableReflection != null) draft.setEnableReflection(enableReflection);
+    }
 
     if (links != null && !links.isEmpty()) {
       links.forEach(

--- a/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/seeder/ActivityDraftSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/seeder/ActivityDraftSeeder.java
@@ -2,7 +2,6 @@ package fr.avenirsesr.portfolio.activity.infrastructure.adapter.seeder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import fr.avenirsesr.portfolio.activity.domain.model.ActivityDraft;
-import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityStatus;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityThematic;
 import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
 import fr.avenirsesr.portfolio.activity.infrastructure.adapter.mapper.ActivityDraftMapper;
@@ -124,8 +123,7 @@ public class ActivityDraftSeeder {
             }
 
             var updatedDraft =
-                activityService.updateActivity(
-                    EActivityStatus.DRAFT,
+                activityService.updateActivityDraft(
                     draft.getId(),
                     data.title(),
                     data.thematic(),

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java
@@ -31,7 +31,7 @@ class ActivityControllerIT extends ContainerConfigurationTest {
   private static final String PRESENTATION_PATH =
       BASE_PATH + "/PUBLISHED/{activityId}/presentation";
   private static final String DRAFT_PATH = BASE_PATH + "/draft";
-  private static final String DRAFT_UPDATE_PATH = BASE_PATH + "/DRAFT/{draftId}";
+  private static final String DRAFT_UPDATE_PATH = BASE_PATH + "/{draftId}";
   private static final String WORKING_SPACE_PATH = BASE_PATH + "/staff/working-space";
   private static final String LIBRARY_PATH = BASE_PATH + "/staff/library";
   private static final String PUBLISH_PATH = BASE_PATH + "/publish/{draftId}";

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -206,8 +206,7 @@ class ActivityServiceImplTest {
 
             List<String> links = List.of("https://example.com", "https://avenirs-esr.fr");
             ActivityDraft result =
-                activityService.updateActivity(
-                    EActivityStatus.DRAFT,
+                activityService.updateActivityDraft(
                     draftId,
                     "Nouveau titre",
                     EActivityThematic.EXPERIENCES,
@@ -238,19 +237,8 @@ class ActivityServiceImplTest {
           void thenItShouldNotUpdateFieldsWhenNullIsPassed() {
             BddLogger.then("no field should be updated when null values are passed");
 
-            activityService.updateActivity(
-                EActivityStatus.DRAFT,
-                draftId,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
+            activityService.updateActivityDraft(
+                draftId, null, null, null, null, null, null, null, null, null, null);
 
             verify(draft, never()).setTitle(any());
             verify(draft, never()).setThematic(any());
@@ -269,19 +257,8 @@ class ActivityServiceImplTest {
           void thenItShouldOnlyUpdateProvidedFields() {
             BddLogger.then("only provided fields should be updated");
 
-            activityService.updateActivity(
-                EActivityStatus.DRAFT,
-                draftId,
-                "Titre seul",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
+            activityService.updateActivityDraft(
+                draftId, "Titre seul", null, null, null, null, null, null, null, null, null);
 
             verify(draft).setTitle("Titre seul");
             verify(draft, never()).setThematic(any());
@@ -303,19 +280,8 @@ class ActivityServiceImplTest {
             when(activityDraftRepository.save(draft)).thenReturn(savedDraft);
 
             ActivityDraft result =
-                activityService.updateActivity(
-                    EActivityStatus.DRAFT,
-                    draftId,
-                    "Titre",
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null);
+                activityService.updateActivityDraft(
+                    draftId, "Titre", null, null, null, null, null, null, null, null, null);
 
             assertEquals(savedDraft, result);
           }
@@ -337,19 +303,8 @@ class ActivityServiceImplTest {
             assertThrows(
                 UserNotAuthorizedException.class,
                 () ->
-                    activityService.updateActivity(
-                        EActivityStatus.DRAFT,
-                        draftId,
-                        "Titre",
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null));
+                    activityService.updateActivityDraft(
+                        draftId, "Titre", null, null, null, null, null, null, null, null, null));
 
             verify(activityDraftRepository, never()).save(any());
           }
@@ -372,19 +327,8 @@ class ActivityServiceImplTest {
           assertThrows(
               ActivityDraftNotFoundException.class,
               () ->
-                  activityService.updateActivity(
-                      EActivityStatus.DRAFT,
-                      draftId,
-                      "Titre",
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null));
+                  activityService.updateActivityDraft(
+                      draftId, "Titre", null, null, null, null, null, null, null, null, null));
 
           verify(activityDraftRepository, never()).save(any());
         }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> This PR refactors the activity update endpoint so it only supports activity drafts, since a published activity can never be updated directly.
>
> - Replace `PATCH /me/activities/{activityStatus}/{activityId}` with `PATCH /me/activities/{activityDraftId}`
> - Rename the controller method to `updateActivityDraft` and remove the `activityStatus` path parameter
> - Rename `ActivityService.updateActivity` to `updateActivityDraft` and remove the `EActivityStatus` parameter
> - Remove the status `switch` in `ActivityServiceImpl` (with its `UnsupportedOperationException` for `PUBLISHED`/`UNPUBLISHED` cases); the former private `updateActivityDraft` method becomes the public implementation
> - Update the seeder and tests accordingly

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2091

---

### Documentation
> The OpenAPI specification is updated implicitly: the `activityStatus` path parameter and its Swagger annotation are removed from the update endpoint.

---

### Target Branch
> `develop`

---

### Additional Notes
> The field-locking logic when students are enrolled (`hasEnrolledStudents`) is unchanged: `traceAllowedAssociations`, `feedbackAllowedIterations` and `enableReflection` are still ignored when students are enrolled in the activity.

---

### Known Limitations or Side Effects
> Breaking change for API consumers: the update endpoint URL changes from `/me/activities/{activityStatus}/{activityId}` to `/me/activities/{activityDraftId}`. The frontend must be updated accordingly.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process