### PR TITLE
feat(declared-activity): switch updatePeriod endpoint to a generic patch

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityController.java
@@ -15,12 +15,7 @@ import fr.avenirsesr.portfolio.shared.application.adapter.dto.AssociationsCreati
 import fr.avenirsesr.portfolio.shared.application.adapter.dto.AssociationsDeleteRequest;
 import fr.avenirsesr.portfolio.shared.application.adapter.dto.CreationResponse;
 import fr.avenirsesr.portfolio.shared.application.adapter.mapper.FileDTOMapper;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.DeclaredActivityAssociationsDTO;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.DeclaredActivityDetailsDTO;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.DeclaredActivityPeriodRequest;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.DeclaredActivityViewDTO;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.SubscribeDeclaredActivityRequest;
-import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.UpdateReflectionRequest;
+import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto.*;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.DeclaredActivityAssociationsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.DeclaredActivityDetailsDTOMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.mapper.DeclaredActivityViewDTOMapper;
@@ -33,6 +28,7 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +36,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -185,20 +182,15 @@ public class DeclaredActivityController {
     return ResponseEntity.ok("Declared activities associations successfully deleted");
   }
 
-  @PutMapping("/{declaredActivityId}/period")
-  public ResponseEntity<String> updatePeriod(
-      @Valid @RequestBody DeclaredActivityPeriodRequest declaredActivityPeriodRequest,
+  @PatchMapping("/{declaredActivityId}")
+  public ResponseEntity<String> updateDeclaredActivity(
+      @Valid @RequestBody DeclaredActivityUpdateRequest declaredActivityUpdateRequest,
       @PathVariable UUID declaredActivityId) {
-    LocalDate startDate =
-        declaredActivityPeriodRequest.period() != null
-            ? declaredActivityPeriodRequest.period().startDate()
-            : null;
-    LocalDate endDate =
-        declaredActivityPeriodRequest.period() != null
-            ? declaredActivityPeriodRequest.period().endDate()
-            : null;
-    declaredActivityService.updateDeclaredActivityDates(declaredActivityId, startDate, endDate);
-    return ResponseEntity.ok("Declared activities dates successfully updated");
+    var optionalPeriod = Optional.ofNullable(declaredActivityUpdateRequest.period());
+    LocalDate startDate = optionalPeriod.map(DeclaredActivityPeriodDTO::startDate).orElse(null);
+    LocalDate endDate = optionalPeriod.map(DeclaredActivityPeriodDTO::endDate).orElse(null);
+    declaredActivityService.updateDeclaredActivity(declaredActivityId, startDate, endDate);
+    return ResponseEntity.ok("Declared activity successfully updated");
   }
 
   @PostMapping("/{declaredActivityId}/associate/traces")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/DeclaredActivityUpdateRequest.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/DeclaredActivityUpdateRequest.java
@@ -1,3 +1,3 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto;
 
-public record DeclaredActivityPeriodRequest(DeclaredActivityPeriodDTO period) {}
+public record DeclaredActivityUpdateRequest(DeclaredActivityPeriodDTO period) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
@@ -40,7 +40,7 @@ public interface DeclaredActivityService {
 
   void deleteAssociations(UUID declaredActivityId, List<UUID> idsToDelete);
 
-  void updateDeclaredActivityDates(UUID declaredActivityId, LocalDate startDate, LocalDate endDate);
+  void updateDeclaredActivity(UUID declaredActivityId, LocalDate startDate, LocalDate endDate);
 
   PagedResult<DeclaredActivity> searchDeclaredActivity(String keyword, PageCriteria pageCriteria);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -220,7 +220,7 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
   }
 
   @Override
-  public void updateDeclaredActivityDates(
+  public void updateDeclaredActivity(
       UUID declaredActivityId, LocalDate startDate, LocalDate endDate) {
 
     var student = loggedInUserService.getLoggedInStudent();
@@ -238,10 +238,11 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
       throw new UserNotAuthorizedException();
     }
 
-    validateActivityDates(startDate, endDate, declaredActivity.getCreatedAt());
-
-    declaredActivity.setStartDate(startDate);
-    declaredActivity.setEndDate(endDate);
+    if (startDate != null || endDate != null) {
+      validateActivityDates(startDate, endDate, declaredActivity.getCreatedAt());
+      declaredActivity.setStartDate(startDate);
+      declaredActivity.setEndDate(endDate);
+    }
 
     declaredActivityRepository.save(declaredActivity);
   }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -600,13 +600,34 @@ class DeclaredActivityServiceImplTest {
 
     // When
     BddLogger.when("The service is called with valid dates.");
-    declaredActivityService.updateDeclaredActivityDates(declaredActivityId, startDate, endDate);
+    declaredActivityService.updateDeclaredActivity(declaredActivityId, startDate, endDate);
 
     // Then
     BddLogger.then("The DeclaredActivity receives the new dates.");
     verify(declaredActivity).setStartDate(startDate);
     verify(declaredActivity).setEndDate(endDate);
 
+    verify(declaredActivityRepository).save(declaredActivity);
+  }
+
+  @Test
+  void updateDeclaredActivity_should_leave_dates_untouched_when_none_provided() {
+    BddLogger.given("A logged-in student and his existing declared activity");
+    UUID declaredActivityId = UUID.randomUUID();
+    var student = mock(Student.class);
+    var declaredActivity = mock(DeclaredActivity.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findById(declaredActivityId))
+        .thenReturn(Optional.of(declaredActivity));
+    when(declaredActivity.getStudent()).thenReturn(student);
+
+    BddLogger.when("The service is called without any period field");
+    declaredActivityService.updateDeclaredActivity(declaredActivityId, null, null);
+
+    BddLogger.then("The DeclaredActivity dates are left untouched but it is still saved");
+    verify(declaredActivity, never()).setStartDate(any());
+    verify(declaredActivity, never()).setEndDate(any());
     verify(declaredActivityRepository).save(declaredActivity);
   }
 
@@ -629,7 +650,7 @@ class DeclaredActivityServiceImplTest {
         Assertions.assertThrows(
             FieldValidationException.class,
             () ->
-                declaredActivityService.updateDeclaredActivityDates(
+                declaredActivityService.updateDeclaredActivity(
                     declaredActivityId, startDate, endDate));
 
     Assertions.assertEquals(EErrorCode.END_DATE_BEFORE_START_DATE, ex.getErrorCode());
@@ -656,7 +677,7 @@ class DeclaredActivityServiceImplTest {
         Assertions.assertThrows(
             BusinessException.class,
             () ->
-                declaredActivityService.updateDeclaredActivityDates(
+                declaredActivityService.updateDeclaredActivity(
                     declaredActivityId, startDate, endDate));
 
     Assertions.assertEquals(


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Replace the `updatePeriod` (PUT) endpoint on `DeclaredActivityController` with a generic `updateDeclaredActivity` (PATCH) endpoint. `DeclaredActivityPeriodRequest` is renamed to `DeclaredActivityUpdateRequest`, which takes an optional `period` field so other declared activity fields can be added to the same patch endpoint in the future. The service layer (`updateDeclaredActivityDates` renamed to `updateDeclaredActivity`) now only updates `startDate`/`endDate` when a period is actually provided in the request, instead of always overwriting them — giving the endpoint true patch semantics.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2276

---

### Documentation
> No documentation updates required. The endpoint is a rename/behavior change; no OpenAPI/Postman assets referenced the old path.

---

### Target Branch
> `develop`

---

### Additional Notes
> Only the `period` field is currently supported by the request, matching current business needs; the DTO and service method are structured to accept additional optional fields later without further breaking changes. No existing integration tests covered the previous `updatePeriod` endpoint, so none needed migration; unit tests in `DeclaredActivityServiceImplTest` were updated and a new test was added to cover the "no period provided" patch case.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
