### PR TITLE
feat(self-knowledge): add valorized field to self knowledge element

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeController.java
@@ -108,7 +108,8 @@ public class SelfKnowledgeController {
             selfKnowledgeElementId,
             selfKnowledgeElementRequest.title(),
             selfKnowledgeElementRequest.description(),
-            selfKnowledgeElementRequest.rating());
+            selfKnowledgeElementRequest.rating(),
+            selfKnowledgeElementRequest.valorized());
 
     return ResponseEntity.ok(selfKnowledgeElementViewMapper.toDTO(selfKnowledgeElement));
   }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/dto/SelfKnowledgeElementDetailsDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/dto/SelfKnowledgeElementDetailsDTO.java
@@ -10,5 +10,6 @@ public record SelfKnowledgeElementDetailsDTO(
     String title,
     String description,
     Integer rating,
+    boolean valorized,
     Instant createdAt,
     Instant updatedAt) {}

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/dto/SelfKnowledgeElementRequest.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/dto/SelfKnowledgeElementRequest.java
@@ -5,8 +5,9 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
-@Schema(requiredProperties = {"title", "description"})
+@Schema(requiredProperties = {"title", "description", "valorized"})
 public record SelfKnowledgeElementRequest(
     @Size(max = 80) String title,
     @Size(max = 400) String description,
-    @Min(1) @Max(5) Integer rating) {}
+    @Min(1) @Max(5) Integer rating,
+    Boolean valorized) {}

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/dto/SelfKnowledgeElementViewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/dto/SelfKnowledgeElementViewDTO.java
@@ -5,4 +5,4 @@ import java.util.UUID;
 
 @Schema(requiredProperties = {"id", "title", "description"})
 public record SelfKnowledgeElementViewDTO(
-    UUID id, String title, String description, Integer rating) {}
+    UUID id, String title, String description, Integer rating, boolean valorized) {}

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/model/SelfKnowledgeElement.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/model/SelfKnowledgeElement.java
@@ -15,6 +15,7 @@ public class SelfKnowledgeElement extends AvenirsBaseModel {
   private String description;
   private Integer rating;
   private final SelfKnowledgeCategory selfKnowledgeCategory;
+  private boolean valorized;
 
   private SelfKnowledgeElement(
       UUID id,
@@ -23,6 +24,7 @@ public class SelfKnowledgeElement extends AvenirsBaseModel {
       String description,
       Integer rating,
       SelfKnowledgeCategory selfKnowledgeCategory,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     super(id, createdAt, updatedAt);
@@ -31,6 +33,7 @@ public class SelfKnowledgeElement extends AvenirsBaseModel {
     this.description = description;
     this.rating = rating;
     this.selfKnowledgeCategory = selfKnowledgeCategory;
+    this.valorized = valorized;
   }
 
   public static SelfKnowledgeElement create(
@@ -47,6 +50,7 @@ public class SelfKnowledgeElement extends AvenirsBaseModel {
         description,
         rating,
         selfKnowledgeCategory,
+        false,
         Instant.now(),
         Instant.now());
   }
@@ -58,9 +62,18 @@ public class SelfKnowledgeElement extends AvenirsBaseModel {
       String description,
       Integer rating,
       SelfKnowledgeCategory selfKnowledgeCategory,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     return new SelfKnowledgeElement(
-        id, student, title, description, rating, selfKnowledgeCategory, createdAt, updatedAt);
+        id,
+        student,
+        title,
+        description,
+        rating,
+        selfKnowledgeCategory,
+        valorized,
+        createdAt,
+        updatedAt);
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/input/SelfKnowledgeService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/input/SelfKnowledgeService.java
@@ -20,7 +20,11 @@ public interface SelfKnowledgeService {
       UUID selfKnowledgeCategoryId, String title, String description, Integer rating);
 
   SelfKnowledgeElement updateSelfKnowledgeElement(
-      UUID selfKnowledgeElementId, String title, String description, Integer rating);
+      UUID selfKnowledgeElementId,
+      String title,
+      String description,
+      Integer rating,
+      boolean valorized);
 
   void deleteSelfKnowledgeElements(List<UUID> selfKnowledgeElementIds);
 

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImpl.java
@@ -86,7 +86,11 @@ public class SelfKnowledgeServiceImpl implements SelfKnowledgeService {
 
   @Override
   public SelfKnowledgeElement updateSelfKnowledgeElement(
-      UUID selfKnowledgeElementId, String title, String description, Integer rating) {
+      UUID selfKnowledgeElementId,
+      String title,
+      String description,
+      Integer rating,
+      boolean valorized) {
     Student student = loggedInUserService.getLoggedInStudent();
 
     checkTitleField(title);
@@ -108,6 +112,8 @@ public class SelfKnowledgeServiceImpl implements SelfKnowledgeService {
     if (rating != null) {
       selfKnowledgeElement.setRating(rating);
     }
+
+    selfKnowledgeElement.setValorized(valorized);
 
     return selfKnowledgeElementRepository.save(selfKnowledgeElement);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/mapper/SelfKnowledgeElementMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/mapper/SelfKnowledgeElementMapper.java
@@ -18,6 +18,7 @@ public class SelfKnowledgeElementMapper
         element.getDescription(),
         element.getRating(),
         SelfKnowledgeCategoryMapper.INSTANCE.fromDomain(element.getSelfKnowledgeCategory()),
+        element.isValorized(),
         element.getCreatedAt(),
         element.getUpdatedAt());
   }
@@ -31,6 +32,7 @@ public class SelfKnowledgeElementMapper
         entity.getDescription(),
         entity.getRating(),
         SelfKnowledgeCategoryMapper.INSTANCE.toDomain(entity.getSelfKnowledgeCategory()),
+        entity.isValorized(),
         entity.getCreatedAt(),
         entity.getUpdatedAt());
   }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/model/SelfKnowledgeElementEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/model/SelfKnowledgeElementEntity.java
@@ -46,6 +46,9 @@ public class SelfKnowledgeElementEntity extends AvenirsBaseEntity {
   @JoinColumn(name = "self_knowledge_category_id", nullable = false)
   private SelfKnowledgeCategoryEntity selfKnowledgeCategory;
 
+  @Column(nullable = false)
+  private boolean valorized;
+
   private SelfKnowledgeElementEntity(
       UUID id,
       StudentEntity student,
@@ -53,6 +56,7 @@ public class SelfKnowledgeElementEntity extends AvenirsBaseEntity {
       String description,
       Integer rating,
       SelfKnowledgeCategoryEntity selfKnowledgeCategory,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     this.setId(id);
@@ -61,6 +65,7 @@ public class SelfKnowledgeElementEntity extends AvenirsBaseEntity {
     this.description = description;
     this.rating = rating;
     this.selfKnowledgeCategory = selfKnowledgeCategory;
+    this.valorized = valorized;
     this.setCreatedAt(createdAt);
     this.setUpdatedAt(updatedAt);
   }
@@ -72,9 +77,18 @@ public class SelfKnowledgeElementEntity extends AvenirsBaseEntity {
       String description,
       Integer rating,
       SelfKnowledgeCategoryEntity selfKnowledgeCategory,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     return new SelfKnowledgeElementEntity(
-        id, student, title, description, rating, selfKnowledgeCategory, createdAt, updatedAt);
+        id,
+        student,
+        title,
+        description,
+        rating,
+        selfKnowledgeCategory,
+        valorized,
+        createdAt,
+        updatedAt);
   }
 }

--- a/src/main/resources/db/changelog/generated/changelog_2026-07-23__add-valorized-to-self-knowledge-element.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-07-23__add-valorized-to-self-knowledge-element.xml
@@ -1,0 +1,24 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="iamgreendev" id="add-valorized-to-self-knowledge-element">
+        <addColumn tableName="self_knowledge_element">
+            <column name="valorized" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="self_knowledge_element" columnName="valorized"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeControllerIT.java
@@ -197,7 +197,41 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
         .jsonPath("$.id")
         .exists()
         .jsonPath("$.title")
-        .isEqualTo("New");
+        .isEqualTo("New")
+        .jsonPath("$.valorized")
+        .isEqualTo(false);
+  }
+
+  @Test
+  void shouldUpdateSelfKnowledgeElementValorizedFlag() throws Exception {
+    String categoryId = getLinkedCategoryId();
+    String elementId = createElement(categoryId, "Test", "Desc", 3);
+
+    webTestClient
+        .put()
+        .uri(BASE_PATH + "/element/{elementId}", elementId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "title": "Test",
+              "description": "Desc",
+              "rating": 3,
+              "valorized": true
+            }
+            """)
+        .header("Accept-Language", ELanguage.FRENCH.getCode())
+        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+        .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.id")
+        .isEqualTo(elementId)
+        .jsonPath("$.valorized")
+        .isEqualTo(true);
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/mapper/SelfKnowledgeElementDetailsMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/mapper/SelfKnowledgeElementDetailsMapperTest.java
@@ -28,5 +28,6 @@ class SelfKnowledgeElementDetailsMapperTest {
     assertEquals(element.getTitle(), dto.title());
     assertEquals(element.getDescription(), dto.description());
     assertEquals(element.getRating(), dto.rating());
+    assertEquals(element.isValorized(), dto.valorized());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/mapper/SelfKnowledgeElementViewMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/mapper/SelfKnowledgeElementViewMapperTest.java
@@ -28,5 +28,6 @@ class SelfKnowledgeElementViewMapperTest {
     assertEquals(element.getTitle(), dto.title());
     assertEquals(element.getDescription(), dto.description());
     assertEquals(element.getRating(), dto.rating());
+    assertEquals(element.isValorized(), dto.valorized());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImplTest.java
@@ -395,16 +395,40 @@ class SelfKnowledgeServiceImplTest {
             BddLogger.when("updating self knowledge element");
             SelfKnowledgeElement result =
                 selfKnowledgeService.updateSelfKnowledgeElement(
-                    selfKnowledgeElementId, newTitle, newDescription, newRating);
+                    selfKnowledgeElementId, newTitle, newDescription, newRating, true);
 
             BddLogger.then("it should update self knowledge element");
 
             assertThat(result.getTitle()).isEqualTo(newTitle);
             assertThat(result.getDescription()).isEqualTo(newDescription);
             assertThat(result.getRating()).isEqualTo(newRating);
+            assertThat(result.isValorized()).isTrue();
 
             verify(loggedInUserService).getLoggedInStudent();
             verify(selfKnowledgeElementRepository).findById(selfKnowledgeElementId);
+            verify(selfKnowledgeElementRepository).save(selfKnowledgeElement);
+          }
+        }
+
+        @Nested
+        class WhenUpdatingSelfKnowledgeElementValorizedFlagToFalse {
+
+          @Test
+          void thenItShouldSetValorizedToFalse() {
+            BddLogger.when("updating self knowledge element with valorized set to false");
+
+            when(selfKnowledgeElementRepository.findById(selfKnowledgeElementId))
+                .thenReturn(Optional.of(selfKnowledgeElement));
+            when(selfKnowledgeElementRepository.save(any(SelfKnowledgeElement.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+            SelfKnowledgeElement result =
+                selfKnowledgeService.updateSelfKnowledgeElement(
+                    selfKnowledgeElementId, "Title", "Description", 1, false);
+
+            BddLogger.then("it should set valorized to false");
+            assertThat(result.isValorized()).isFalse();
+
             verify(selfKnowledgeElementRepository).save(selfKnowledgeElement);
           }
         }
@@ -423,7 +447,7 @@ class SelfKnowledgeServiceImplTest {
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
             selfKnowledgeService.updateSelfKnowledgeElement(
-                selfKnowledgeElementId, "New title", "New desc", null);
+                selfKnowledgeElementId, "New title", "New desc", null, false);
 
             BddLogger.then("it should keep previous rating");
             assertThat(selfKnowledgeElement.getRating()).isEqualTo(existingRating);
@@ -450,7 +474,7 @@ class SelfKnowledgeServiceImplTest {
                 UserNotAuthorizedException.class,
                 () ->
                     selfKnowledgeService.updateSelfKnowledgeElement(
-                        selfKnowledgeElementId, "Title", "Description", 1));
+                        selfKnowledgeElementId, "Title", "Description", 1, false));
 
             verify(selfKnowledgeElementRepository).findById(selfKnowledgeElementId);
             verify(selfKnowledgeElementRepository, never()).save(any());
@@ -469,7 +493,7 @@ class SelfKnowledgeServiceImplTest {
                 SelfKnowledgeInvalidTitleException.class,
                 () ->
                     selfKnowledgeService.updateSelfKnowledgeElement(
-                        selfKnowledgeElementId, tooLong, "Description", 1));
+                        selfKnowledgeElementId, tooLong, "Description", 1, false));
 
             verifyNoInteractions(selfKnowledgeElementRepository);
           }
@@ -487,7 +511,7 @@ class SelfKnowledgeServiceImplTest {
                 SelfKnowledgeInvalidDescriptionException.class,
                 () ->
                     selfKnowledgeService.updateSelfKnowledgeElement(
-                        selfKnowledgeElementId, "Title", tooLong, 1));
+                        selfKnowledgeElementId, "Title", tooLong, 1, false));
 
             verifyNoInteractions(selfKnowledgeElementRepository);
           }
@@ -505,7 +529,7 @@ class SelfKnowledgeServiceImplTest {
                 SelfKnowledgeInvalidRatingException.class,
                 () ->
                     selfKnowledgeService.updateSelfKnowledgeElement(
-                        selfKnowledgeElementId, "Title", "Description", invalid));
+                        selfKnowledgeElementId, "Title", "Description", invalid, false));
 
             verifyNoInteractions(selfKnowledgeElementRepository);
           }
@@ -634,7 +658,7 @@ class SelfKnowledgeServiceImplTest {
                 SelfKnowledgeElementNotFoundException.class,
                 () ->
                     selfKnowledgeService.updateSelfKnowledgeElement(
-                        unknownId, "Title", "Description", 1));
+                        unknownId, "Title", "Description", 1, false));
           }
         }
       }
@@ -1071,7 +1095,7 @@ class SelfKnowledgeServiceImplTest {
               UserNotFoundException.class,
               () ->
                   selfKnowledgeService.updateSelfKnowledgeElement(
-                      UUID.randomUUID(), "Title", "Description", 1));
+                      UUID.randomUUID(), "Title", "Description", 1, false));
         }
       }
 
@@ -1233,7 +1257,7 @@ class SelfKnowledgeServiceImplTest {
               UserIsNotStudentException.class,
               () ->
                   selfKnowledgeService.updateSelfKnowledgeElement(
-                      UUID.randomUUID(), "Title", "Description", 1));
+                      UUID.randomUUID(), "Title", "Description", 1, false));
         }
       }
 

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/fixture/SelfKnowledgeElementFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/fixture/SelfKnowledgeElementFixture.java
@@ -16,6 +16,7 @@ public class SelfKnowledgeElementFixture {
   private String description;
   private Integer rating;
   private SelfKnowledgeCategory selfKnowledgeCategory;
+  private boolean valorized;
   private Instant createdAt;
   private Instant updatedAt;
 
@@ -28,6 +29,7 @@ public class SelfKnowledgeElementFixture {
             + " mes projets scolaires et personnels.";
     this.rating = 1;
     this.selfKnowledgeCategory = SelfKnowledgeCategoryFixture.create().toModel();
+    this.valorized = false;
     this.createdAt = Instant.now();
     this.updatedAt = Instant.now();
   }
@@ -75,6 +77,11 @@ public class SelfKnowledgeElementFixture {
     return this;
   }
 
+  public SelfKnowledgeElementFixture withValorized(boolean valorized) {
+    this.valorized = valorized;
+    return this;
+  }
+
   public SelfKnowledgeElementFixture withCreatedAt(Instant createdAt) {
     this.createdAt = createdAt;
     return this;
@@ -87,6 +94,14 @@ public class SelfKnowledgeElementFixture {
 
   public SelfKnowledgeElement toModel() {
     return SelfKnowledgeElement.toDomain(
-        id, student, title, description, rating, selfKnowledgeCategory, createdAt, updatedAt);
+        id,
+        student,
+        title,
+        description,
+        rating,
+        selfKnowledgeCategory,
+        valorized,
+        createdAt,
+        updatedAt);
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a `valorized` boolean field to `SelfKnowledgeElement`, allowing self-knowledge elements to be flagged as valorized, consistent with the same field already introduced on declared experiences and declared programs. Covers domain model, service, controller, DTOs (request/view/details), entity/mapper, and a Liquibase migration adding the `valorized` column (default `false`, not null) to `self_knowledge_element`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2272
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2273

---

### Documentation
> Added Liquibase changelog `changelog_2026-07-23__add-valorized-to-self-knowledge-element.xml` adding the `valorized` column to `self_knowledge_element` (default `false`, not null, with rollback).

---

### Target Branch
> `develop`

---

### Additional Notes
> Follows the same pattern used for the `valorized` field on declared experience and declared program.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
