### PR TITLE
feat(declared-experience): add valorized field to declared experience

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
@@ -95,7 +95,7 @@ public class DeclaredExperienceController {
             request.externalLink(),
             request.startDate(),
             request.endDate(),
-            request.valorized());
+            Boolean.TRUE.equals(request.valorized()));
 
     return ResponseEntity.ok(declaredExperienceMapper.toDTO(experience));
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
@@ -94,7 +94,8 @@ public class DeclaredExperienceController {
             request.summary(),
             request.externalLink(),
             request.startDate(),
-            request.endDate());
+            request.endDate(),
+            request.valorized());
 
     return ResponseEntity.ok(declaredExperienceMapper.toDTO(experience));
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceRequest.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceRequest.java
@@ -25,4 +25,5 @@ public record DeclaredExperienceRequest(
     @Size(max = SUMMARY_LENGTH) String summary,
     String externalLink,
     LocalDate startDate,
-    LocalDate endDate) {}
+    LocalDate endDate,
+    boolean valorized) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceRequest.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceRequest.java
@@ -26,4 +26,4 @@ public record DeclaredExperienceRequest(
     String externalLink,
     LocalDate startDate,
     LocalDate endDate,
-    boolean valorized) {}
+    Boolean valorized) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceViewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceViewDTO.java
@@ -20,5 +20,6 @@ public record DeclaredExperienceViewDTO(
     String externalLink,
     LocalDate startDate,
     LocalDate endDate,
+    boolean valorized,
     Instant createdAt,
     Instant updatedAt) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/model/DeclaredExperience.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/model/DeclaredExperience.java
@@ -24,6 +24,7 @@ public class DeclaredExperience extends AvenirsBaseModel {
   private String externalLink;
   private LocalDate startDate;
   private LocalDate endDate;
+  private boolean valorized;
 
   private DeclaredExperience(
       UUID id,
@@ -40,7 +41,8 @@ public class DeclaredExperience extends AvenirsBaseModel {
       String summary,
       String externalLink,
       LocalDate startDate,
-      LocalDate endDate) {
+      LocalDate endDate,
+      boolean valorized) {
     super(id, createdAt, updatedAt);
     this.student = student;
     this.title = title;
@@ -54,6 +56,7 @@ public class DeclaredExperience extends AvenirsBaseModel {
     this.externalLink = externalLink;
     this.startDate = startDate;
     this.endDate = endDate;
+    this.valorized = valorized;
   }
 
   public static DeclaredExperience create(
@@ -84,7 +87,8 @@ public class DeclaredExperience extends AvenirsBaseModel {
         summary,
         externalLink,
         startDate,
-        endDate);
+        endDate,
+        false);
   }
 
   public static DeclaredExperience toDomain(
@@ -102,7 +106,8 @@ public class DeclaredExperience extends AvenirsBaseModel {
       String summary,
       String externalLink,
       LocalDate startDate,
-      LocalDate endDate) {
+      LocalDate endDate,
+      boolean valorized) {
     return new DeclaredExperience(
         id,
         createdAt,
@@ -118,6 +123,7 @@ public class DeclaredExperience extends AvenirsBaseModel {
         summary,
         externalLink,
         startDate,
-        endDate);
+        endDate,
+        valorized);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
@@ -51,7 +51,8 @@ public interface DeclaredExperienceService {
       String summary,
       String externalLink,
       LocalDate startDate,
-      LocalDate endDate);
+      LocalDate endDate,
+      boolean valorized);
 
   void delete(List<UUID> experienceIds);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
@@ -162,7 +162,8 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
       String summary,
       String externalLink,
       LocalDate startDate,
-      LocalDate endDate) {
+      LocalDate endDate,
+      boolean valorized) {
     Student student = loggedInUserService.getLoggedInStudent();
     log.info("Update experienceId {} by {}", experienceId, student);
 
@@ -196,6 +197,7 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
     experience.setExternalLink(externalLink);
     experience.setStartDate(startDate);
     experience.setEndDate(endDate);
+    experience.setValorized(valorized);
     experience = experienceRepository.save(experience);
 
     log.info("{} updated successfully", experience);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/mapper/DeclaredExperienceMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/mapper/DeclaredExperienceMapper.java
@@ -27,7 +27,8 @@ public class DeclaredExperienceMapper
         declaredExperience.getSummary(),
         declaredExperience.getExternalLink(),
         declaredExperience.getStartDate(),
-        declaredExperience.getEndDate());
+        declaredExperience.getEndDate(),
+        declaredExperience.isValorized());
   }
 
   @Override
@@ -47,7 +48,8 @@ public class DeclaredExperienceMapper
         entity.getSummary(),
         entity.getExternalLink(),
         entity.getStartDate(),
-        entity.getEndDate());
+        entity.getEndDate(),
+        entity.isValorized());
   }
 
   @Override
@@ -71,6 +73,7 @@ public class DeclaredExperienceMapper
         entity.getSummary(),
         entity.getExternalLink(),
         entity.getStartDate(),
-        entity.getEndDate());
+        entity.getEndDate(),
+        entity.isValorized());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/model/DeclaredExperienceEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/model/DeclaredExperienceEntity.java
@@ -68,6 +68,9 @@ public class DeclaredExperienceEntity extends PeriodEntity<LocalDate> {
   @Column(name = "external_link")
   private String externalLink;
 
+  @Column(nullable = false)
+  private boolean valorized;
+
   private DeclaredExperienceEntity(
       UUID id,
       Instant createdAt,
@@ -83,7 +86,8 @@ public class DeclaredExperienceEntity extends PeriodEntity<LocalDate> {
       String summary,
       String externalLink,
       LocalDate startDate,
-      LocalDate endDate) {
+      LocalDate endDate,
+      boolean valorized) {
     this.setId(id);
     this.setCreatedAt(createdAt);
     this.setUpdatedAt(updatedAt);
@@ -99,6 +103,7 @@ public class DeclaredExperienceEntity extends PeriodEntity<LocalDate> {
     this.externalLink = externalLink;
     this.startDate = startDate;
     this.endDate = endDate;
+    this.valorized = valorized;
   }
 
   public static DeclaredExperienceEntity of(
@@ -116,7 +121,8 @@ public class DeclaredExperienceEntity extends PeriodEntity<LocalDate> {
       String summary,
       String externalLink,
       LocalDate startDate,
-      LocalDate endDate) {
+      LocalDate endDate,
+      boolean valorized) {
     return new DeclaredExperienceEntity(
         id,
         createdAt,
@@ -132,6 +138,7 @@ public class DeclaredExperienceEntity extends PeriodEntity<LocalDate> {
         summary,
         externalLink,
         startDate,
-        endDate);
+        endDate,
+        valorized);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/seeder/fake/FakeDeclaredExperience.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/seeder/fake/FakeDeclaredExperience.java
@@ -39,7 +39,8 @@ public class FakeDeclaredExperience {
             "fake summary",
             faker.internet().url(),
             LocalDate.now().minusWeeks(5),
-            null));
+            null,
+            false));
   }
 
   public DeclaredExperienceEntity toEntity() {

--- a/src/main/resources/db/changelog/generated/changelog_2026-07-23__add-valorized-to-declared-experience.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-07-23__add-valorized-to-declared-experience.xml
@@ -1,0 +1,24 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="iamgreendev" id="add-valorized-to-declared-experience">
+        <addColumn tableName="declared_experience">
+            <column name="valorized" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="declared_experience" columnName="valorized"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -86,7 +86,9 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
         .jsonPath("$.id")
         .exists()
         .jsonPath("$.title")
-        .isEqualTo("My Experience");
+        .isEqualTo("My Experience")
+        .jsonPath("$.valorized")
+        .isEqualTo(false);
   }
 
   @Transactional
@@ -272,6 +274,65 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
         .isEqualTo("Lyon")
         .jsonPath("$.externalLink")
         .isEqualTo("https://updated.com");
+  }
+
+  @Transactional
+  @Test
+  void shouldUpdateDeclaredExperienceValorizedFlag() throws Exception {
+    BddLogger.given("an existing declared experience");
+    String responseBody =
+        webTestClient
+            .post()
+            .uri(BASE_PATH + "/")
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(buildCreateExperienceJson())
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    String createdId = extractIdFromResponse(responseBody);
+
+    String updateJson =
+        "{\n"
+            + "  \"title\": \"My Experience\",\n"
+            + "  \"experienceType\": \"PROFESSIONAL\",\n"
+            + "  \"organization\": \"ACME Inc\",\n"
+            + "  \"activitySector\": \"IT\",\n"
+            + "  \"location\": \"Paris\",\n"
+            + "  \"description\": \"Some description\",\n"
+            + "  \"sourceOfInformation\": \"SELF_DECLARED\",\n"
+            + "  \"summary\": \"Summary text\",\n"
+            + "  \"externalLink\": \"https://example.com\",\n"
+            + "  \"startDate\": \"2024-01-01\",\n"
+            + "  \"endDate\": \"2024-03-01\",\n"
+            + "  \"valorized\": true\n"
+            + "}\n";
+
+    BddLogger.when("performing PUT with valorized set to true");
+    BddLogger.then("it should return the experience marked as valorized");
+
+    webTestClient
+        .put()
+        .uri(BASE_PATH + "/" + createdId)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(updateJson)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.id")
+        .isEqualTo(createdId)
+        .jsonPath("$.valorized")
+        .isEqualTo(true);
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/mapper/DeclaredExperienceMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/mapper/DeclaredExperienceMapperTest.java
@@ -8,7 +8,9 @@ import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
@@ -55,5 +57,36 @@ class DeclaredExperienceMapperTest {
     assertEquals(experience.getTitle(), dto.title());
     assertEquals(EExperienceType.PROFESSIONAL, dto.experienceType());
     assertEquals("Tech Corp", dto.organization());
+    assertFalse(dto.valorized());
+  }
+
+  @Test
+  void shouldMapValorizedExperienceToViewDTO() {
+    BddLogger.given("a valorized declared experience");
+    Student student = StudentFixture.create().toModel();
+    DeclaredExperience experience =
+        DeclaredExperience.toDomain(
+            UUID.randomUUID(),
+            Instant.now(),
+            Instant.now(),
+            student,
+            "Software Experience",
+            EExperienceType.PROFESSIONAL,
+            "Tech Corp",
+            "Software",
+            "Paris",
+            "Backend development",
+            "LinkedIn",
+            "Built REST APIs",
+            "https://techcorp.com",
+            LocalDate.now().minusMonths(6),
+            LocalDate.now(),
+            true);
+
+    BddLogger.when("mapping to DeclaredExperienceViewDTO");
+    DeclaredExperienceViewDTO dto = mapper.toDTO(experience);
+
+    BddLogger.then("it should reflect the valorized flag");
+    assertTrue(dto.valorized());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
@@ -454,7 +454,8 @@ class DeclaredExperienceServiceImplTest {
             "Summary",
             "https://test.fr",
             start,
-            end);
+            end,
+            false);
 
     assertNotNull(result);
     verify(loggedInUserService).getLoggedInStudent();
@@ -482,7 +483,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -510,7 +512,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -537,7 +540,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -565,7 +569,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                wrongEnd));
+                wrongEnd,
+                false));
   }
 
   @Test
@@ -592,7 +597,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -620,7 +626,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -648,7 +655,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -676,7 +684,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -704,7 +713,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -732,7 +742,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -760,7 +771,8 @@ class DeclaredExperienceServiceImplTest {
                 tooLong,
                 "https://test.fr",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -787,7 +799,8 @@ class DeclaredExperienceServiceImplTest {
                 "Summary",
                 "not-an-url",
                 start,
-                end));
+                end,
+                false));
   }
 
   @Test
@@ -817,7 +830,8 @@ class DeclaredExperienceServiceImplTest {
             "New Summary",
             "https://new.link",
             start,
-            end);
+            end,
+            true);
 
     // THEN
     assertNotNull(result);
@@ -834,8 +848,69 @@ class DeclaredExperienceServiceImplTest {
     verify(experience).setExternalLink("https://new.link");
     verify(experience).setStartDate(start);
     verify(experience).setEndDate(end);
+    verify(experience).setValorized(true);
 
     verify(experienceRepository).save(experience);
+  }
+
+  @Test
+  void thenItShouldUpdateValorizedFieldToTrue() {
+    Student loggedIn = student;
+    DeclaredExperience experience = mock(DeclaredExperience.class);
+    DeclaredExperience saved = mock(DeclaredExperience.class);
+    UUID expId = UUID.randomUUID();
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(experienceRepository.findById(expId)).thenReturn(Optional.of(experience));
+    when(experience.getStudent()).thenReturn(loggedIn);
+    when(experienceRepository.save(any())).thenReturn(saved);
+
+    service.update(
+        expId,
+        "Titre",
+        EExperienceType.PROFESSIONAL,
+        "Org",
+        "Sector",
+        "Paris",
+        "Desc",
+        "Source",
+        "Summary",
+        "https://test.fr",
+        start,
+        end,
+        true);
+
+    verify(experience).setValorized(true);
+  }
+
+  @Test
+  void thenItShouldUpdateValorizedFieldToFalse() {
+    Student loggedIn = student;
+    DeclaredExperience experience = mock(DeclaredExperience.class);
+    DeclaredExperience saved = mock(DeclaredExperience.class);
+    UUID expId = UUID.randomUUID();
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(experienceRepository.findById(expId)).thenReturn(Optional.of(experience));
+    when(experience.getStudent()).thenReturn(loggedIn);
+    when(experienceRepository.save(any())).thenReturn(saved);
+
+    service.update(
+        expId,
+        "Titre",
+        EExperienceType.PROFESSIONAL,
+        "Org",
+        "Sector",
+        "Paris",
+        "Desc",
+        "Source",
+        "Summary",
+        "https://test.fr",
+        start,
+        end,
+        false);
+
+    verify(experience).setValorized(false);
   }
 
   @Test


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a `valorized` boolean field to `DeclaredExperience`, mirroring the existing `Trace.valorized` pattern. The field is added to the domain model, JPA entity (with a Liquibase migration), infrastructure mapper, and view DTO. It defaults to `false` on creation and can only be set through the update endpoint (`PUT /me/declared/experiences/{experienceId}`) — create requests silently ignore it, consistent with how traces are valorized after review rather than at creation time.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2268
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2269

---

### Documentation
> No external documentation updates. A new Liquibase changelog (`changelog_2026-07-23__add-valorized-to-declared-experience.xml`) adds the `valorized` column (`BOOLEAN NOT NULL DEFAULT false`) to the `declared_experience` table, with a rollback dropping the column.

---

### Target Branch
> `develop`

---

### Additional Notes
> `DeclaredExperienceRequest` is shared between create and update (unlike Trace, which has separate create/update DTOs). The `valorized` field was added to this shared DTO but is only honored on update — create ignores it, so a client sending `valorized: true` on creation has no effect.

---

### Known Limitations or Side Effects
> None known. No filtering/search support for `valorized` was added on `DeclaredExperience` (unlike Trace's `isValorized` filter), since it wasn't part of this scope.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process