### PR TITLE
feat(trace): add attachment, authorType, personalNote and aiUseJustification to TraceViewDTO

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/TraceViewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/TraceViewDTO.java
@@ -1,5 +1,7 @@
 package fr.avenirsesr.portfolio.trace.application.adapter.dto;
 
+import fr.avenirsesr.portfolio.file.application.adapter.dto.FileDTO;
+import fr.avenirsesr.portfolio.trace.domain.model.enums.ETraceAuthorType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -12,6 +14,7 @@ import java.util.UUID;
       "isAssociated",
       "createdAt",
       "updatedAt",
+      "authorType",
     })
 public record TraceViewDTO(
     UUID id,
@@ -19,4 +22,8 @@ public record TraceViewDTO(
     boolean isAssociated,
     Instant createdAt,
     Instant updatedAt,
-    LocalDate willBeDeletedAt) {}
+    LocalDate willBeDeletedAt,
+    FileDTO attachment,
+    @Schema(ref = "#/components/schemas/ETraceAuthorType") ETraceAuthorType authorType,
+    String personalNote,
+    String aiUseJustification) {}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceViewMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceViewMapper.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.trace.application.adapter.mapper;
 
+import fr.avenirsesr.portfolio.file.application.adapter.mapper.FileDtoMapper;
 import fr.avenirsesr.portfolio.trace.application.adapter.dto.TraceViewDTO;
 import fr.avenirsesr.portfolio.trace.domain.data.TraceViewData;
 import java.time.LocalDate;
@@ -7,7 +8,9 @@ import java.util.List;
 import java.util.Optional;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+    componentModel = "spring",
+    uses = {FileDtoMapper.class})
 public interface TraceViewMapper {
 
   TraceViewDTO toDTO(TraceViewData trace);

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/data/TraceViewData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/data/TraceViewData.java
@@ -1,5 +1,7 @@
 package fr.avenirsesr.portfolio.trace.domain.data;
 
+import fr.avenirsesr.portfolio.file.domain.model.File;
+import fr.avenirsesr.portfolio.trace.domain.model.enums.ETraceAuthorType;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -11,4 +13,8 @@ public record TraceViewData(
     boolean isAssociated,
     Instant createdAt,
     Instant updatedAt,
-    Optional<LocalDate> willBeDeletedAt) {}
+    Optional<LocalDate> willBeDeletedAt,
+    Optional<File> attachment,
+    ETraceAuthorType authorType,
+    String personalNote,
+    String aiUseJustification) {}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/domain/service/TraceServiceImpl.java
@@ -120,7 +120,11 @@ public class TraceServiceImpl implements TraceService {
                       trace.getUpdatedAt(),
                       isAssociated
                           ? Optional.empty()
-                          : Optional.of(computeDeletionDateForUnassociatedTrace(trace, config)));
+                          : Optional.of(computeDeletionDateForUnassociatedTrace(trace, config)),
+                      trace.getAttachment(),
+                      trace.getAuthorType(),
+                      trace.getPersonalNote().orElse(null),
+                      trace.getAiUseJustification().orElse(null));
                 })
             .toList(),
         pagedResult.pageInfo());

--- a/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceViewMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceViewMapperTest.java
@@ -3,19 +3,28 @@ package fr.avenirsesr.portfolio.trace.application.adapter.mapper;
 import static org.junit.jupiter.api.Assertions.*;
 
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
+import fr.avenirsesr.portfolio.file.application.adapter.mapper.FileDtoMapper;
 import fr.avenirsesr.portfolio.trace.application.adapter.dto.TraceViewDTO;
 import fr.avenirsesr.portfolio.trace.domain.data.TraceViewData;
+import fr.avenirsesr.portfolio.trace.domain.model.enums.ETraceAuthorType;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class TraceViewMapperTest {
 
-  private final TraceViewMapper mapper = Mappers.getMapper(TraceViewMapper.class);
+  @Spy private FileDtoMapper fileDtoMapper = Mappers.getMapper(FileDtoMapper.class);
+
+  @InjectMocks private TraceViewMapperImpl mapper;
 
   @Test
   void shouldMapTraceViewDataToDTO() {
@@ -28,7 +37,17 @@ class TraceViewMapperTest {
     Instant updatedAt = Instant.now();
 
     TraceViewData data =
-        new TraceViewData(id, "My Trace", true, createdAt, updatedAt, Optional.of(deletionDate));
+        new TraceViewData(
+            id,
+            "My Trace",
+            true,
+            createdAt,
+            updatedAt,
+            Optional.of(deletionDate),
+            Optional.empty(),
+            ETraceAuthorType.PERSONAL,
+            "My personal note",
+            "My AI use justification");
 
     BddLogger.when("mapping to TraceViewDTO");
     TraceViewDTO dto = mapper.toDTO(data);
@@ -41,6 +60,10 @@ class TraceViewMapperTest {
     assertTrue(dto.isAssociated());
     assertEquals(createdAt, dto.createdAt());
     assertEquals(updatedAt, dto.updatedAt());
+    assertNull(dto.attachment());
+    assertEquals(ETraceAuthorType.PERSONAL, dto.authorType());
+    assertEquals("My personal note", dto.personalNote());
+    assertEquals("My AI use justification", dto.aiUseJustification());
   }
 
   @Test
@@ -54,7 +77,11 @@ class TraceViewMapperTest {
             false,
             Instant.now(),
             Instant.now(),
-            Optional.empty());
+            Optional.empty(),
+            Optional.empty(),
+            ETraceAuthorType.COLLECTIVE,
+            null,
+            null);
 
     BddLogger.when("mapping to TraceViewDTO");
     TraceViewDTO dto = mapper.toDTO(data);
@@ -74,14 +101,27 @@ class TraceViewMapperTest {
     List<TraceViewData> dataList =
         List.of(
             new TraceViewData(
-                UUID.randomUUID(), "Trace A", true, Instant.now(), Instant.now(), Optional.empty()),
+                UUID.randomUUID(),
+                "Trace A",
+                true,
+                Instant.now(),
+                Instant.now(),
+                Optional.empty(),
+                Optional.empty(),
+                ETraceAuthorType.PERSONAL,
+                null,
+                null),
             new TraceViewData(
                 UUID.randomUUID(),
                 "Trace B",
                 false,
                 Instant.now(),
                 Instant.now(),
-                Optional.empty()));
+                Optional.empty(),
+                Optional.empty(),
+                ETraceAuthorType.THIRD_PARTY,
+                null,
+                null));
 
     BddLogger.when("mapping list to DTOs");
     List<TraceViewDTO> dtos = mapper.toDTOs(dataList);


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds `attachment`, `authorType`, `personalNote` and `aiUseJustification` fields to `TraceViewDTO` (and the underlying `TraceViewData`, `TraceViewMapper` and `TraceServiceImpl`) so the trace list view can display badges. `authorType` is marked as a required property in the OpenAPI schema.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2154

---

### Documentation
> No documentation updates needed. `TraceViewDTO`'s OpenAPI schema now lists `authorType` as required.

---

### Target Branch
> `develop`

---

### Additional Notes
> The new fields follow the same mapping pattern already used by `TraceDetailDTO`/`TraceDetailData` (reusing `FileDtoMapper` to map the optional attachment file).

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process