### PR TITLE
fix(2076): fix feedback ordering when checking last feedback status

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImpl.java
@@ -87,7 +87,7 @@ public class FeedbackServiceImpl implements FeedbackService {
         feedbackRepository.findAllByDeclaredActivityId(declaredActivityId);
 
     if (!existingFeedbacks.isEmpty()) {
-      Feedback lastFeedback = existingFeedbacks.getLast();
+      Feedback lastFeedback = existingFeedbacks.getFirst();
       switch (lastFeedback.getStatus()) {
         case IN_PROCESS -> throw new FeedbackInProcessException();
         case NEW -> {

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/FeedbackControllerIT.java
@@ -259,6 +259,8 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
         .expectBody()
         .jsonPath("$.id")
         .isEqualTo(feedbackId);
+    updateFeedbackWithText(feedbackId, "Retour.");
+    submitFeedback(feedbackId);
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/FeedbackServiceImplTest.java
@@ -272,6 +272,58 @@ class FeedbackServiceImplTest {
     }
 
     @Test
+    void should_throw_FeedbackInProcessException_when_recent_feedback_is_IN_PROCESS() {
+      BddLogger.given(
+          "A logged-in student with 2 feedbacks: the most recent is IN_PROCESS, the older is"
+              + " SUBMITTED");
+      UUID declaredActivityId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      DeclaredActivity declaredActivity =
+          DeclaredActivity.create(
+              UUID.randomUUID(), student, activity, null, null, null, null, null);
+
+      Feedback submittedFeedback =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now().minusSeconds(120),
+              Instant.now().minusSeconds(120),
+              declaredActivity,
+              null,
+              "Retour du formateur",
+              EFeedbackStatus.SUBMITTED,
+              1,
+              List.of(),
+              List.of());
+
+      Feedback inProcessFeedback =
+          Feedback.toDomain(
+              UUID.randomUUID(),
+              Instant.now(),
+              Instant.now(),
+              declaredActivity,
+              null,
+              null,
+              EFeedbackStatus.IN_PROCESS,
+              2,
+              List.of(),
+              List.of());
+
+      when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
+              declaredActivityId))
+          .thenReturn(declaredActivity);
+      when(feedbackRepository.findAllByDeclaredActivityId(declaredActivityId))
+          .thenReturn(List.of(inProcessFeedback, submittedFeedback));
+
+      BddLogger.when("createFeedback is called");
+
+      BddLogger.then("A FeedbackInProcessException is thrown and nothing is saved");
+      assertThatThrownBy(() -> service.createFeedback(declaredActivityId))
+          .isInstanceOf(FeedbackInProcessException.class);
+
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
     void should_update_existing_feedback_when_last_feedback_is_NEW() {
       BddLogger.given(
           "A logged-in student whose last feedback is NEW, and the declared activity has a"


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
Fix incorrect feedback ordering when checking the last feedback status in `createFeedback`. The list returned by the repository is sorted by `createdAt` descending, so `getLast()` was returning the oldest feedback instead of the most recent one. Replaced with `getFirst()`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
Related to https://github.com/avenirs-esr/AVENIRS-Project/issues/2076

---

### Target Branch
develop

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

