### PR TITLE
feat(notification): type notification parameters per notification type

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/notification/application/adapter/dto/NotificationDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/application/adapter/dto/NotificationDTO.java
@@ -1,9 +1,9 @@
 package fr.avenirsesr.portfolio.notification.application.adapter.dto;
 
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
 @Schema(requiredProperties = {"id", "createdAt", "type", "seen"})
@@ -12,5 +12,5 @@ public record NotificationDTO(
     Instant createdAt,
     ENotificationType type,
     UUID elementId,
-    List<String> parameters,
+    NotificationParameters parameters,
     boolean seen) {}

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/Notification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/Notification.java
@@ -4,8 +4,8 @@ import fr.avenirsesr.portfolio.common.data.domain.model.AvenirsBaseModel;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,7 +17,7 @@ public class Notification extends AvenirsBaseModel {
   private final UUID elementId;
   private final User user;
   private final EUserCategory userCategory;
-  private List<String> parameters;
+  private NotificationParameters parameters;
   private boolean seen;
 
   private Notification(
@@ -28,7 +28,7 @@ public class Notification extends AvenirsBaseModel {
       UUID elementId,
       User user,
       EUserCategory userCategory,
-      List<String> parameters,
+      NotificationParameters parameters,
       boolean seen) {
     super(id, createdAt, updatedAt);
     this.type = type;
@@ -40,7 +40,7 @@ public class Notification extends AvenirsBaseModel {
   }
 
   public static Notification create(
-      ENotificationType type, UUID elementId, User user, List<String> parameters) {
+      ENotificationType type, UUID elementId, User user, NotificationParameters parameters) {
     Instant now = Instant.now();
     return new Notification(
         UUID.randomUUID(),
@@ -62,7 +62,7 @@ public class Notification extends AvenirsBaseModel {
       UUID elementId,
       User user,
       EUserCategory userCategory,
-      List<String> parameters,
+      NotificationParameters parameters,
       boolean seen) {
     return new Notification(
         id, createdAt, updatedAt, type, elementId, user, userCategory, parameters, seen);

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/enums/ENotificationType.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/enums/ENotificationType.java
@@ -1,14 +1,24 @@
 package fr.avenirsesr.portfolio.notification.domain.model.enums;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.ActivityModifiedParameters;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.AskForFeedbackParameters;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
+import java.util.List;
+import java.util.function.Function;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum ENotificationType {
-  ACTIVITY_MODIFIED(EUserCategory.STUDENT),
-  ASK_FOR_FEEDBACK(EUserCategory.STAFF);
+  ACTIVITY_MODIFIED(EUserCategory.STUDENT, ActivityModifiedParameters::fromStringList),
+  ASK_FOR_FEEDBACK(EUserCategory.STAFF, AskForFeedbackParameters::fromStringList);
 
   private final EUserCategory restrictedTo;
+  private final Function<List<String>, NotificationParameters> parametersFactory;
+
+  public NotificationParameters toParameters(List<String> rawParameters) {
+    return parametersFactory.apply(rawParameters);
+  }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/ActivityUpdatedNotification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/ActivityUpdatedNotification.java
@@ -4,8 +4,8 @@ import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
-import java.util.ArrayList;
-import java.util.Collections;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.ActivityModifiedParameters;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
 import java.util.List;
 
 public class ActivityUpdatedNotification extends BaseNotification {
@@ -20,9 +20,7 @@ public class ActivityUpdatedNotification extends BaseNotification {
   }
 
   @Override
-  protected List<String> buildParameters() {
-    var params = new ArrayList<>(Collections.singleton(activity.getTitle()));
-    params.addAll(updatedFields.stream().map(Enum::name).toList());
-    return params;
+  protected NotificationParameters buildParameters() {
+    return new ActivityModifiedParameters(activity.getTitle(), updatedFields);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/AskForFeedbackNotification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/AskForFeedbackNotification.java
@@ -2,8 +2,9 @@ package fr.avenirsesr.portfolio.notification.domain.model.notification;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.AskForFeedbackParameters;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
-import java.util.List;
 
 public class AskForFeedbackNotification extends BaseNotification {
 
@@ -15,8 +16,8 @@ public class AskForFeedbackNotification extends BaseNotification {
   }
 
   @Override
-  protected List<String> buildParameters() {
-    return List.of(
+  protected NotificationParameters buildParameters() {
+    return new AskForFeedbackParameters(
         feedback.getDeclaredActivity().getStudent().getUser().getFirstName(),
         feedback.getDeclaredActivity().getStudent().getUser().getLastName(),
         feedback.getDeclaredActivity().getActivity().getTitle());

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/BaseNotification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/BaseNotification.java
@@ -3,7 +3,7 @@ package fr.avenirsesr.portfolio.notification.domain.model.notification;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.notification.domain.model.Notification;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
-import java.util.List;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
 import java.util.UUID;
 
 public abstract class BaseNotification {
@@ -18,7 +18,7 @@ public abstract class BaseNotification {
     this.elementId = elementId;
   }
 
-  protected abstract List<String> buildParameters();
+  protected abstract NotificationParameters buildParameters();
 
   public Notification build() {
     return Notification.create(type, elementId, user, buildParameters());

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/parameters/ActivityModifiedParameters.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/parameters/ActivityModifiedParameters.java
@@ -1,0 +1,24 @@
+package fr.avenirsesr.portfolio.notification.domain.model.notification.parameters;
+
+import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField;
+import java.util.ArrayList;
+import java.util.List;
+
+public record ActivityModifiedParameters(
+    String activityTitle, List<EActivityUpdatableField> updatedFields)
+    implements NotificationParameters {
+
+  public static ActivityModifiedParameters fromStringList(List<String> values) {
+    return new ActivityModifiedParameters(
+        values.getFirst(),
+        values.subList(1, values.size()).stream().map(EActivityUpdatableField::valueOf).toList());
+  }
+
+  @Override
+  public List<String> toStringList() {
+    var result = new ArrayList<String>();
+    result.add(activityTitle);
+    updatedFields.forEach(field -> result.add(field.name()));
+    return result;
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/parameters/AskForFeedbackParameters.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/parameters/AskForFeedbackParameters.java
@@ -1,0 +1,17 @@
+package fr.avenirsesr.portfolio.notification.domain.model.notification.parameters;
+
+import java.util.List;
+
+public record AskForFeedbackParameters(
+    String studentFirstName, String studentLastName, String activityTitle)
+    implements NotificationParameters {
+
+  public static AskForFeedbackParameters fromStringList(List<String> values) {
+    return new AskForFeedbackParameters(values.get(0), values.get(1), values.get(2));
+  }
+
+  @Override
+  public List<String> toStringList() {
+    return List.of(studentFirstName, studentLastName, activityTitle);
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/parameters/NotificationParameters.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/parameters/NotificationParameters.java
@@ -1,0 +1,9 @@
+package fr.avenirsesr.portfolio.notification.domain.model.notification.parameters;
+
+import java.util.List;
+
+public sealed interface NotificationParameters
+    permits AskForFeedbackParameters, ActivityModifiedParameters {
+
+  List<String> toStringList();
+}

--- a/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/mapper/NotificationMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/mapper/NotificationMapper.java
@@ -19,7 +19,7 @@ public class NotificationMapper implements Mapper<NotificationEntity, Notificati
         domain.getElementId(),
         UserMapper.INSTANCE.fromDomain(domain.getUser()),
         domain.getUserCategory(),
-        domain.getParameters(),
+        domain.getParameters().toStringList(),
         domain.isSeen());
   }
 
@@ -33,7 +33,7 @@ public class NotificationMapper implements Mapper<NotificationEntity, Notificati
         entity.getElementId(),
         UserMapper.INSTANCE.toDomain(entity.getUser()),
         entity.getUserCategory(),
-        entity.getParameters(),
+        entity.getType().toParameters(entity.getParameters()),
         entity.isSeen());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -26,6 +26,7 @@ import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorize
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.file.domain.model.File;
 import fr.avenirsesr.portfolio.notification.domain.model.notification.ActivityUpdatedNotification;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.ActivityModifiedParameters;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
@@ -675,16 +676,17 @@ class ActivityServiceImplTest {
           assertEquals(user1, notifications.get(0).build().getUser());
           assertEquals(user2, notifications.get(1).build().getUser());
 
-          List<String> expectedUpdatedFields =
+          List<EActivityUpdatableField> expectedUpdatedFields =
               List.of(
-                  EActivityUpdatableField.ACTIVITY_TITLE.name(),
-                  EActivityUpdatableField.SUMMARY.name(),
-                  EActivityUpdatableField.DESCRIPTION.name(),
-                  EActivityUpdatableField.EXECUTION_PERIOD.name(),
-                  EActivityUpdatableField.THEMATIC.name(),
-                  EActivityUpdatableField.FILES_AND_LINKS.name());
-          List<String> parameters = notifications.getFirst().build().getParameters();
-          assertEquals(expectedUpdatedFields, parameters.subList(1, parameters.size()));
+                  EActivityUpdatableField.ACTIVITY_TITLE,
+                  EActivityUpdatableField.SUMMARY,
+                  EActivityUpdatableField.DESCRIPTION,
+                  EActivityUpdatableField.EXECUTION_PERIOD,
+                  EActivityUpdatableField.THEMATIC,
+                  EActivityUpdatableField.FILES_AND_LINKS);
+          ActivityModifiedParameters parameters =
+              (ActivityModifiedParameters) notifications.getFirst().build().getParameters();
+          assertEquals(expectedUpdatedFields, parameters.updatedFields());
         }
 
         @Nested

--- a/src/test/java/fr/avenirsesr/portfolio/notification/application/adapter/controller/NotificationControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/application/adapter/controller/NotificationControllerIT.java
@@ -94,7 +94,7 @@ public class NotificationControllerIT extends ContainerConfigurationTest {
                     UUID.randomUUID(),
                     user,
                     null,
-                    List.of("notification universelle"),
+                    List.of("Prenom", "Nom", "titre universel"),
                     false))
             .getId()
             .toString();

--- a/src/test/java/fr/avenirsesr/portfolio/notification/application/adapter/controller/NotificationControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/application/adapter/controller/NotificationControllerTest.java
@@ -14,6 +14,7 @@ import fr.avenirsesr.portfolio.notification.application.adapter.dto.Notification
 import fr.avenirsesr.portfolio.notification.domain.exception.NotificationNotFoundException;
 import fr.avenirsesr.portfolio.notification.domain.model.Notification;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.AskForFeedbackParameters;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import java.security.Principal;
 import java.time.Instant;
@@ -93,7 +94,8 @@ class NotificationControllerTest {
     when(notif.getCreatedAt()).thenReturn(Instant.parse("2026-01-01T10:00:00Z"));
     when(notif.getType()).thenReturn(ENotificationType.ASK_FOR_FEEDBACK);
     when(notif.getElementId()).thenReturn(UUID.randomUUID());
-    when(notif.getParameters()).thenReturn(List.of("Alice", "Martin", "titre"));
+    when(notif.getParameters())
+        .thenReturn(new AskForFeedbackParameters("Alice", "Martin", "titre"));
     when(notif.isSeen()).thenReturn(false);
 
     when(notificationService.getNotifications(eq(EUserCategory.STAFF), any(PageCriteria.class)))

--- a/src/test/java/fr/avenirsesr/portfolio/notification/application/adapter/mapper/NotificationResponseMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/application/adapter/mapper/NotificationResponseMapperTest.java
@@ -8,6 +8,9 @@ import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.notification.application.adapter.dto.NotificationDTO;
 import fr.avenirsesr.portfolio.notification.domain.model.Notification;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.ActivityModifiedParameters;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.AskForFeedbackParameters;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.time.Instant;
 import java.util.List;
@@ -23,7 +26,7 @@ class NotificationResponseMapperTest {
   private ENotificationType type;
   private UUID elementId;
   private EUserCategory userCategory;
-  private List<String> parameters;
+  private NotificationParameters parameters;
   private User user;
 
   @BeforeEach
@@ -34,7 +37,7 @@ class NotificationResponseMapperTest {
     type = ENotificationType.ASK_FOR_FEEDBACK;
     elementId = UUID.randomUUID();
     userCategory = EUserCategory.STAFF;
-    parameters = List.of("Alice", "Martin", "Activité de test");
+    parameters = new AskForFeedbackParameters("Alice", "Martin", "Activité de test");
     user = UserFixture.create().toModel();
   }
 
@@ -72,17 +75,27 @@ class NotificationResponseMapperTest {
   }
 
   @Test
-  void toDTO_should_map_empty_parameters_list() {
-    BddLogger.given("A Notification with an empty parameters list");
+  void toDTO_should_map_activity_modified_parameters_with_empty_updated_fields() {
+    BddLogger.given("A Notification whose parameters have an empty updated fields list");
+    NotificationParameters activityModifiedParameters =
+        new ActivityModifiedParameters("Activité de test", List.of());
     Notification notification =
         Notification.toDomain(
-            id, createdAt, updatedAt, type, elementId, user, userCategory, List.of(), false);
+            id,
+            createdAt,
+            updatedAt,
+            ENotificationType.ACTIVITY_MODIFIED,
+            elementId,
+            user,
+            userCategory,
+            activityModifiedParameters,
+            false);
 
     BddLogger.when("toDTO is called");
     NotificationDTO dto = NotificationResponseMapper.INSTANCE.toDTO(notification);
 
-    BddLogger.then("The DTO has an empty parameters list");
-    assertThat(dto.parameters()).isEmpty();
+    BddLogger.then("The DTO carries the typed parameters with an empty updated fields list");
+    assertThat(dto.parameters()).isEqualTo(activityModifiedParameters);
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/notification/domain/model/notification/AskForFeedbackNotificationTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/domain/model/notification/AskForFeedbackNotificationTest.java
@@ -8,6 +8,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.notification.domain.model.Notification;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.AskForFeedbackParameters;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
@@ -101,7 +102,8 @@ class AskForFeedbackNotificationTest {
     BddLogger.when("build() is called");
     Notification result = notif.build();
 
-    BddLogger.then("The parameters list contains the student full name and the activity title");
-    assertThat(result.getParameters()).containsExactly("Alice", "Martin", "Activité de test");
+    BddLogger.then("The parameters contain the student full name and the activity title");
+    assertThat(result.getParameters())
+        .isEqualTo(new AskForFeedbackParameters("Alice", "Martin", "Activité de test"));
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/domain/service/NotificationServiceImplTest.java
@@ -14,6 +14,7 @@ import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.notification.domain.model.Notification;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
 import fr.avenirsesr.portfolio.notification.domain.model.notification.BaseNotification;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.AskForFeedbackParameters;
 import fr.avenirsesr.portfolio.notification.domain.port.output.repository.NotificationRepository;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.user.domain.model.Staff;
@@ -60,7 +61,7 @@ class NotificationServiceImplTest {
         UUID.randomUUID(),
         user,
         category,
-        List.of(),
+        new AskForFeedbackParameters("Alice", "Martin", "Activité de test"),
         false);
   }
 

--- a/src/test/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/mapper/NotificationMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/mapper/NotificationMapperTest.java
@@ -7,6 +7,8 @@ import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.notification.domain.model.Notification;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.AskForFeedbackParameters;
+import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
 import fr.avenirsesr.portfolio.notification.infrastructure.adapter.model.NotificationEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.UserEntity;
@@ -27,7 +29,8 @@ class NotificationMapperTest {
   private User user;
   private UserEntity userEntity;
   private EUserCategory userCategory;
-  private List<String> parameters;
+  private List<String> rawParameters;
+  private NotificationParameters parameters;
   private boolean seen;
 
   @BeforeEach
@@ -38,7 +41,8 @@ class NotificationMapperTest {
     type = ENotificationType.ASK_FOR_FEEDBACK;
     elementId = UUID.randomUUID();
     userCategory = type.getRestrictedTo();
-    parameters = List.of("Alice", "Martin", "Activité de test");
+    rawParameters = List.of("Alice", "Martin", "Activité de test");
+    parameters = new AskForFeedbackParameters("Alice", "Martin", "Activité de test");
     seen = false;
     user = UserFixture.create().toModel();
     userEntity = UserMapper.INSTANCE.fromDomain(user);
@@ -61,7 +65,7 @@ class NotificationMapperTest {
     assertThat(entity.getType()).isEqualTo(type);
     assertThat(entity.getElementId()).isEqualTo(elementId);
     assertThat(entity.getUser().getId()).isEqualTo(user.getId());
-    assertThat(entity.getParameters()).isEqualTo(parameters);
+    assertThat(entity.getParameters()).isEqualTo(rawParameters);
     assertThat(entity.isSeen()).isEqualTo(seen);
   }
 
@@ -70,7 +74,15 @@ class NotificationMapperTest {
     BddLogger.given("A NotificationEntity with all fields set");
     NotificationEntity entity =
         NotificationEntity.of(
-            id, createdAt, updatedAt, type, elementId, userEntity, userCategory, parameters, seen);
+            id,
+            createdAt,
+            updatedAt,
+            type,
+            elementId,
+            userEntity,
+            userCategory,
+            rawParameters,
+            seen);
 
     BddLogger.when("toDomain is called");
     Notification domain = NotificationMapper.INSTANCE.toDomain(entity);


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Notification `parameters` were exposed to the frontend as a raw, positional `List<String>` whose meaning silently depended on the notification `type` (undocumented, already inconsistent between `ASK_FOR_FEEDBACK` and `ACTIVITY_MODIFIED`). This PR introduces a sealed `NotificationParameters` interface implemented by one record per notification type (`AskForFeedbackParameters`, `ActivityModifiedParameters`), used end-to-end in the domain model and the API DTO. `ENotificationType` now centralizes the `List<String>` ↔ typed record conversion, and `NotificationMapper` (entity ↔ domain boundary) is the only place where flattening/reconstruction happens.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2113

---

### Documentation
> No documentation update needed.

---

### Target Branch
> `develop`

---

### Additional Notes
> Storage stays untouched: `NotificationEntity.parameters` remains a `List<String>` persisted via the existing `StringListJsonConverter` in a `TEXT` column — no database migration required. Only the domain model and the DTO exposed to the frontend are now strongly typed per notification type.

---

### Known Limitations or Side Effects
> No `@JsonTypeInfo`/OpenAPI `oneOf` polymorphic schema was added. Jackson already serializes the typed `parameters` correctly based on the runtime type, but the generated Swagger schema documents `parameters` generically rather than as a discriminated union per notification `type`.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process