### PR TITLE
fix(notification): use declared activity id for activity updated notification

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -34,7 +34,6 @@ import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
 import fr.avenirsesr.portfolio.user.domain.model.Staff;
-import fr.avenirsesr.portfolio.user.domain.model.Student;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -138,10 +137,10 @@ public class ActivityServiceImpl implements ActivityService {
                 draft.getLinks()));
 
     if (publishedActivity.isPresent()) {
-      var enrolledStudents = declaredActivityService.getEnrolledStudents(activity);
-      var updatedFields = updateActivity(activity, draft, !enrolledStudents.isEmpty());
+      var enrolledDeclaredActivities = declaredActivityService.getEnrolledStudents(activity);
+      var updatedFields = updateActivity(activity, draft, !enrolledDeclaredActivities.isEmpty());
       activity.setStatus(EActivityStatus.PUBLISHED);
-      notifyActivityUpdated(activity, updatedFields, enrolledStudents);
+      notifyActivityUpdated(updatedFields, enrolledDeclaredActivities);
     }
 
     var savedActivity = activityRepository.save(activity);
@@ -207,15 +206,16 @@ public class ActivityServiceImpl implements ActivityService {
   }
 
   private void notifyActivityUpdated(
-      Activity activity, List<EActivityUpdatableField> updatedFields, List<Student> students) {
-    if (students.isEmpty() || updatedFields.isEmpty()) {
+      List<EActivityUpdatableField> updatedFields, List<DeclaredActivity> declaredActivities) {
+    if (declaredActivities.isEmpty() || updatedFields.isEmpty()) {
       return;
     }
     notificationService.notifyAll(
-        students.stream()
+        declaredActivities.stream()
             .map(
-                student ->
-                    new ActivityUpdatedNotification(student.getUser(), activity, updatedFields))
+                declaredActivity ->
+                    new ActivityUpdatedNotification(
+                        declaredActivity.getStudent().getUser(), declaredActivity, updatedFields))
             .toList());
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/ActivityUpdatedNotification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/domain/model/notification/ActivityUpdatedNotification.java
@@ -1,26 +1,26 @@
 package fr.avenirsesr.portfolio.notification.domain.model.notification;
 
-import fr.avenirsesr.portfolio.activity.domain.model.Activity;
 import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.notification.domain.model.enums.ENotificationType;
 import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.ActivityModifiedParameters;
 import fr.avenirsesr.portfolio.notification.domain.model.notification.parameters.NotificationParameters;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import java.util.List;
 
 public class ActivityUpdatedNotification extends BaseNotification {
-  private final Activity activity;
+  private final DeclaredActivity declaredActivity;
   private final List<EActivityUpdatableField> updatedFields;
 
   public ActivityUpdatedNotification(
-      User user, Activity activity, List<EActivityUpdatableField> updatedFields) {
-    super(user, ENotificationType.ACTIVITY_MODIFIED, activity.getId());
-    this.activity = activity;
+      User user, DeclaredActivity declaredActivity, List<EActivityUpdatableField> updatedFields) {
+    super(user, ENotificationType.ACTIVITY_MODIFIED, declaredActivity.getId());
+    this.declaredActivity = declaredActivity;
     this.updatedFields = updatedFields;
   }
 
   @Override
   protected NotificationParameters buildParameters() {
-    return new ActivityModifiedParameters(activity.getTitle(), updatedFields);
+    return new ActivityModifiedParameters(declaredActivity.getActivity().getTitle(), updatedFields);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
@@ -76,5 +76,5 @@ public interface DeclaredActivityService {
 
   int countEnrolledStudents(Activity activity);
 
-  List<Student> getEnrolledStudents(Activity activity);
+  List<DeclaredActivity> getEnrolledStudents(Activity activity);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -563,11 +563,9 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
   }
 
   @Override
-  public List<Student> getEnrolledStudents(Activity activity) {
+  public List<DeclaredActivity> getEnrolledStudents(Activity activity) {
     var graph = FetchGraph.init().add("student").fetch("user");
-    return declaredActivityRepository.findAllByActivity(activity, graph).stream()
-        .map(DeclaredActivity::getStudent)
-        .toList();
+    return declaredActivityRepository.findAllByActivity(activity, graph);
   }
 
   private EAssociationType getAssociationType(EAssociationContextType contextType) {

--- a/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImplTest.java
@@ -623,6 +623,8 @@ class ActivityServiceImplTest {
         Student student2;
         User user1;
         User user2;
+        DeclaredActivity declaredActivity1;
+        DeclaredActivity declaredActivity2;
 
         @BeforeEach
         void setupAnd() {
@@ -631,10 +633,16 @@ class ActivityServiceImplTest {
           student2 = mock(Student.class);
           user1 = mock(User.class);
           user2 = mock(User.class);
+          declaredActivity1 = mock(DeclaredActivity.class);
+          declaredActivity2 = mock(DeclaredActivity.class);
           lenient().when(student1.getUser()).thenReturn(user1);
           lenient().when(student2.getUser()).thenReturn(user2);
+          lenient().when(declaredActivity1.getStudent()).thenReturn(student1);
+          lenient().when(declaredActivity2.getStudent()).thenReturn(student2);
+          lenient().when(declaredActivity1.getActivity()).thenReturn(existingActivity);
+          lenient().when(declaredActivity2.getActivity()).thenReturn(existingActivity);
           when(declaredActivityService.getEnrolledStudents(existingActivity))
-              .thenReturn(List.of(student1, student2));
+              .thenReturn(List.of(declaredActivity1, declaredActivity2));
         }
 
         @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -1727,7 +1727,7 @@ class DeclaredActivityServiceImplTest {
   }
 
   @Test
-  void getEnrolledStudents_should_return_students_of_the_activity_declared_activities() {
+  void getEnrolledStudents_should_return_declared_activities_of_the_activity() {
     BddLogger.given("an activity with two enrolled students");
     Activity activity = ActivityFixture.create().toModel();
     Student student1 = StudentFixture.create().toModel();
@@ -1742,10 +1742,10 @@ class DeclaredActivityServiceImplTest {
         .thenReturn(List.of(declaredActivity1, declaredActivity2));
 
     BddLogger.when("getting the enrolled students");
-    List<Student> result = service.getEnrolledStudents(activity);
+    List<DeclaredActivity> result = service.getEnrolledStudents(activity);
 
-    BddLogger.then("it should return the students of each declared activity");
-    assertThat(result).containsExactly(student1, student2);
+    BddLogger.then("it should return the declared activities of the activity");
+    assertThat(result).containsExactly(declaredActivity1, declaredActivity2);
   }
 
   @Test
@@ -1756,7 +1756,7 @@ class DeclaredActivityServiceImplTest {
         .thenReturn(List.of());
 
     BddLogger.when("getting the enrolled students");
-    List<Student> result = service.getEnrolledStudents(activity);
+    List<DeclaredActivity> result = service.getEnrolledStudents(activity);
 
     BddLogger.then("it should return an empty list");
     assertThat(result).isEmpty();


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> The `ActivityUpdatedNotification` and the `notifyActivityUpdated` flow previously carried the `Activity` and derived the list of `Student`s from `DeclaredActivityService.getEnrolledStudents`. This PR changes `getEnrolledStudents` to return the `DeclaredActivity` entities instead of `Student`s, and updates `ActivityUpdatedNotification` to reference the `DeclaredActivity` (progress) id rather than the `Activity` id, so notification consumers resolve the correct declared-activity/progress context per student.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2128

---

### Documentation
> No documentation updates required.

---

### Target Branch
> `develop`

---

### Additional Notes
> `getEnrolledStudents(Activity)` now returns `List<DeclaredActivity>` instead of `List<Student>`, and `ActivityUpdatedNotification` takes a `DeclaredActivity` instead of an `Activity`. Tests in `ActivityServiceImplTest` and `DeclaredActivityServiceImplTest` were updated accordingly.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process