### PR TITLE
refactor(trace-overview): add aiUseJustification to DTO

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/TraceOverviewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/dto/TraceOverviewDTO.java
@@ -11,5 +11,6 @@ public record TraceOverviewDTO(
     String title,
     String programName,
     @Schema(ref = "#/components/schemas/ETraceAuthorType") ETraceAuthorType authorType,
+    String aiUseJustification,
     Instant createdAt,
     Instant updatedAt) {}

--- a/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceOverviewMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceOverviewMapper.java
@@ -1,15 +1,19 @@
 package fr.avenirsesr.portfolio.trace.application.adapter.mapper;
 
+import fr.avenirsesr.portfolio.shared.application.adapter.mapper.OptionalMapper;
 import fr.avenirsesr.portfolio.trace.application.adapter.dto.TraceOverviewDTO;
 import fr.avenirsesr.portfolio.trace.domain.data.TraceWithProjectNameData;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+    componentModel = "spring",
+    uses = {OptionalMapper.class})
 public interface TraceOverviewMapper {
 
   @Mapping(source = "trace.id", target = "id")
+  @Mapping(source = "trace.aiUseJustification", target = "aiUseJustification")
   TraceOverviewDTO toDTO(Trace trace, String programName);
 
   default TraceOverviewDTO toDTO(Trace trace) {

--- a/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerIT.java
@@ -251,6 +251,12 @@ class TraceControllerIT extends ContainerConfigurationTest {
         .isOk()
         .expectBody()
         .jsonPath("$[0].id")
+        .exists()
+        .jsonPath("$[0].title")
+        .exists()
+        .jsonPath("$[0].programName")
+        .exists()
+        .jsonPath("$[0].aiUseJustification")
         .exists();
 
     BddLogger.then("it should return trace overview");

--- a/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/controller/TraceControllerTest.java
@@ -66,6 +66,7 @@ class TraceControllerTest {
                 trace.getTitle(),
                 "Program Name",
                 ETraceAuthorType.PERSONAL,
+                "Some justification for ia use",
                 null,
                 null));
 

--- a/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceOverviewMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/application/adapter/mapper/TraceOverviewMapperTest.java
@@ -3,16 +3,24 @@ package fr.avenirsesr.portfolio.trace.application.adapter.mapper;
 import static org.junit.jupiter.api.Assertions.*;
 
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
+import fr.avenirsesr.portfolio.shared.application.adapter.mapper.OptionalMapper;
 import fr.avenirsesr.portfolio.trace.application.adapter.dto.TraceOverviewDTO;
 import fr.avenirsesr.portfolio.trace.domain.data.TraceWithProjectNameData;
 import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.trace.infrastructure.fixture.TraceFixture;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class TraceOverviewMapperTest {
 
-  private final TraceOverviewMapper mapper = Mappers.getMapper(TraceOverviewMapper.class);
+  @Spy private OptionalMapper optionalMapper = Mappers.getMapper(OptionalMapper.class);
+
+  @InjectMocks private TraceOverviewMapperImpl mapper;
 
   @Test
   void shouldMapTraceAndProgramNameToDTO() {


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
<!-- Describe the changes introduced by this pull request. -->

:recycle: TraceOverviewDTO - add aiUseJustification

---

### Reference to an Issue, Feature, Task, User Story or another PR
<!-- Mention related issue numbers or links (e.g. Closes #123, Implements #456). -->
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2297

---

### Documentation
<!-- Detail any updates made to documentation, configuration steps, or technical specs. -->

---

### Target Branch
<!-- Which branch is this PR targeting (e.g. `main`, `develop`)? -->

---

### Additional Notes
<!-- Include any relevant context, technical details, or reasons behind certain decisions. -->

<img width="1262" height="686" alt="image" src="https://github.com/user-attachments/assets/cb8a0171-d6f3-46a1-b80a-9f6da85da66c" />

---

### Known Limitations or Side Effects
<!-- List any limitations, known bugs, or side effects this PR may introduce. -->

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process

---

# Remember

**DO NOT** keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

Please do not submit a pull request to ask questions.

Do not submit pull requests without tests that verify or reproduce your intended use case. The pull request will
most likely be automatically closed immediately, unless the change is extremely trivial. 

