### PR TITLE
feat(trace): add valued boolean field to trace

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/mapper/FeedbackMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/mapper/FeedbackMapper.java
@@ -106,7 +106,8 @@ public class FeedbackMapper implements Mapper<FeedbackEntity, Feedback> {
                         snap.attachmentId() != null ? files.get(snap.attachmentId()) : null,
                         snap.createdAt(),
                         snap.updatedAt(),
-                        snap.language()))
+                        snap.language(),
+                        false))
             .toList();
 
     List<DeclaredSkillProgress> progresses =

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/model/Trace.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/model/Trace.java
@@ -19,6 +19,7 @@ public class Trace extends AvenirsBaseModel {
   private String title;
   private ETraceAuthorType authorType;
   private ELanguage language;
+  private boolean valorized;
 
   @Getter(AccessLevel.NONE)
   private String aiUseJustification;
@@ -42,6 +43,7 @@ public class Trace extends AvenirsBaseModel {
       String personalNote,
       String link,
       File attachment,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     super(id, createdAt, updatedAt);
@@ -53,6 +55,7 @@ public class Trace extends AvenirsBaseModel {
     this.personalNote = personalNote;
     this.link = link;
     this.attachment = attachment;
+    this.valorized = valorized;
   }
 
   public static Trace create(
@@ -76,6 +79,7 @@ public class Trace extends AvenirsBaseModel {
         personalNote,
         link,
         attachment,
+        false,
         Instant.now(),
         Instant.now());
   }
@@ -91,7 +95,8 @@ public class Trace extends AvenirsBaseModel {
       File attachment,
       Instant createdAt,
       Instant updatedAt,
-      ELanguage language) {
+      ELanguage language,
+      boolean valorized) {
     return new Trace(
         id,
         user,
@@ -102,6 +107,7 @@ public class Trace extends AvenirsBaseModel {
         personalNote,
         link,
         attachment,
+        valorized,
         createdAt,
         updatedAt);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/input/TraceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/input/TraceService.java
@@ -46,7 +46,8 @@ public interface TraceService {
       ETraceAuthorType authorType,
       String personalNote,
       String aiJustification,
-      String link);
+      String link,
+      boolean valorized);
 
   TraceDetailData updateTrace(
       UUID traceId,

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
@@ -299,7 +299,8 @@ public class TraceServiceImpl implements TraceService {
       ETraceAuthorType authorType,
       String personalNote,
       String aiJustification,
-      String link) {
+      String link,
+      boolean valorized) {
     return createTrace(
         traceId,
         userService.getUser(userId),
@@ -308,7 +309,8 @@ public class TraceServiceImpl implements TraceService {
         authorType,
         personalNote,
         aiJustification,
-        link);
+        link,
+        valorized);
   }
 
   @Override
@@ -328,7 +330,8 @@ public class TraceServiceImpl implements TraceService {
         authorType,
         personalNote,
         aiJustification,
-        link);
+        link,
+        false);
   }
 
   private Trace createTrace(
@@ -339,13 +342,15 @@ public class TraceServiceImpl implements TraceService {
       ETraceAuthorType authorType,
       String personalNote,
       String aiJustification,
-      String link) {
+      String link,
+      boolean valorized) {
     requireNotBlankAndMaxLength("title", title, TITLE_LENGTH);
     validateOptionalTextMaxLength("link", link, LINK_LENGTH);
     validateUrl(link);
     var trace =
         Trace.create(
             traceId, user, title, language, authorType, aiJustification, personalNote, link, null);
+    trace.setValorized(valorized);
 
     return traceRepository.save(trace);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/mapper/TraceMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/mapper/TraceMapper.java
@@ -22,6 +22,7 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
         trace.getPersonalNote().orElse(null),
         trace.getLink().orElse(null),
         trace.getAttachment().map(FileMapper.INSTANCE::fromDomain).orElse(null),
+        trace.isValorized(),
         trace.getCreatedAt(),
         trace.getUpdatedAt());
   }
@@ -41,7 +42,8 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
             : FileMapper.INSTANCE.toDomain(traceEntity.getAttachment()),
         traceEntity.getCreatedAt(),
         traceEntity.getUpdatedAt(),
-        traceEntity.getLanguage());
+        traceEntity.getLanguage(),
+        traceEntity.isValorized());
   }
 
   @Override
@@ -60,6 +62,7 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
             : null,
         traceEntity.getCreatedAt(),
         traceEntity.getUpdatedAt(),
-        traceEntity.getLanguage());
+        traceEntity.getLanguage(),
+        traceEntity.isValorized());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/model/TraceEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/model/TraceEntity.java
@@ -57,6 +57,9 @@ public class TraceEntity extends AvenirsBaseEntity {
 
   @OneToOne private FileEntity attachment;
 
+  @Column(nullable = false)
+  private boolean valorized;
+
   private TraceEntity(
       UUID id,
       UserEntity user,
@@ -67,6 +70,7 @@ public class TraceEntity extends AvenirsBaseEntity {
       String personalNote,
       String link,
       FileEntity attachment,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     this.setId(id);
@@ -80,6 +84,7 @@ public class TraceEntity extends AvenirsBaseEntity {
     this.personalNote = personalNote;
     this.link = link;
     this.attachment = attachment;
+    this.valorized = valorized;
   }
 
   public static TraceEntity of(
@@ -92,6 +97,7 @@ public class TraceEntity extends AvenirsBaseEntity {
       String personalNote,
       String link,
       FileEntity attachment,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     return new TraceEntity(
@@ -104,6 +110,7 @@ public class TraceEntity extends AvenirsBaseEntity {
         personalNote,
         link,
         attachment,
+        valorized,
         createdAt,
         updatedAt);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/FakeTrace.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/FakeTrace.java
@@ -33,6 +33,7 @@ public class FakeTrace {
                 null,
                 null,
                 null,
+                false,
                 Instant.now(),
                 Instant.now()));
 
@@ -42,6 +43,7 @@ public class FakeTrace {
     if (new Random().nextBoolean()) fakeTrace = fakeTrace.withLink();
     if (new Random().nextBoolean())
       fakeTrace = fakeTrace.withAuthorType(types[new Random().nextInt(types.length)]);
+    if (new Random().nextBoolean()) fakeTrace = fakeTrace.withValorized(true);
 
     return fakeTrace;
   }
@@ -68,6 +70,11 @@ public class FakeTrace {
 
   public FakeTrace withLink() {
     trace.setLink(faker().internet().url());
+    return this;
+  }
+
+  public FakeTrace withValorized(boolean valorized) {
+    trace.setValorized(valorized);
     return this;
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/TraceSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/TraceSeeder.java
@@ -80,7 +80,8 @@ public class TraceSeeder {
                   data.authorType(),
                   data.personalNote(),
                   data.aiJustification(),
-                  data.link());
+                  data.link(),
+                  data.valorized());
           traces.add(trace);
 
           RequestContext.set(
@@ -117,6 +118,7 @@ public class TraceSeeder {
                     entity.getAiUseJustification(),
                     entity.getPersonalNote(),
                     entity.getLink(),
+                    entity.isValorized(),
                     entity.getLink() == null
                         ? IntStream.range(
                                 1,

--- a/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/data/TraceCreationData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/seeder/data/TraceCreationData.java
@@ -14,6 +14,7 @@ public record TraceCreationData(
     String aiJustification,
     String personalNote,
     String link,
+    boolean valorized,
     List<TraceAttachementCreationData> attachements) {
   public TraceCreationData {
     if (attachements == null) attachements = List.of();

--- a/src/main/resources/db/changelog/generated/changelog_2026-07-06__add-valorized-to-trace.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-07-06__add-valorized-to-trace.xml
@@ -1,0 +1,24 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="iamgreendev" id="add-valorized-to-trace">
+        <addColumn tableName="trace">
+            <column name="valorized" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="trace" columnName="valorized"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
@@ -195,6 +195,7 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
             null,
             null,
             null,
+            false,
             Instant.now(),
             Instant.now());
     entityManager.persist(trace);

--- a/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/fixture/TraceFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/fixture/TraceFixture.java
@@ -26,6 +26,7 @@ public class TraceFixture {
   private String link;
   private File attachment;
   private ELanguage language = ELanguage.FRENCH;
+  private boolean valorized;
 
   private TraceFixture() {
     var fakeUser = UserFixture.create().toModel();
@@ -36,6 +37,7 @@ public class TraceFixture {
     this.createdAt = base.getCreatedAt();
     this.updatedAt = base.getUpdatedAt();
     this.authorType = base.getAuthorType();
+    this.valorized = base.isValorized();
     this.attachment =
         File.create(
             UUID.randomUUID(),
@@ -108,6 +110,11 @@ public class TraceFixture {
     return this;
   }
 
+  public TraceFixture withValorized(boolean valorized) {
+    this.valorized = valorized;
+    return this;
+  }
+
   public Trace toModel() {
     return Trace.toDomain(
         id,
@@ -120,6 +127,7 @@ public class TraceFixture {
         attachment,
         createdAt,
         updatedAt,
-        language);
+        language,
+        valorized);
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a new non-nullable `valued` boolean field to `Trace` (defaults to `false`). Propagated through the domain model, JPA entity, infra mapper, and the trace seeder (varied randomly in FAKER mode via a dedicated `createTrace` overload used only by the seeder, so the public create/update REST flows are untouched). A Liquibase changelog adds the column with a `false` default for existing rows.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1973

---

### Documentation
> No external documentation impacted. A Liquibase changelog (`changelog_2026-07-06__add-valued-to-trace.xml`) handles the DB migration for existing environments (`addColumn` with `defaultValueBoolean="false"` and `nullable="false"`, with rollback).

---

### Target Branch
> `develop`

---

### Additional Notes
> The trace update form/endpoint (`UpdateTraceDTO`, `TraceService#updateTrace`) intentionally does not expose `valued` yet — that will be handled in a follow-up PR. The historical JSON trace snapshot used for feedback (`AssociationsJson.TraceSnapshot`) predates this field and is reconstructed with `valued=false`, since it is not stored in the snapshot.

---

### Known Limitations or Side Effects
> `valued` is not yet settable via the update form/endpoint (by design, deferred to a future PR). It is currently only variable through the FAKER seeder for local/dev data.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
