### PR TITLE
feat(notification): add seeder for activity updated notifications

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/seeder/NotificationSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/seeder/NotificationSeeder.java
@@ -1,0 +1,165 @@
+package fr.avenirsesr.portfolio.notification.infrastructure.adapter.seeder;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityThematic;
+import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField;
+import fr.avenirsesr.portfolio.activity.domain.port.input.ActivityService;
+import fr.avenirsesr.portfolio.activity.infrastructure.adapter.model.ActivityEntity;
+import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
+import fr.avenirsesr.portfolio.common.seeder.infrastructure.adapter.data.ESeederSource;
+import fr.avenirsesr.portfolio.common.utils.FileReader;
+import fr.avenirsesr.portfolio.common.web.infrastructure.context.RequestContext;
+import fr.avenirsesr.portfolio.common.web.infrastructure.context.RequestData;
+import fr.avenirsesr.portfolio.notification.infrastructure.adapter.seeder.data.ActivityUpdatedNotificationCreationData;
+import fr.avenirsesr.portfolio.shared.domain.port.input.ClockService;
+import fr.avenirsesr.portfolio.shared.infrastructure.adapter.seeder.SeederConfig;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.infrastructure.adapter.model.DeclaredActivityEntity;
+import fr.avenirsesr.portfolio.user.domain.port.input.UserService;
+import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationSeeder {
+  private static final String ACTIVITY_UPDATED_PATH_FILE =
+      "seeder/activity-updated-notifications.json";
+
+  private final FileReader fileReader;
+  private final ActivityService activityService;
+  private final UserService userService;
+  private final ClockService clockService;
+
+  @Value("${seeder.source}")
+  private ESeederSource seederSource;
+
+  @Transactional
+  public void seed(
+      List<ActivityEntity> savedActivities, List<DeclaredActivityEntity> savedDeclaredActivities) {
+    log.info("Seeding Notifications...");
+    seedActivityUpdatedNotifications(savedActivities, savedDeclaredActivities);
+  }
+
+  private void seedActivityUpdatedNotifications(
+      List<ActivityEntity> savedActivities, List<DeclaredActivityEntity> savedDeclaredActivities) {
+    List<ActivityUpdatedNotificationCreationData> creationData =
+        switch (seederSource) {
+          case CSV ->
+              fileReader.readJSON(
+                  ACTIVITY_UPDATED_PATH_FILE,
+                  new TypeReference<List<ActivityUpdatedNotificationCreationData>>() {});
+          case FAKER ->
+              savedDeclaredActivities.stream()
+                  .collect(
+                      Collectors.toMap(
+                          declaredActivity -> declaredActivity.getActivity().getId(),
+                          Function.identity(),
+                          (first, second) -> first,
+                          LinkedHashMap::new))
+                  .values()
+                  .stream()
+                  .limit(SeederConfig.NB_OF_ACTIVITY_UPDATED_NOTIFICATIONS)
+                  .map(
+                      declaredActivity ->
+                          new ActivityUpdatedNotificationCreationData(
+                              declaredActivity.getActivity().getId(),
+                              declaredActivity.getStudent().getId(),
+                              clockService.now(),
+                              List.of(EActivityUpdatableField.ACTIVITY_TITLE)))
+                  .toList();
+        };
+
+    creationData.forEach(
+        data -> {
+          enableNotificationPreferences(data.studentId());
+          try {
+            clockService.fixed(data.createdAt());
+            republishWithModifiedFields(data.activityId(), data.updatedFields(), savedActivities);
+          } finally {
+            clockService.clear();
+          }
+        });
+
+    log.info("✔ {} activity updated notifications created", creationData.size());
+  }
+
+  private void enableNotificationPreferences(UUID studentId) {
+    var student = userService.getUser(studentId);
+    RequestContext.set(new RequestData(Optional.of(student), ELanguage.FRENCH));
+    userService.updateNotificationPreferences(true);
+  }
+
+  private void republishWithModifiedFields(
+      UUID activityId,
+      List<EActivityUpdatableField> updatedFields,
+      List<ActivityEntity> savedActivities) {
+    var activity =
+        savedActivities.stream()
+            .filter(a -> a.getId().equals(activityId))
+            .findFirst()
+            .orElseThrow();
+
+    RequestContext.set(
+        new RequestData(
+            Optional.ofNullable(UserMapper.INSTANCE.toDomain(activity.getAuthor().getUser())),
+            ELanguage.FRENCH));
+
+    var draft = activityService.createDraftFromActivity(activityId);
+
+    String title = null;
+    EActivityThematic thematic = null;
+    String summary = null;
+    String description = null;
+    String executionPeriodInfo = null;
+    List<String> links = null;
+
+    for (var field : updatedFields) {
+      switch (field) {
+        case ACTIVITY_TITLE -> title = draft.getTitle() + " (modifié)";
+        case THEMATIC -> thematic = nextThematic(draft.getThematic());
+        case SUMMARY -> summary = draft.getSummary().orElse("") + " (modifié)";
+        case DESCRIPTION -> description = draft.getDescription().orElse("") + " (modifié)";
+        case EXECUTION_PERIOD ->
+            executionPeriodInfo = draft.getExecutionPeriodInfo().orElse("") + " (modifié)";
+        case FILES_AND_LINKS ->
+            links =
+                Stream.concat(draft.getLinks().stream(), Stream.of("https://example.com/modifie"))
+                    .toList();
+        case BANNER ->
+            throw new UnsupportedOperationException(
+                "BANNER updates are not supported by the notification seeder");
+      }
+    }
+
+    activityService.updateActivityDraft(
+        draft.getId(),
+        title,
+        thematic,
+        summary,
+        description,
+        executionPeriodInfo,
+        null,
+        null,
+        null,
+        null,
+        links);
+
+    activityService.publish(draft.getId());
+  }
+
+  private EActivityThematic nextThematic(EActivityThematic current) {
+    var values = EActivityThematic.values();
+    return values[(current.ordinal() + 1) % values.length];
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/seeder/data/ActivityUpdatedNotificationCreationData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/notification/infrastructure/adapter/seeder/data/ActivityUpdatedNotificationCreationData.java
@@ -1,0 +1,12 @@
+package fr.avenirsesr.portfolio.notification.infrastructure.adapter.seeder.data;
+
+import fr.avenirsesr.portfolio.activity.domain.model.enums.EActivityUpdatableField;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record ActivityUpdatedNotificationCreationData(
+    UUID activityId,
+    UUID studentId,
+    Instant createdAt,
+    List<EActivityUpdatableField> updatedFields) {}

--- a/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/seeder/SeederConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/seeder/SeederConfig.java
@@ -58,4 +58,7 @@ public class SeederConfig {
   // Declared Activities
   public static final int NB_DECLARED_ACTIVITIES_PER_STUDENT = 2;
   public static final int NB_DECLARED_ACTIVITIES_TRACE_ASSOCIATION = 5;
+
+  // Notifications
+  public static final int NB_OF_ACTIVITY_UPDATED_NOTIFICATIONS = 2;
 }

--- a/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/seeder/SeederOrchestrator.java
+++ b/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/seeder/SeederOrchestrator.java
@@ -9,6 +9,7 @@ import fr.avenirsesr.portfolio.common.seeder.infrastructure.configuration.Seedin
 import fr.avenirsesr.portfolio.declaredskill.infrastructure.adapter.seeder.DeclaredSkillSeeder;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.seeder.ActivityFileSeeder;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.seeder.UserPhotoSeeder;
+import fr.avenirsesr.portfolio.notification.infrastructure.adapter.seeder.NotificationSeeder;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.seeder.InstitutionSeeder;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.seeder.ProgramSeeder;
 import fr.avenirsesr.portfolio.program.infrastructure.adapter.seeder.SkillSeeder;
@@ -84,6 +85,7 @@ public class SeederOrchestrator {
   private final ActivityFileSeeder activityFileSeeder;
   private final FeedbackSeeder feedbackSeeder;
   private final AssociationSeeder associationSeeder;
+  private final NotificationSeeder notificationSeeder;
 
   private final SeedingState seedingState;
 
@@ -136,6 +138,8 @@ public class SeederOrchestrator {
       activityFileSeeder.seed(savedActivityDrafts, savedActivities);
 
       feedbackSeeder.seed(savedStudents, declaredActivities);
+
+      notificationSeeder.seed(savedActivities, declaredActivities);
 
       log.info("✔ Seeding successfully finished");
       seedingState.markCompleted();

--- a/src/main/resources/seeder/activity-updated-notifications.json
+++ b/src/main/resources/seeder/activity-updated-notifications.json
@@ -1,0 +1,14 @@
+[
+  {
+    "activityId": "2a9f6c4d-8b1e-4d33-9c7a-5e2b8f1c6d77",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "createdAt": "2026-07-10T09:00:00Z",
+    "updatedFields": ["ACTIVITY_TITLE"]
+  },
+  {
+    "activityId": "7b3d4e91-6f2a-4c88-9a1e-5d3f7b2c8e44",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "createdAt": "2026-07-12T14:30:00Z",
+    "updatedFields": ["ACTIVITY_TITLE", "THEMATIC"]
+  }
+]

--- a/src/test/java/fr/avenirsesr/portfolio/notification/application/adapter/controller/NotificationControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/notification/application/adapter/controller/NotificationControllerIT.java
@@ -160,7 +160,7 @@ public class NotificationControllerIT extends ContainerConfigurationTest {
         .jsonPath("$.data")
         .isArray()
         .jsonPath("$.page.totalElements")
-        .isEqualTo(2);
+        .isEqualTo(4);
   }
 
   @Test


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a `NotificationSeeder` that generates "activity updated" notifications for declared activities during database seeding, along with the corresponding seed data file and orchestrator wiring.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2137

---

### Documentation
> No documentation updates required.

---

### Target Branch
> `develop`

---

### Additional Notes
> Adds `NB_OF_ACTIVITY_UPDATED_NOTIFICATIONS` config constant and a new `activity-updated-notifications.json` seed data file. The seeder is invoked from `SeederOrchestrator` after feedback seeding.

---

### Known Limitations or Side Effects
> None known.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process