### PR TITLE
feat(activity): notify enrolled students when a published activity is updated

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/model/enums/EActivityUpdatableField.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/model/enums/EActivityUpdatableField.java
@@ -1,0 +1,11 @@
+package fr.avenirsesr.portfolio.activity.domain.model.enums;
+
+public enum EActivityUpdatableField {
+  ACTIVITY_TITLE,
+  THEMATIC,
+  FILES_AND_LINKS,
+  BANNER,
+  SUMMARY,
+  DESCRIPTION,
+  EXECUTION_PERIOD,
+}

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.activity.domain.service;
 
+import static fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField.*;
 import static fr.avenirsesr.portfolio.common.validation.domain.constraints.FieldMaxLengths.*;
 import static fr.avenirsesr.portfolio.common.validation.domain.utils.FieldValidationUtils.*;
 
@@ -14,6 +15,7 @@ import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.activity.domain.model.ActivityDraft;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityStatus;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityThematic;
+import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField;
 import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
 import fr.avenirsesr.portfolio.activity.domain.port.output.repository.ActivityDraftRepository;
 import fr.avenirsesr.portfolio.activity.domain.port.output.repository.ActivityRepository;
@@ -26,13 +28,17 @@ import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorize
 import fr.avenirsesr.portfolio.file.domain.data.FileData;
 import fr.avenirsesr.portfolio.file.domain.model.File;
 import fr.avenirsesr.portfolio.file.infrastructure.configuration.FileStorageConstants;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.ActivityUpdatedNotification;
+import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
 import fr.avenirsesr.portfolio.user.domain.model.Staff;
+import fr.avenirsesr.portfolio.user.domain.model.Student;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +53,7 @@ public class ActivityServiceImpl implements ActivityService {
   private final DeclaredActivityService declaredActivityService;
   private final LoggedInUserService loggedInUserService;
   private final StaffActivityOverviewRepository staffActivityOverviewRepository;
+  private final NotificationService notificationService;
 
   @Override
   public Activity create(
@@ -126,12 +133,10 @@ public class ActivityServiceImpl implements ActivityService {
                 draft.getLinks()));
 
     if (publishedActivity.isPresent()) {
-      if (hasEnrolledStudents(activity)) {
-        updateEngagedActivity(activity, draft);
-      } else {
-        updateUnEngagedActivity(activity, draft);
-      }
+      var enrolledStudents = declaredActivityService.getEnrolledStudents(activity);
+      var updatedFields = updateActivity(activity, draft, !enrolledStudents.isEmpty());
       activity.setStatus(EActivityStatus.PUBLISHED);
+      notifyActivityUpdated(activity, updatedFields, enrolledStudents);
     }
 
     var savedActivity = activityRepository.save(activity);
@@ -140,23 +145,73 @@ public class ActivityServiceImpl implements ActivityService {
     return savedActivity;
   }
 
-  private void updateUnEngagedActivity(Activity publishedActivity, ActivityDraft draft) {
-    updateEngagedActivity(publishedActivity, draft);
-    publishedActivity.setTraceAllowedAssociations(draft.getTraceAllowedAssociations());
-    publishedActivity.setFeedbackAllowedIterations(draft.getFeedbackAllowedIterations());
-    publishedActivity.setEnableReflection(draft.isEnableReflection());
+  private record FieldSync<T>(
+      EActivityUpdatableField field, T currentValue, T newValue, Consumer<T> setter) {
+    boolean applyIfChanged() {
+      if (Objects.equals(currentValue, newValue)) {
+        return false;
+      }
+      setter.accept(newValue);
+      return true;
+    }
   }
 
-  private void updateEngagedActivity(Activity publishedActivity, ActivityDraft draft) {
-    publishedActivity.setTitle(draft.getTitle());
-    publishedActivity.setThematic(draft.getThematic());
-    publishedActivity.setDescription(draft.getDescription().orElse(null));
-    publishedActivity.setSummary(draft.getSummary().orElse(null));
-    publishedActivity.setExecutionPeriodInfo(draft.getExecutionPeriodInfo().orElse(null));
-    publishedActivity.setExecutionPeriodInfoSummary(
-        draft.getExecutionPeriodInfoSummary().orElse(null));
-    publishedActivity.setBanner(draft.getBanner().orElse(null));
-    publishedActivity.setLinks(draft.getLinks());
+  private List<EActivityUpdatableField> updateActivity(
+      Activity activity, ActivityDraft draft, boolean hasEnrolledStudents) {
+    var syncs =
+        List.of(
+            new FieldSync<>(
+                ACTIVITY_TITLE, activity.getTitle(), draft.getTitle(), activity::setTitle),
+            new FieldSync<>(
+                SUMMARY,
+                activity.getSummary(),
+                draft.getSummary().orElse(null),
+                activity::setSummary),
+            new FieldSync<>(
+                DESCRIPTION,
+                activity.getDescription().orElse(null),
+                draft.getDescription().orElse(null),
+                activity::setDescription),
+            new FieldSync<>(
+                EXECUTION_PERIOD,
+                activity.getExecutionPeriodInfo().orElse(null),
+                draft.getExecutionPeriodInfo().orElse(null),
+                activity::setExecutionPeriodInfo),
+            new FieldSync<>(
+                THEMATIC, activity.getThematic(), draft.getThematic(), activity::setThematic),
+            new FieldSync<>(
+                BANNER,
+                activity.getBanner().orElse(null),
+                draft.getBanner().orElse(null),
+                activity::setBanner),
+            new FieldSync<>(
+                FILES_AND_LINKS, activity.getLinks(), draft.getLinks(), activity::setLinks));
+
+    var updatedFields =
+        syncs.stream().filter(FieldSync::applyIfChanged).map(FieldSync::field).toList();
+
+    activity.setExecutionPeriodInfoSummary(draft.getExecutionPeriodInfoSummary().orElse(null));
+
+    if (!hasEnrolledStudents) {
+      activity.setTraceAllowedAssociations(draft.getTraceAllowedAssociations());
+      activity.setFeedbackAllowedIterations(draft.getFeedbackAllowedIterations());
+      activity.setEnableReflection(draft.isEnableReflection());
+    }
+
+    return updatedFields;
+  }
+
+  private void notifyActivityUpdated(
+      Activity activity, List<EActivityUpdatableField> updatedFields, List<Student> students) {
+    if (students.isEmpty() || updatedFields.isEmpty()) {
+      return;
+    }
+    notificationService.notifyAll(
+        students.stream()
+            .map(
+                student ->
+                    new ActivityUpdatedNotification(student.getUser(), activity, updatedFields))
+            .toList());
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/service/ActivityServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/service/ActivityServiceConfig.java
@@ -5,6 +5,7 @@ import fr.avenirsesr.portfolio.activity.domain.port.output.repository.ActivityDr
 import fr.avenirsesr.portfolio.activity.domain.port.output.repository.ActivityRepository;
 import fr.avenirsesr.portfolio.activity.domain.port.output.repository.StaffActivityOverviewRepository;
 import fr.avenirsesr.portfolio.activity.domain.service.ActivityServiceImpl;
+import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class ActivityServiceConfig {
   private final DeclaredActivityService declaredActivityService;
   private final LoggedInUserService loggedInUserService;
   private final StaffActivityOverviewRepository staffActivityOverviewRepository;
+  private final NotificationService notificationService;
 
   @Bean
   public ActivityService activityService() {
@@ -27,6 +29,7 @@ public class ActivityServiceConfig {
         activityDraftRepository,
         declaredActivityService,
         loggedInUserService,
-        staffActivityOverviewRepository);
+        staffActivityOverviewRepository,
+        notificationService);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/ActivityUpdatedNotification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/ActivityUpdatedNotification.java
@@ -1,0 +1,28 @@
+package fr.avenirsesr.portfolio.notification.domain.model.notification;
+
+import fr.avenirsesr.portfolio.activity.domain.model.Activity;
+import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField;
+import fr.avenirsesr.portfolio.common.data.domain.model.User;
+import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ActivityUpdatedNotification extends BaseNotification {
+  private final Activity activity;
+  private final List<EActivityUpdatableField> updatedFields;
+
+  public ActivityUpdatedNotification(
+      User user, Activity activity, List<EActivityUpdatableField> updatedFields) {
+    super(user, ENotificationType.ACTIVITY_MODIFIED, activity.getId());
+    this.activity = activity;
+    this.updatedFields = updatedFields;
+  }
+
+  @Override
+  protected List<String> buildParameters() {
+    var params = new ArrayList<>(Collections.singleton(activity.getTitle()));
+    params.addAll(updatedFields.stream().map(Enum::name).toList());
+    return params;
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/port/input/NotificationService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/port/input/NotificationService.java
@@ -5,10 +5,13 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.notification.domain.model.Notification;
 import fr.avenirsesr.portfolio.notification.domain.model.notification.BaseNotification;
+import java.util.List;
 import java.util.UUID;
 
 public interface NotificationService {
   void notify(BaseNotification notification);
+
+  void notifyAll(List<? extends BaseNotification> notifications);
 
   void markAsSeen(UUID id);
 

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImpl.java
@@ -11,7 +11,7 @@ import fr.avenirsesr.portfolio.notification.domain.port.output.repository.Notifi
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.StaffRepository;
 import fr.avenirsesr.portfolio.user.domain.port.output.repository.StudentRepository;
-import java.util.UUID;
+import java.util.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,28 +26,41 @@ public class NotificationServiceImpl implements NotificationService {
 
   @Override
   public void notify(BaseNotification notification) {
-    var builtNotification = notification.build();
+    notifyAll(List.of(notification));
+  }
 
-    if (!builtNotification.getUser().isNotificationEnabled()) {
-      log.debug(
-          "Notifications disabled for user [{}], skipping notification",
-          builtNotification.getUser().getId());
+  @Override
+  public void notifyAll(List<? extends BaseNotification> notifications) {
+    var builtNotifications =
+        notifications.stream()
+            .map(BaseNotification::build)
+            .filter(n -> n.getUser().isNotificationEnabled())
+            .toList();
+
+    if (builtNotifications.isEmpty()) {
       return;
     }
 
-    var savedNotification = notificationRepository.save(builtNotification);
+    var savedNotifications = notificationRepository.saveAll(builtNotifications);
 
-    var userId = savedNotification.getUser().getId();
-    switch (savedNotification.getUserCategory()) {
-      case STAFF -> setStaffUnseenNotification(userId, true);
-      case STUDENT -> setStudentUnseenNotification(userId, true);
-      case null -> {
-        setStaffUnseenNotification(userId, true);
-        setStudentUnseenNotification(userId, true);
+    List<UUID> staffIds = new ArrayList<>();
+    List<UUID> studentIds = new ArrayList<>();
+    for (var savedNotification : savedNotifications) {
+      var userId = savedNotification.getUser().getId();
+      switch (savedNotification.getUserCategory()) {
+        case STAFF -> staffIds.add(userId);
+        case STUDENT -> studentIds.add(userId);
+        case null -> {
+          staffIds.add(userId);
+          studentIds.add(userId);
+        }
       }
     }
 
-    log.debug("[{}] created", savedNotification);
+    setStaffUnseenNotification(staffIds, true);
+    setStudentUnseenNotification(studentIds, true);
+
+    log.debug("[{}] notification(s) created", savedNotifications.size());
   }
 
   @Override
@@ -66,31 +79,29 @@ public class NotificationServiceImpl implements NotificationService {
     log.debug("Fetching notifications for user [{}] with category [{}]", userId, userCategory);
 
     switch (userCategory) {
-      case STAFF -> setStaffUnseenNotification(userId, false);
-      case STUDENT -> setStudentUnseenNotification(userId, false);
+      case STAFF -> setStaffUnseenNotification(List.of(userId), false);
+      case STUDENT -> setStudentUnseenNotification(List.of(userId), false);
       default -> throw new IllegalArgumentException("Invalid user category");
     }
 
     return notificationRepository.findByUserAndCategory(userId, userCategory, pageCriteria);
   }
 
-  private void setStaffUnseenNotification(UUID staffId, boolean seen) {
-    staffRepository
-        .findById(staffId)
-        .ifPresent(
-            staff -> {
-              staff.setHasUnseenNotification(seen);
-              staffRepository.save(staff);
-            });
+  private void setStaffUnseenNotification(List<UUID> staffIds, boolean seen) {
+    if (staffIds.isEmpty()) {
+      return;
+    }
+    var staff = staffRepository.findAllById(List.copyOf(staffIds));
+    staff.forEach(s -> s.setHasUnseenNotification(seen));
+    staffRepository.saveAll(staff);
   }
 
-  private void setStudentUnseenNotification(UUID studentId, boolean seen) {
-    studentRepository
-        .findById(studentId)
-        .ifPresent(
-            student -> {
-              student.setHasUnseenNotification(seen);
-              studentRepository.save(student);
-            });
+  private void setStudentUnseenNotification(List<UUID> studentIds, boolean seen) {
+    if (studentIds.isEmpty()) {
+      return;
+    }
+    var students = studentRepository.findAllById(List.copyOf(studentIds));
+    students.forEach(s -> s.setHasUnseenNotification(seen));
+    studentRepository.saveAll(students);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
@@ -75,4 +75,6 @@ public interface DeclaredActivityService {
   DeclaredActivity fetchActivityAndCheckLoggedInStudentAuthorization(UUID declaredActivityId);
 
   int countEnrolledStudents(Activity activity);
+
+  List<Student> getEnrolledStudents(Activity activity);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/DeclaredActivityRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/output/repository/DeclaredActivityRepository.java
@@ -29,4 +29,6 @@ public interface DeclaredActivityRepository extends GenericRepositoryPort<Declar
   Optional<DeclaredActivity> findByActivity(Student student, Activity activity);
 
   int countByActivity(Activity activity);
+
+  List<DeclaredActivity> findAllByActivity(Activity activity, FetchGraph fetchGraph);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -562,6 +562,14 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
     return declaredActivityRepository.countByActivity(activity);
   }
 
+  @Override
+  public List<Student> getEnrolledStudents(Activity activity) {
+    var graph = FetchGraph.init().add("student").fetch("user");
+    return declaredActivityRepository.findAllByActivity(activity, graph).stream()
+        .map(DeclaredActivity::getStudent)
+        .toList();
+  }
+
   private EAssociationType getAssociationType(EAssociationContextType contextType) {
     return switch (contextType) {
       case TRACE -> EAssociationType.DECLARED_ACTIVITY_TRACE;

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/DeclaredActivityDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/repository/DeclaredActivityDatabaseRepository.java
@@ -88,4 +88,9 @@ public class DeclaredActivityDatabaseRepository
   public int countByActivity(Activity activity) {
     return jpaRepository.countByActivityId(activity.getId());
   }
+
+  @Override
+  public List<DeclaredActivity> findAllByActivity(Activity activity, FetchGraph fetchGraph) {
+    return findAll(DeclaredActivitySpecification.hasActivityId(activity.getId()), fetchGraph);
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/specification/DeclaredActivitySpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/specification/DeclaredActivitySpecification.java
@@ -21,6 +21,10 @@ public final class DeclaredActivitySpecification {
         .and(hasActivityIdIn(activityIds));
   }
 
+  public static Specification<DeclaredActivityEntity> hasActivityId(UUID activityId) {
+    return (root, query, cb) -> cb.equal(root.get("activity").get("id"), activityId);
+  }
+
   public static Specification<DeclaredActivityEntity> search(String keyword) {
     return (root, query, criteriaBuilder) -> {
       if (keyword == null || keyword.trim().isEmpty()) {

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -13,16 +13,20 @@ import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.activity.domain.model.ActivityDraft;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityStatus;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityThematic;
+import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField;
 import fr.avenirsesr.portfolio.activity.domain.port.output.repository.ActivityDraftRepository;
 import fr.avenirsesr.portfolio.activity.domain.port.output.repository.ActivityRepository;
 import fr.avenirsesr.portfolio.activity.domain.port.output.repository.StaffActivityOverviewRepository;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
+import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.error.domain.exception.FieldValidationException;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.file.domain.model.File;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.ActivityUpdatedNotification;
+import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.enums.EDeclaredActivityStatus;
@@ -44,6 +48,7 @@ class ActivityServiceImplTest {
   @Mock private LoggedInUserService loggedInUserService;
   @Mock private DeclaredActivityService declaredActivityService;
   @Mock private StaffActivityOverviewRepository staffActivityOverviewRepository;
+  @Mock private NotificationService notificationService;
 
   @InjectMocks private ActivityServiceImpl activityService;
 
@@ -536,6 +541,7 @@ class ActivityServiceImplTest {
 
         when(activityRepository.findById(activityId)).thenReturn(Optional.of(existingActivity));
         when(activityRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(existingActivity.getId()).thenReturn(activityId);
       }
 
       @Nested
@@ -544,7 +550,16 @@ class ActivityServiceImplTest {
         @BeforeEach
         void setupAnd() {
           BddLogger.and("the activity has no enrolled students");
-          when(declaredActivityService.countEnrolledStudents(existingActivity)).thenReturn(0);
+          when(declaredActivityService.getEnrolledStudents(existingActivity)).thenReturn(List.of());
+        }
+
+        @Test
+        void thenItShouldNotSendAnyNotification() {
+          BddLogger.then("no notification should be sent since there is no student to notify");
+
+          activityService.publish(activityId);
+
+          verifyNoInteractions(notificationService);
         }
 
         @Test
@@ -560,7 +575,7 @@ class ActivityServiceImplTest {
           verify(existingActivity).setSummary("Nouveau résumé");
           verify(existingActivity).setExecutionPeriodInfo("Nouvelle période");
           verify(existingActivity).setExecutionPeriodInfoSummary("Nouveau label");
-          verify(existingActivity).setBanner(null);
+          verify(existingActivity, never()).setBanner(any());
           verify(existingActivity).setLinks(List.of("https://example.com"));
           verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
           verify(activityRepository).save(existingActivity);
@@ -593,10 +608,22 @@ class ActivityServiceImplTest {
       @Nested
       class AndTheActivityHasEnrolledStudents {
 
+        Student student1;
+        Student student2;
+        User user1;
+        User user2;
+
         @BeforeEach
         void setupAnd() {
           BddLogger.and("the activity has enrolled students");
-          when(declaredActivityService.countEnrolledStudents(existingActivity)).thenReturn(2);
+          student1 = mock(Student.class);
+          student2 = mock(Student.class);
+          user1 = mock(User.class);
+          user2 = mock(User.class);
+          lenient().when(student1.getUser()).thenReturn(user1);
+          lenient().when(student2.getUser()).thenReturn(user2);
+          when(declaredActivityService.getEnrolledStudents(existingActivity))
+              .thenReturn(List.of(student1, student2));
         }
 
         @Test
@@ -612,7 +639,7 @@ class ActivityServiceImplTest {
           verify(existingActivity).setSummary("Nouveau résumé");
           verify(existingActivity).setExecutionPeriodInfo("Nouvelle période");
           verify(existingActivity).setExecutionPeriodInfoSummary("Nouveau label");
-          verify(existingActivity).setBanner(null);
+          verify(existingActivity, never()).setBanner(any());
           verify(existingActivity).setLinks(List.of("https://example.com"));
           verify(existingActivity).setStatus(EActivityStatus.PUBLISHED);
           verify(activityRepository).save(existingActivity);
@@ -630,6 +657,60 @@ class ActivityServiceImplTest {
           verify(existingActivity, never()).setEnableReflection(anyBoolean());
           verify(existingActivity, never()).setTraceAllowedAssociations(anyInt());
           verify(existingActivity, never()).setFeedbackAllowedIterations(anyInt());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void thenItShouldNotifyEachEnrolledStudentAboutTheUpdatedFields() {
+          BddLogger.then("each enrolled student should be notified about the updated fields");
+
+          activityService.publish(activityId);
+
+          ArgumentCaptor<List<ActivityUpdatedNotification>> captor =
+              ArgumentCaptor.forClass(List.class);
+          verify(notificationService).notifyAll(captor.capture());
+          List<ActivityUpdatedNotification> notifications = captor.getValue();
+
+          assertEquals(2, notifications.size());
+          assertEquals(user1, notifications.get(0).build().getUser());
+          assertEquals(user2, notifications.get(1).build().getUser());
+
+          List<String> expectedUpdatedFields =
+              List.of(
+                  EActivityUpdatableField.ACTIVITY_TITLE.name(),
+                  EActivityUpdatableField.SUMMARY.name(),
+                  EActivityUpdatableField.DESCRIPTION.name(),
+                  EActivityUpdatableField.EXECUTION_PERIOD.name(),
+                  EActivityUpdatableField.THEMATIC.name(),
+                  EActivityUpdatableField.FILES_AND_LINKS.name());
+          List<String> parameters = notifications.getFirst().build().getParameters();
+          assertEquals(expectedUpdatedFields, parameters.subList(1, parameters.size()));
+        }
+
+        @Nested
+        class AndNoTrackedFieldActuallyChanged {
+
+          @BeforeEach
+          void setupAnd() {
+            BddLogger.and("none of the notifiable fields differ from the draft");
+            when(existingActivity.getTitle()).thenReturn("Nouveau titre");
+            when(existingActivity.getSummary()).thenReturn("Nouveau résumé");
+            when(existingActivity.getDescription()).thenReturn(Optional.of("Nouvelle description"));
+            when(existingActivity.getExecutionPeriodInfo())
+                .thenReturn(Optional.of("Nouvelle période"));
+            when(existingActivity.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
+            when(existingActivity.getBanner()).thenReturn(Optional.empty());
+            when(existingActivity.getLinks()).thenReturn(List.of("https://example.com"));
+          }
+
+          @Test
+          void thenItShouldNotSendAnyNotification() {
+            BddLogger.then("no notification should be sent since nothing actually changed");
+
+            activityService.publish(activityId);
+
+            verifyNoInteractions(notificationService);
+          }
         }
       }
     }

--- a/src/test/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImplTest.java
@@ -25,7 +25,6 @@ import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -75,15 +74,15 @@ class NotificationServiceImplTest {
       Notification expectedNotification = buildNotification(user, EUserCategory.STUDENT);
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(expectedNotification);
-      when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+      when(notificationRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
       service.notify(baseNotification);
 
       BddLogger.then("The repository saves exactly the notification produced by build()");
-      ArgumentCaptor<Notification> captor = forClass(Notification.class);
-      verify(notificationRepository).save(captor.capture());
-      assertThat(captor.getValue()).isSameAs(expectedNotification);
+      ArgumentCaptor<List<Notification>> captor = forClass(List.class);
+      verify(notificationRepository).saveAll(captor.capture());
+      assertThat(captor.getValue()).containsExactly(expectedNotification);
     }
 
     @Test
@@ -92,7 +91,7 @@ class NotificationServiceImplTest {
       User user = UserFixture.create().withNotificationEnabled(true).toModel();
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(buildNotification(user, EUserCategory.STUDENT));
-      when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+      when(notificationRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
       service.notify(baseNotification);
@@ -175,16 +174,16 @@ class NotificationServiceImplTest {
       Notification notification = buildNotification(user, EUserCategory.STUDENT);
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(notification);
-      when(studentRepository.findById(user.getId())).thenReturn(Optional.of(student));
-      when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+      when(studentRepository.findAllById(List.of(user.getId()))).thenReturn(List.of(student));
+      when(notificationRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
       service.notify(baseNotification);
 
       BddLogger.then("hasUnseenNotification is set to true on the student and saved");
-      ArgumentCaptor<Student> captor = ArgumentCaptor.forClass(Student.class);
-      verify(studentRepository).save(captor.capture());
-      assertTrue(captor.getValue().isHasUnseenNotification());
+      ArgumentCaptor<List<Student>> captor = forClass(List.class);
+      verify(studentRepository).saveAll(captor.capture());
+      assertTrue(captor.getValue().get(0).isHasUnseenNotification());
     }
 
     @Test
@@ -194,14 +193,14 @@ class NotificationServiceImplTest {
       Student student = StudentFixture.create().withUser(user).toModel();
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(buildNotification(user, EUserCategory.STUDENT));
-      when(studentRepository.findById(user.getId())).thenReturn(Optional.of(student));
-      when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+      when(studentRepository.findAllById(List.of(user.getId()))).thenReturn(List.of(student));
+      when(notificationRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
       service.notify(baseNotification);
 
       BddLogger.then("staffRepository is never queried");
-      verify(staffRepository, never()).findById(any());
+      verify(staffRepository, never()).findAllById(any());
     }
 
     @Test
@@ -212,16 +211,16 @@ class NotificationServiceImplTest {
       Notification notification = buildNotification(user, EUserCategory.STAFF);
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(notification);
-      when(staffRepository.findById(user.getId())).thenReturn(Optional.of(staff));
-      when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+      when(staffRepository.findAllById(List.of(user.getId()))).thenReturn(List.of(staff));
+      when(notificationRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
       service.notify(baseNotification);
 
       BddLogger.then("hasUnseenNotification is set to true on the staff and saved");
-      ArgumentCaptor<Staff> captor = ArgumentCaptor.forClass(Staff.class);
-      verify(staffRepository).save(captor.capture());
-      assertTrue(captor.getValue().isHasUnseenNotification());
+      ArgumentCaptor<List<Staff>> captor = forClass(List.class);
+      verify(staffRepository).saveAll(captor.capture());
+      assertTrue(captor.getValue().get(0).isHasUnseenNotification());
     }
 
     @Test
@@ -231,14 +230,14 @@ class NotificationServiceImplTest {
       Staff staff = StaffFixture.create().withUser(user).toModel();
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(buildNotification(user, EUserCategory.STAFF));
-      when(staffRepository.findById(user.getId())).thenReturn(Optional.of(staff));
-      when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+      when(staffRepository.findAllById(List.of(user.getId()))).thenReturn(List.of(staff));
+      when(notificationRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
       service.notify(baseNotification);
 
       BddLogger.then("studentRepository is never queried");
-      verify(studentRepository, never()).findById(any());
+      verify(studentRepository, never()).findAllById(any());
     }
 
     @Test
@@ -251,21 +250,21 @@ class NotificationServiceImplTest {
       Notification notification = buildNotification(user, null);
       BaseNotification baseNotification = mock(BaseNotification.class);
       when(baseNotification.build()).thenReturn(notification);
-      when(studentRepository.findById(user.getId())).thenReturn(Optional.of(student));
-      when(staffRepository.findById(user.getId())).thenReturn(Optional.of(staff));
-      when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+      when(studentRepository.findAllById(List.of(user.getId()))).thenReturn(List.of(student));
+      when(staffRepository.findAllById(List.of(user.getId()))).thenReturn(List.of(staff));
+      when(notificationRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
       BddLogger.when("notify is called");
       service.notify(baseNotification);
 
       BddLogger.then("hasUnseenNotification is set to true on both student and staff");
-      ArgumentCaptor<Student> studentCaptor = ArgumentCaptor.forClass(Student.class);
-      verify(studentRepository).save(studentCaptor.capture());
-      assertTrue(studentCaptor.getValue().isHasUnseenNotification());
+      ArgumentCaptor<List<Student>> studentCaptor = forClass(List.class);
+      verify(studentRepository).saveAll(studentCaptor.capture());
+      assertTrue(studentCaptor.getValue().get(0).isHasUnseenNotification());
 
-      ArgumentCaptor<Staff> staffCaptor = ArgumentCaptor.forClass(Staff.class);
-      verify(staffRepository).save(staffCaptor.capture());
-      assertTrue(staffCaptor.getValue().isHasUnseenNotification());
+      ArgumentCaptor<List<Staff>> staffCaptor = forClass(List.class);
+      verify(staffRepository).saveAll(staffCaptor.capture());
+      assertTrue(staffCaptor.getValue().get(0).isHasUnseenNotification());
     }
   }
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -1725,4 +1725,40 @@ class DeclaredActivityServiceImplTest {
     BddLogger.then("it should return zero");
     assertThat(count).isZero();
   }
+
+  @Test
+  void getEnrolledStudents_should_return_students_of_the_activity_declared_activities() {
+    BddLogger.given("an activity with two enrolled students");
+    Activity activity = ActivityFixture.create().toModel();
+    Student student1 = StudentFixture.create().toModel();
+    Student student2 = StudentFixture.create().toModel();
+    DeclaredActivity declaredActivity1 =
+        DeclaredActivity.create(
+            UUID.randomUUID(), student1, activity, null, null, null, null, null);
+    DeclaredActivity declaredActivity2 =
+        DeclaredActivity.create(
+            UUID.randomUUID(), student2, activity, null, null, null, null, null);
+    when(declaredActivityRepository.findAllByActivity(eq(activity), any(FetchGraph.class)))
+        .thenReturn(List.of(declaredActivity1, declaredActivity2));
+
+    BddLogger.when("getting the enrolled students");
+    List<Student> result = service.getEnrolledStudents(activity);
+
+    BddLogger.then("it should return the students of each declared activity");
+    assertThat(result).containsExactly(student1, student2);
+  }
+
+  @Test
+  void getEnrolledStudents_should_return_empty_list_when_no_students_enrolled() {
+    BddLogger.given("an activity with no enrolled students");
+    Activity activity = ActivityFixture.create().toModel();
+    when(declaredActivityRepository.findAllByActivity(eq(activity), any(FetchGraph.class)))
+        .thenReturn(List.of());
+
+    BddLogger.when("getting the enrolled students");
+    List<Student> result = service.getEnrolledStudents(activity);
+
+    BddLogger.then("it should return an empty list");
+    assertThat(result).isEmpty();
+  }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> When a staff member republishes an activity draft, the changes made to the activity are now diffed field by field against the previously published version. Enrolled students are notified only about the fields that actually changed (title, thematic, description, execution period, banner, files/links). Notifications are now sent in batch to all enrolled students instead of one call per notification.
>
> Also adds `DeclaredActivityService.getEnrolledStudents(Activity)` to retrieve the list of students enrolled in an activity (used to build the notification recipients).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2069

---

### Documentation
> None.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Field-level diffing is implemented via a small `FieldSync<T>` record (current value / new value / setter) instead of a long sequence of `if` statements, so the tracked fields and their notification mapping stay declarative.
> - No notification is sent when there are no enrolled students, or when none of the tracked fields actually changed.
> - `NotificationService.notifyAll` now accepts `List<? extends BaseNotification>` and batches DB writes/unseen-flag updates for staff and students instead of looping one user at a time.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
