### PR TITLE
fix(activity): compare links and files order-independently on update

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/domain/service/ActivityServiceImpl.java
@@ -207,7 +207,10 @@ public class ActivityServiceImpl implements ActivityService {
                 draft.getBanner().orElse(null),
                 activity::setBanner),
             new FieldSync<>(
-                FILES_AND_LINKS, activity.getLinks(), draft.getLinks(), activity::setLinks),
+                FILES_AND_LINKS,
+                new HashSet<>(activity.getLinks()),
+                new HashSet<>(draft.getLinks()),
+                links -> activity.setLinks(links.stream().toList())),
             new FieldSync<>(
                 FILES_AND_LINKS, activity.getFiles(), draft.getFiles(), activity::setFiles));
 

--- a/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/model/ActivityDraftEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/model/ActivityDraftEntity.java
@@ -73,6 +73,7 @@ public class ActivityDraftEntity extends AvenirsBaseEntity {
       name = "activity_draft_files",
       joinColumns = @JoinColumn(name = "activity_draft_id"),
       inverseJoinColumns = @JoinColumn(name = "file_id"))
+  @OrderBy("createdAt")
   private List<FileEntity> files = new ArrayList<>();
 
   public ActivityDraftEntity(

--- a/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/model/ActivityEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/activity/infrastructure/adapter/model/ActivityEntity.java
@@ -77,6 +77,7 @@ public class ActivityEntity extends AvenirsBaseEntity {
       name = "activity_files",
       joinColumns = @JoinColumn(name = "activity_id"),
       inverseJoinColumns = @JoinColumn(name = "file_id"))
+  @OrderBy("createdAt")
   private List<FileEntity> files = new ArrayList<>();
 
   private ActivityEntity(


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> `updateActivity` compared `activity`/`draft` fields with `Objects.equals`, which for `List` is order-sensitive. `links` and `files` collections had no guaranteed order (`@ManyToMany` without `@OrderBy`), so identical content in a different order was reported as "changed", causing the notification to trigger systematically even when nothing actually changed. `links` now compares as a `Set`, and `@OrderBy("createdAt")` was added to the `files` collections on both `ActivityEntity` and `ActivityDraftEntity` so activity and draft return files in the same order.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2148

---

### Documentation
> _No documentation updates required._

---

### Target Branch
> `develop`

---

### Additional Notes
> `@ManyToMany` collections without `@OrderBy`/`@OrderColumn` have no guaranteed row order per the JPA spec, so `activity_files` and `activity_draft_files` could return the same files in different order across the two join tables.

---

### Known Limitations or Side Effects
> _None identified._

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process