### PR TITLE
feat(trace): expose valorized field in trace update flow

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceController.java
@@ -238,7 +238,8 @@ public class TraceController {
             updateTraceDTO.authorType(),
             updateTraceDTO.personalNote(),
             updateTraceDTO.iaJustification(),
-            updateTraceDTO.link());
+            updateTraceDTO.link(),
+            updateTraceDTO.valorized());
 
     return ResponseEntity.ok(traceDetailMapper.toDTO(trace));
   }

--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/UpdateTraceDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/UpdateTraceDTO.java
@@ -8,11 +8,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-@Schema(requiredProperties = {"title", "language", "authorType"})
+@Schema(requiredProperties = {"title", "language", "authorType", "valorized"})
 public record UpdateTraceDTO(
     @NotBlank @Size(max = TITLE_LENGTH) String title,
     @Schema(ref = "#/components/schemas/ELanguage") ELanguage language,
     @Schema(ref = "#/components/schemas/ETraceAuthorType") ETraceAuthorType authorType,
     String personalNote,
     String iaJustification,
-    String link) {}
+    String link,
+    boolean valorized) {}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/input/TraceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/port/input/TraceService.java
@@ -56,7 +56,8 @@ public interface TraceService {
       ETraceAuthorType authorType,
       String personalNote,
       String aiJustification,
-      String link);
+      String link,
+      boolean valorized);
 
   TraceDetailData updateTrace(
       UUID traceId,

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
@@ -363,7 +363,8 @@ public class TraceServiceImpl implements TraceService {
       ETraceAuthorType authorType,
       String personalNote,
       String aiJustification,
-      String link) {
+      String link,
+      boolean valorized) {
     User loggedInUser = loggedInUserService.getLoggedInUser();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
     checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
@@ -373,6 +374,7 @@ public class TraceServiceImpl implements TraceService {
     trace.setAuthorType(authorType);
     trace.setPersonalNote(personalNote);
     trace.setAiUseJustification(aiJustification);
+    trace.setValorized(valorized);
 
     if (link != null) {
       validateOptionalTextMaxLength("link", link, LINK_LENGTH);
@@ -393,7 +395,20 @@ public class TraceServiceImpl implements TraceService {
       ETraceAuthorType authorType,
       String personalNote,
       String aiJustification) {
-    return updateTrace(traceId, title, language, authorType, personalNote, aiJustification, null);
+    boolean currentValorized =
+        traceRepository
+            .findById(traceId)
+            .map(Trace::isValorized)
+            .orElseThrow(TraceNotFoundException::new);
+    return updateTrace(
+        traceId,
+        title,
+        language,
+        authorType,
+        personalNote,
+        aiJustification,
+        null,
+        currentValorized);
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerTest.java
@@ -4,15 +4,20 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.trace.application.adapter.dto.CreateTraceDTO;
+import fr.avenirsesr.portfolio.trace.application.adapter.dto.TraceDetailDTO;
 import fr.avenirsesr.portfolio.trace.application.adapter.dto.TraceOverviewDTO;
+import fr.avenirsesr.portfolio.trace.application.adapter.dto.UpdateTraceDTO;
+import fr.avenirsesr.portfolio.trace.application.adapter.mapper.TraceDetailMapper;
 import fr.avenirsesr.portfolio.trace.application.adapter.mapper.TraceOverviewMapper;
 import fr.avenirsesr.portfolio.trace.application.adapter.response.TracesCreationResponse;
+import fr.avenirsesr.portfolio.trace.domain.data.TraceDetailData;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.trace.domain.model.enums.ETraceAuthorType;
 import fr.avenirsesr.portfolio.trace.domain.port.input.TraceService;
@@ -32,6 +37,7 @@ class TraceControllerTest {
 
   @Mock private TraceService traceService;
   @Mock private TraceOverviewMapper traceOverviewMapper;
+  @Mock private TraceDetailMapper traceDetailMapper;
 
   @InjectMocks private TraceController controller;
 
@@ -141,5 +147,102 @@ class TraceControllerTest {
     verify(traceService)
         .createTrace(
             "Trace sans IA", ELanguage.FRENCH, ETraceAuthorType.PERSONAL, null, null, null);
+  }
+
+  @Test
+  void shouldUpdateTraceWithValorisedTrue() {
+    BddLogger.given("a TraceController");
+    UUID traceId = UUID.randomUUID();
+    TraceDetailData traceDetailData = mock(TraceDetailData.class);
+    TraceDetailDTO traceDetailDTO = mock(TraceDetailDTO.class);
+
+    when(traceService.updateTrace(
+            eq(traceId),
+            eq("Updated title"),
+            eq(ELanguage.FRENCH),
+            eq(ETraceAuthorType.PERSONAL),
+            eq("Updated note"),
+            eq("Updated justification"),
+            isNull(),
+            eq(true)))
+        .thenReturn(traceDetailData);
+    when(traceDetailMapper.toDTO(traceDetailData)).thenReturn(traceDetailDTO);
+
+    UpdateTraceDTO dto =
+        new UpdateTraceDTO(
+            "Updated title",
+            ELanguage.FRENCH,
+            ETraceAuthorType.PERSONAL,
+            "Updated note",
+            "Updated justification",
+            null,
+            true);
+
+    BddLogger.when("updating a trace with valorized to true");
+    ResponseEntity<TraceDetailDTO> response = controller.updateTrace(principal, traceId, dto);
+
+    BddLogger.then("it should update the trace with valorized to true");
+    assertEquals(200, response.getStatusCode().value());
+    assertEquals(traceDetailDTO, response.getBody());
+
+    verify(traceService)
+        .updateTrace(
+            eq(traceId),
+            eq("Updated title"),
+            eq(ELanguage.FRENCH),
+            eq(ETraceAuthorType.PERSONAL),
+            eq("Updated note"),
+            eq("Updated justification"),
+            isNull(),
+            eq(true));
+    verify(traceDetailMapper).toDTO(traceDetailData);
+  }
+
+  @Test
+  void shouldUpdateTraceWithValorisedFalse() {
+    BddLogger.given("a TraceController");
+    UUID traceId = UUID.randomUUID();
+    TraceDetailData traceDetailData = mock(TraceDetailData.class);
+    TraceDetailDTO traceDetailDTO = mock(TraceDetailDTO.class);
+
+    when(traceService.updateTrace(
+            eq(traceId),
+            eq("Updated title"),
+            eq(ELanguage.FRENCH),
+            eq(ETraceAuthorType.PERSONAL),
+            eq("Updated note"),
+            eq("Updated justification"),
+            isNull(),
+            eq(false)))
+        .thenReturn(traceDetailData);
+    when(traceDetailMapper.toDTO(traceDetailData)).thenReturn(traceDetailDTO);
+
+    UpdateTraceDTO dto =
+        new UpdateTraceDTO(
+            "Updated title",
+            ELanguage.FRENCH,
+            ETraceAuthorType.PERSONAL,
+            "Updated note",
+            "Updated justification",
+            null,
+            false);
+
+    BddLogger.when("updating a trace with valorized to false");
+    ResponseEntity<TraceDetailDTO> response = controller.updateTrace(principal, traceId, dto);
+
+    BddLogger.then("it should update the trace with valorized to false");
+    assertEquals(200, response.getStatusCode().value());
+    assertEquals(traceDetailDTO, response.getBody());
+
+    verify(traceService)
+        .updateTrace(
+            eq(traceId),
+            eq("Updated title"),
+            eq(ELanguage.FRENCH),
+            eq(ETraceAuthorType.PERSONAL),
+            eq("Updated note"),
+            eq("Updated justification"),
+            isNull(),
+            eq(false));
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImplTest.java
@@ -406,7 +406,8 @@ class TraceServiceImplTest {
             ETraceAuthorType.THIRD_PARTY,
             "Updated note",
             "Updated justification",
-            "https://example.com/updated");
+            "https://example.com/updated",
+            false);
 
         BddLogger.then("it should update and save the link");
 
@@ -494,6 +495,64 @@ class TraceServiceImplTest {
       }
 
       @Test
+      void thenItShouldUpdateValorizedFieldToTrue() {
+        BddLogger.when("updating a trace and setting valorized to true");
+
+        Trace trace =
+            TraceFixture.create().withUser(student.getUser()).withValorized(false).toModel();
+
+        when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
+        when(traceRepository.save(trace)).thenReturn(trace);
+        when(traceRepository.isAssociated(List.of(trace))).thenReturn(Map.of(trace, false));
+
+        traceService.updateTrace(
+            trace.getId(),
+            "Updated title",
+            ELanguage.FRENCH,
+            ETraceAuthorType.PERSONAL,
+            "Updated note",
+            "Updated justification",
+            null,
+            true);
+
+        BddLogger.then("it should update valorized to true");
+
+        ArgumentCaptor<Trace> captor = ArgumentCaptor.forClass(Trace.class);
+        verify(traceRepository).save(captor.capture());
+
+        assertTrue(captor.getValue().isValorized());
+      }
+
+      @Test
+      void thenItShouldUpdateValorizedFieldToFalse() {
+        BddLogger.when("updating a trace and setting valorized to false");
+
+        Trace trace =
+            TraceFixture.create().withUser(student.getUser()).withValorized(true).toModel();
+
+        when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
+        when(traceRepository.save(trace)).thenReturn(trace);
+        when(traceRepository.isAssociated(List.of(trace))).thenReturn(Map.of(trace, false));
+
+        traceService.updateTrace(
+            trace.getId(),
+            "Updated title",
+            ELanguage.FRENCH,
+            ETraceAuthorType.PERSONAL,
+            "Updated note",
+            "Updated justification",
+            null,
+            false);
+
+        BddLogger.then("it should update valorized to false");
+
+        ArgumentCaptor<Trace> captor = ArgumentCaptor.forClass(Trace.class);
+        verify(traceRepository).save(captor.capture());
+
+        assertFalse(captor.getValue().isValorized());
+      }
+
+      @Test
       void thenItShouldThrowTraceNotFoundWhenTraceDoesNotExist() {
         BddLogger.when("updating an unknown trace");
 
@@ -511,7 +570,8 @@ class TraceServiceImplTest {
                         ETraceAuthorType.PERSONAL,
                         null,
                         null,
-                        null));
+                        null,
+                        false));
 
         BddLogger.then("it should throw TRACE_NOT_FOUND");
 
@@ -536,7 +596,8 @@ class TraceServiceImplTest {
                         ETraceAuthorType.PERSONAL,
                         null,
                         null,
-                        null));
+                        null,
+                        false));
 
         BddLogger.then("it should throw USER_NOT_AUTHORIZED");
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Exposes the `valorized` field of a `Trace` in the update flow: added as a required, non-nullable boolean field to `UpdateTraceDTO`, propagated through `TraceController.updateTrace()` and `TraceService`, and applied in `TraceServiceImpl.updateTrace()`. The legacy 6-argument overload of `updateTrace` now fetches and preserves the trace's current `valorized` value so it is not accidentally reset.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1974

---

### Documentation
> No documentation updates required. No database schema change (the `valorized` column and its migration were introduced in a prior PR).

---

### Target Branch
> `develop`

---

### Additional Notes
> This PR builds on top of the `valorized` field previously added to the `Trace` domain model (issue #1973). `valorized` is required in the update request body (non-nullable boolean), matching the read model.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process