### PR TITLE
feat(activity): require a description to publish an activity

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/mapper/ActivityPresentationDataMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/mapper/ActivityPresentationDataMapper.java
@@ -16,7 +16,7 @@ public interface ActivityPresentationDataMapper {
         activity.getThematic(),
         Optional.ofNullable(subscribedDeclaredActivity),
         activity.getSummary(),
-        activity.getDescription().orElse(null),
+        activity.getDescription(),
         activity.getExecutionPeriodInfo().orElse(null),
         banner,
         activity.getCreatedAt(),

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/model/Activity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/model/Activity.java
@@ -24,8 +24,6 @@ public class Activity extends AvenirsBaseModel {
   private boolean enableReflection;
   private int traceAllowedAssociations;
   private int feedbackAllowedIterations;
-
-  @Getter(AccessLevel.NONE)
   private String description;
 
   @Getter(AccessLevel.NONE)
@@ -148,10 +146,6 @@ public class Activity extends AvenirsBaseModel {
 
   public Optional<String> getExecutionPeriodInfo() {
     return Optional.ofNullable(executionPeriodInfo);
-  }
-
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
   }
 
   public Optional<File> getBanner() {

--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -113,6 +113,11 @@ public class ActivityServiceImpl implements ActivityService {
           EErrorCode.NOT_BLANK, "summary must be defined to publish an activity");
     }
 
+    if (draft.getDescription().isEmpty()) {
+      throw new FieldValidationException(
+          EErrorCode.NOT_BLANK, "description must be defined to publish an activity");
+    }
+
     var publishedActivity = activityRepository.findById(activityDraftId);
 
     Activity activity =
@@ -123,7 +128,7 @@ public class ActivityServiceImpl implements ActivityService {
                 draft.getTitle(),
                 draft.getThematic(),
                 draft.getSummary().orElseThrow(),
-                draft.getDescription().orElse(null),
+                draft.getDescription().orElseThrow(),
                 draft.getExecutionPeriodInfo().orElse(null),
                 draft.getExecutionPeriodInfoSummary().orElse(null),
                 draft.isEnableReflection(),
@@ -169,7 +174,7 @@ public class ActivityServiceImpl implements ActivityService {
                 activity::setSummary),
             new FieldSync<>(
                 DESCRIPTION,
-                activity.getDescription().orElse(null),
+                activity.getDescription(),
                 draft.getDescription().orElse(null),
                 activity::setDescription),
             new FieldSync<>(
@@ -473,7 +478,7 @@ public class ActivityServiceImpl implements ActivityService {
             activity.getAuthor(),
             activity.getThematic(),
             activity.getSummary(),
-            activity.getDescription().orElse(null),
+            activity.getDescription(),
             activity.getExecutionPeriodInfo().orElse(null),
             activity.getExecutionPeriodInfoSummary().orElse(null),
             activity.getTraceAllowedAssociations(),

--- a/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/mapper/ActivityMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/mapper/ActivityMapper.java
@@ -19,7 +19,7 @@ public class ActivityMapper implements Mapper<ActivityEntity, Activity> {
         domain.getThematic(),
         domain.getSummary(),
         domain.getStatus(),
-        domain.getDescription().orElse(null),
+        domain.getDescription(),
         domain.getExecutionPeriodInfo().orElse(null),
         domain.getExecutionPeriodInfoSummary().orElse(null),
         domain.getTraceAllowedAssociations(),

--- a/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/model/ActivityEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/model/ActivityEntity.java
@@ -44,7 +44,7 @@ public class ActivityEntity extends AvenirsBaseEntity {
   @Column(nullable = false, length = SUMMARY_LENGTH)
   private String summary;
 
-  @Column(length = RICH_DESCRIPTION_LENGTH)
+  @Column(nullable = false, length = RICH_DESCRIPTION_LENGTH)
   private String description;
 
   @Column(name = "execution_period_info", length = ACTIVITY_EXECUTION_PERIOD_INFO)

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityAssociationMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityAssociationMapper.java
@@ -24,7 +24,7 @@ public interface DeclaredActivityAssociationMapper {
         declaredActivity.getActivity().getTitle(),
         declaredActivity.getActivity().getThematic(),
         declaredActivity.getActivity().getSummary(),
-        declaredActivity.getActivity().getDescription().orElse(null),
+        declaredActivity.getActivity().getDescription(),
         declaredActivity.getActivity().getExecutionPeriodInfoSummary().orElse(null),
         status,
         declaredActivity.getStartDate(),

--- a/src/main/resources/db/changelog/generated/changelog_2026-07-13__require-activity-description.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-07-13__require-activity-description.xml
@@ -1,0 +1,18 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="bilelbanelhaq" id="backfill-null-activity-description">
+        <update tableName="activity">
+            <column name="description" value="Description à compléter."/>
+            <where>description IS NULL</where>
+        </update>
+    </changeSet>
+    <changeSet author="bilelbanelhaq" id="require-activity-description">
+        <addNotNullConstraint tableName="activity"
+                              columnName="description"
+                              columnDataType="varchar(10000)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/controller/ActivityControllerIT.java
@@ -511,7 +511,7 @@ class ActivityControllerIT extends ContainerConfigurationTest {
       void thenItShouldPublishActivityDraftAndReturnActivityId() throws Exception {
         BddLogger.and("given an existing activity draft with a summary");
         UUID draftId = createDraftAndGetId("Brouillon à publier");
-        fillDraftWithSummary(draftId);
+        fillDraftWithSummaryAndDescription(draftId);
 
         BddLogger.then("it should return 200 with the published activity id");
 
@@ -534,7 +534,7 @@ class ActivityControllerIT extends ContainerConfigurationTest {
       void thenItShouldPublishActivityDraftAndReturnSameIdAsDraft() throws Exception {
         BddLogger.and("given an existing activity draft with a summary");
         UUID draftId = createDraftAndGetId("Brouillon id conservé");
-        fillDraftWithSummary(draftId);
+        fillDraftWithSummaryAndDescription(draftId);
 
         BddLogger.then("it should return the same id as the draft");
 
@@ -555,7 +555,7 @@ class ActivityControllerIT extends ContainerConfigurationTest {
       void thenItShouldDeleteDraftAfterPublishing() throws Exception {
         BddLogger.and("given an existing activity draft with a summary");
         UUID draftId = createDraftAndGetId("Brouillon supprimé après publication");
-        fillDraftWithSummary(draftId);
+        fillDraftWithSummaryAndDescription(draftId);
 
         webTestClient
             .post()
@@ -581,7 +581,7 @@ class ActivityControllerIT extends ContainerConfigurationTest {
       void thenItShouldMakeActivityAccessibleAfterPublishing() throws Exception {
         BddLogger.and("given an existing draft with a summary");
         UUID draftId = createDraftAndGetId("Brouillon accessible après publication");
-        fillDraftWithSummary(draftId);
+        fillDraftWithSummaryAndDescription(draftId);
 
         webTestClient
             .post()
@@ -648,10 +648,31 @@ class ActivityControllerIT extends ContainerConfigurationTest {
       }
 
       @Test
+      void thenItShouldReturn400WhenDraftHasNoDescription() throws Exception {
+        BddLogger.and("given an existing draft with a summary but no description");
+        UUID draftId = createDraftAndGetId("Brouillon sans consigne");
+        fillDraftWithSummary(draftId);
+
+        BddLogger.then("it should return 400 because description is required to publish");
+
+        webTestClient
+            .post()
+            .uri(PUBLISH_PATH, draftId)
+            .headers(ActivityControllerIT.this::addStaffHeaders)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isEqualTo(400)
+            .expectBody()
+            .jsonPath("$.code")
+            .exists();
+      }
+
+      @Test
       void thenItShouldReturn403WhenStudentTriesToPublish() throws Exception {
         BddLogger.and("given an existing draft and a student account");
         UUID draftId = createDraftAndGetId("Brouillon publication refusée");
-        fillDraftWithSummary(draftId);
+        fillDraftWithSummaryAndDescription(draftId);
 
         BddLogger.then("it should return 403 with USER_IS_NOT_STAFF error code");
 
@@ -1558,9 +1579,36 @@ class ActivityControllerIT extends ContainerConfigurationTest {
         .isOk();
   }
 
+  private void fillDraftWithSummaryAndDescription(UUID draftId) throws Exception {
+    String requestBody =
+        objectMapper.writeValueAsString(
+            new ActivityDraftUpdateRequest(
+                null,
+                EActivityThematic.EXPERIENCES,
+                "Un résumé valide pour la publication",
+                "Une consigne valide pour la publication",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+    webTestClient
+        .patch()
+        .uri(DRAFT_UPDATE_PATH, draftId)
+        .headers(this::addStaffHeaders)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
   private UUID publishNewActivity(String title) throws Exception {
     UUID draftId = createDraftAndGetId(title);
-    fillDraftWithSummary(draftId);
+    fillDraftWithSummaryAndDescription(draftId);
 
     String body =
         webTestClient

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityContentDtoMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityContentDtoMapperTest.java
@@ -40,7 +40,7 @@ class ActivityContentDtoMapperTest {
     assertEquals(activity.getTitle(), dto.title());
     assertEquals(activity.getThematic(), dto.thematic());
     assertEquals(activity.getSummary(), dto.summary());
-    assertEquals(activity.getDescription().orElse(null), dto.description());
+    assertEquals(activity.getDescription(), dto.description());
     assertEquals(activity.getExecutionPeriodInfo().orElse(null), dto.executionPeriodInfo());
     assertNull(dto.hasEnrolledStudent());
   }

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityPresentationDtoMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityPresentationDtoMapperTest.java
@@ -39,7 +39,7 @@ class ActivityPresentationDtoMapperTest {
             activity.getThematic(),
             Optional.empty(),
             activity.getSummary(),
-            activity.getDescription().orElse(null),
+            activity.getDescription(),
             activity.getExecutionPeriodInfo().orElse(null),
             banner,
             activity.getCreatedAt(),

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -107,7 +107,7 @@ class ActivityServiceImplTest {
         assertEquals("This is a test activity", createdActivity.getSummary());
         assertEquals(
             "<h3>Objectives</h3><p>Test activity description</p>",
-            createdActivity.getDescription().get());
+            createdActivity.getDescription());
         assertEquals("2026", createdActivity.getExecutionPeriodInfo().get());
         assertEquals(links, createdActivity.getLinks());
 
@@ -409,14 +409,12 @@ class ActivityServiceImplTest {
           void thenItShouldMapOptionalFieldsAsEmptyOptionalsWhenNotPresent() {
             BddLogger.then("optional fields should be empty when absent from draft");
 
-            when(draft.getDescription()).thenReturn(Optional.empty());
             when(draft.getExecutionPeriodInfo()).thenReturn(Optional.empty());
             when(draft.getExecutionPeriodInfoSummary()).thenReturn(Optional.empty());
 
             Activity result = activityService.publish(draftId);
 
             assertNotNull(result);
-            assertTrue(result.getDescription().isEmpty());
             assertTrue(result.getExecutionPeriodInfo().isEmpty());
             assertTrue(result.getExecutionPeriodInfoSummary().isEmpty());
           }
@@ -443,7 +441,7 @@ class ActivityServiceImplTest {
             assertEquals("Titre complet", result.getTitle());
             assertEquals(EActivityThematic.SELF_KNOWLEDGE, result.getThematic());
             assertEquals("Résumé complet", result.getSummary());
-            assertEquals("<p>Description complète</p>", result.getDescription().get());
+            assertEquals("<p>Description complète</p>", result.getDescription());
             assertEquals("Avant entretien", result.getExecutionPeriodInfo().get());
             assertEquals("Label court", result.getExecutionPeriodInfoSummary().get());
             assertFalse(result.isEnableReflection());
@@ -457,6 +455,18 @@ class ActivityServiceImplTest {
             BddLogger.then("the service should throw FieldValidationException");
 
             when(draft.getSummary()).thenReturn(Optional.empty());
+
+            assertThrows(FieldValidationException.class, () -> activityService.publish(draftId));
+
+            verify(activityRepository, never()).save(any());
+            verify(activityDraftRepository, never()).removeFromDatabase(any());
+          }
+
+          @Test
+          void thenItShouldThrowFieldValidationExceptionWhenDescriptionIsEmpty() {
+            BddLogger.then("the service should throw FieldValidationException");
+
+            when(draft.getDescription()).thenReturn(Optional.empty());
 
             assertThrows(FieldValidationException.class, () -> activityService.publish(draftId));
 
@@ -697,7 +707,7 @@ class ActivityServiceImplTest {
             BddLogger.and("none of the notifiable fields differ from the draft");
             when(existingActivity.getTitle()).thenReturn("Nouveau titre");
             when(existingActivity.getSummary()).thenReturn("Nouveau résumé");
-            when(existingActivity.getDescription()).thenReturn(Optional.of("Nouvelle description"));
+            when(existingActivity.getDescription()).thenReturn("Nouvelle description");
             when(existingActivity.getExecutionPeriodInfo())
                 .thenReturn(Optional.of("Nouvelle période"));
             when(existingActivity.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
@@ -1254,7 +1264,7 @@ class ActivityServiceImplTest {
           when(activity.getThematic()).thenReturn(EActivityThematic.EXPERIENCES);
           when(activity.getSummary()).thenReturn("is a test activity");
           when(activity.getDescription())
-              .thenReturn(Optional.of("<h3>Objectives</h3><p>Test activity description</p>"));
+              .thenReturn("<h3>Objectives</h3><p>Test activity description</p>");
           when(activity.getExecutionPeriodInfo()).thenReturn(Optional.of("2026"));
           when(activity.getCreatedAt()).thenReturn(Instant.now());
           when(activity.getUpdatedAt()).thenReturn(Instant.now());

--- a/src/test/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/mapper/ActivityMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/mapper/ActivityMapperTest.java
@@ -130,7 +130,7 @@ class ActivityMapperTest {
     assertEquals(title, mappedActivity.getTitle());
     assertEquals(thematic, mappedActivity.getThematic());
     assertEquals(summary, mappedActivity.getSummary());
-    assertEquals(description, mappedActivity.getDescription().get());
+    assertEquals(description, mappedActivity.getDescription());
     assertEquals(executionPeriodInfo, mappedActivity.getExecutionPeriodInfo().get());
     assertEquals(executionPeriodInfoSummary, mappedActivity.getExecutionPeriodInfoSummary().get());
     assertEquals(traceAllowedAssociations, mappedActivity.getTraceAllowedAssociations());

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
@@ -165,7 +165,7 @@ class DeclaredActivityPresentationDTOMapperTest {
         activity.getTitle(),
         activity.getThematic(),
         activity.getSummary(),
-        activity.getDescription().orElse(null),
+        activity.getDescription(),
         activity.getExecutionPeriodInfo().orElse(null),
         activity.isEnableReflection(),
         activity.getTraceAllowedAssociations(),

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityViewDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityViewDTOMapperTest.java
@@ -49,7 +49,7 @@ class DeclaredActivityViewDTOMapperTest {
     assertEquals(activity.getTitle(), dto.title());
     assertEquals(activity.getThematic(), dto.thematic());
     assertEquals(activity.getSummary(), dto.summary());
-    assertEquals(activity.getDescription().get(), dto.description());
+    assertEquals(activity.getDescription(), dto.description());
     assertEquals(EDeclaredActivityStatus.SUBSCRIBED, dto.status());
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> `Activity.description` is now a mandatory field, mirroring `summary`. The domain model drops its `Optional<String> getDescription()` in favor of a plain getter, the `activity` table's `description` column is now `NOT NULL`, and publishing an `ActivityDraft` without a description is rejected with a `FieldValidationException` (same pattern as the existing summary check). `ActivityDraft.description` keeps its `Optional` getter since a draft can still be incomplete.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1976

---

### Documentation
> No external documentation updates needed. A new Liquibase changelog (`changelog_2026-07-13__require-activity-description.xml`) backfills any existing NULL `activity.description` rows with a placeholder value before adding the `NOT NULL` constraint.

---

### Target Branch
> `develop`

---

### Additional Notes
> The description-required-at-publish rule was implemented TDD (failing test added first, then the rule). Seeders (`ActivitySeeder`, `FakeActivity`, `activities.json`, `ActivityFixture`) already always set a description, so no seeder changes were needed.

---

### Known Limitations or Side Effects
> Activities that were previously published without a description will be backfilled with a generic placeholder text ("Description à compléter.") by the migration.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process