### PR TITLE
feat(declared-activity): add valorized field and expose it in update endpoint

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/controller/DeclaredActivityController.java
@@ -189,7 +189,8 @@ public class DeclaredActivityController {
     var optionalPeriod = Optional.ofNullable(declaredActivityUpdateRequest.period());
     LocalDate startDate = optionalPeriod.map(DeclaredActivityPeriodDTO::startDate).orElse(null);
     LocalDate endDate = optionalPeriod.map(DeclaredActivityPeriodDTO::endDate).orElse(null);
-    declaredActivityService.updateDeclaredActivity(declaredActivityId, startDate, endDate);
+    declaredActivityService.updateDeclaredActivity(
+        declaredActivityId, startDate, endDate, declaredActivityUpdateRequest.valorized());
     return ResponseEntity.ok("Declared activity successfully updated");
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/DeclaredActivityDetailsDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/DeclaredActivityDetailsDTO.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-@Schema(requiredProperties = {"id", "activity", "status", "createdAt", "updatedAt"})
+@Schema(requiredProperties = {"id", "activity", "valorized", "status", "createdAt", "updatedAt"})
 public record DeclaredActivityDetailsDTO(
     UUID id,
     ActivityContentDTO activity,
@@ -17,6 +17,7 @@ public record DeclaredActivityDetailsDTO(
     LocalDate startDate,
     LocalDate endDate,
     Instant finishedAt,
+    boolean valorized,
     Instant createdAt,
     Instant updatedAt,
     List<FeedbackOverviewDTO> feedbacks) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/DeclaredActivityUpdateRequest.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/DeclaredActivityUpdateRequest.java
@@ -1,3 +1,3 @@
 package fr.avenirsesr.portfolio.student.progress.declared.activity.application.adapter.dto;
 
-public record DeclaredActivityUpdateRequest(DeclaredActivityPeriodDTO period) {}
+public record DeclaredActivityUpdateRequest(DeclaredActivityPeriodDTO period, Boolean valorized) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/DeclaredActivityViewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/dto/DeclaredActivityViewDTO.java
@@ -28,4 +28,5 @@ public record DeclaredActivityViewDTO(
     @Schema(ref = "#/components/schemas/EDeclaredActivityStatus") EDeclaredActivityStatus status,
     LocalDate startDate,
     LocalDate endDate,
+    boolean valorized,
     Instant updatedAt) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityAssociationMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityAssociationMapper.java
@@ -29,6 +29,7 @@ public interface DeclaredActivityAssociationMapper {
         status,
         declaredActivity.getStartDate(),
         declaredActivity.getEndDate(),
+        declaredActivity.isValorized(),
         declaredActivity.getUpdatedAt());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityDetailsDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityDetailsDTOMapper.java
@@ -29,6 +29,7 @@ public interface DeclaredActivityDetailsDTOMapper {
   @Mapping(source = "data.declaredActivity.startDate", target = "startDate")
   @Mapping(source = "data.declaredActivity.endDate", target = "endDate")
   @Mapping(source = "data.declaredActivity.finishedAt", target = "finishedAt")
+  @Mapping(source = "data.declaredActivity.valorized", target = "valorized")
   @Mapping(source = "data.declaredActivity.createdAt", target = "createdAt")
   @Mapping(source = "data.declaredActivity.updatedAt", target = "updatedAt")
   DeclaredActivityDetailsDTO toDTO(
@@ -44,12 +45,14 @@ public interface DeclaredActivityDetailsDTOMapper {
   @Mapping(source = "data.declaredActivity.startDate", target = "startDate")
   @Mapping(source = "data.declaredActivity.endDate", target = "endDate")
   @Mapping(source = "data.declaredActivity.finishedAt", target = "finishedAt")
+  @Mapping(source = "data.declaredActivity.valorized", target = "valorized")
   @Mapping(source = "data.declaredActivity.createdAt", target = "createdAt")
   @Mapping(source = "data.declaredActivity.updatedAt", target = "updatedAt")
   DeclaredActivityDetailsDTO toDTO(
       DeclaredActivityDetailsData data, EDeclaredActivityStatus status, List<FileDTO> files);
 
   @Mapping(source = "activity", target = "activity")
+  @Mapping(source = "valorized", target = "valorized")
   @Mapping(target = "status", ignore = true)
   @Mapping(target = "feedbacks", ignore = true)
   DeclaredActivityDetailsDTO toDTO(DeclaredActivity declaredActivity);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityViewDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityViewDTOMapper.java
@@ -19,6 +19,7 @@ public interface DeclaredActivityViewDTOMapper {
       source = "declaredActivity.activity.executionPeriodInfoSummary",
       target = "executionPeriodInfoSummary")
   @Mapping(source = "status", target = "status")
+  @Mapping(source = "declaredActivity.valorized", target = "valorized")
   DeclaredActivityViewDTO toDTO(DeclaredActivity declaredActivity, EDeclaredActivityStatus status);
 
   default String unwrap(Optional<String> value) {

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/model/DeclaredActivity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/model/DeclaredActivity.java
@@ -27,6 +27,8 @@ public class DeclaredActivity extends AvenirsBaseModel {
   @Getter(AccessLevel.NONE)
   private Instant finishedAt;
 
+  private boolean valorized;
+
   private DeclaredActivity(
       UUID id,
       Student student,
@@ -36,6 +38,7 @@ public class DeclaredActivity extends AvenirsBaseModel {
       LocalDate startDate,
       LocalDate endDate,
       Instant finishedAt,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     super(id, createdAt, updatedAt);
@@ -46,6 +49,7 @@ public class DeclaredActivity extends AvenirsBaseModel {
     this.startDate = startDate;
     this.endDate = endDate;
     this.finishedAt = finishedAt;
+    this.valorized = valorized;
   }
 
   public static DeclaredActivity create(
@@ -66,6 +70,7 @@ public class DeclaredActivity extends AvenirsBaseModel {
         startDate,
         endDate,
         finishedAt,
+        false,
         Instant.now(),
         Instant.now());
   }
@@ -79,6 +84,7 @@ public class DeclaredActivity extends AvenirsBaseModel {
       LocalDate startDate,
       LocalDate endDate,
       Instant finishedAt,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     return new DeclaredActivity(
@@ -90,6 +96,7 @@ public class DeclaredActivity extends AvenirsBaseModel {
         startDate,
         endDate,
         finishedAt,
+        valorized,
         createdAt,
         updatedAt);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/port/input/DeclaredActivityService.java
@@ -40,7 +40,8 @@ public interface DeclaredActivityService {
 
   void deleteAssociations(UUID declaredActivityId, List<UUID> idsToDelete);
 
-  void updateDeclaredActivity(UUID declaredActivityId, LocalDate startDate, LocalDate endDate);
+  void updateDeclaredActivity(
+      UUID declaredActivityId, LocalDate startDate, LocalDate endDate, Boolean valorized);
 
   PagedResult<DeclaredActivity> searchDeclaredActivity(String keyword, PageCriteria pageCriteria);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -221,7 +221,7 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
 
   @Override
   public void updateDeclaredActivity(
-      UUID declaredActivityId, LocalDate startDate, LocalDate endDate) {
+      UUID declaredActivityId, LocalDate startDate, LocalDate endDate, Boolean valorized) {
 
     var student = loggedInUserService.getLoggedInStudent();
     log.debug("Authenticated student id: {}", student.getId());
@@ -242,6 +242,10 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
       validateActivityDates(startDate, endDate, declaredActivity.getCreatedAt());
       declaredActivity.setStartDate(startDate);
       declaredActivity.setEndDate(endDate);
+    }
+
+    if (valorized != null) {
+      declaredActivity.setValorized(valorized);
     }
 
     declaredActivityRepository.save(declaredActivity);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/mapper/DeclaredActivityMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/mapper/DeclaredActivityMapper.java
@@ -21,6 +21,7 @@ public class DeclaredActivityMapper implements Mapper<DeclaredActivityEntity, De
         declaredActivity.getStartDate(),
         declaredActivity.getEndDate(),
         declaredActivity.getFinishedAt().orElse(null),
+        declaredActivity.isValorized(),
         declaredActivity.getCreatedAt(),
         declaredActivity.getUpdatedAt());
   }
@@ -36,6 +37,7 @@ public class DeclaredActivityMapper implements Mapper<DeclaredActivityEntity, De
         entity.getStartDate(),
         entity.getEndDate(),
         entity.getFinishedAt(),
+        entity.isValorized(),
         entity.getCreatedAt(),
         entity.getUpdatedAt());
   }
@@ -56,6 +58,7 @@ public class DeclaredActivityMapper implements Mapper<DeclaredActivityEntity, De
         entity.getStartDate(),
         entity.getEndDate(),
         entity.getFinishedAt(),
+        entity.isValorized(),
         entity.getCreatedAt(),
         entity.getUpdatedAt());
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/model/DeclaredActivityEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/model/DeclaredActivityEntity.java
@@ -49,6 +49,9 @@ public class DeclaredActivityEntity extends PeriodEntity<LocalDate> {
   @Formula("CASE WHEN finished_at IS NULL THEN 0 ELSE 1 END")
   private Integer isFinishedOrder;
 
+  @Column(nullable = false)
+  private boolean valorized;
+
   private DeclaredActivityEntity(
       UUID id,
       StudentEntity student,
@@ -58,6 +61,7 @@ public class DeclaredActivityEntity extends PeriodEntity<LocalDate> {
       LocalDate startDate,
       LocalDate endDate,
       Instant finishedAt,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     setId(id);
@@ -70,6 +74,7 @@ public class DeclaredActivityEntity extends PeriodEntity<LocalDate> {
     this.startDate = startDate;
     this.endDate = endDate;
     this.finishedAt = finishedAt;
+    this.valorized = valorized;
   }
 
   public static DeclaredActivityEntity of(
@@ -81,6 +86,7 @@ public class DeclaredActivityEntity extends PeriodEntity<LocalDate> {
       LocalDate startDate,
       LocalDate endDate,
       Instant finishedAt,
+      boolean valorized,
       Instant createdAt,
       Instant updatedAt) {
     return new DeclaredActivityEntity(
@@ -92,6 +98,7 @@ public class DeclaredActivityEntity extends PeriodEntity<LocalDate> {
         startDate,
         endDate,
         finishedAt,
+        valorized,
         createdAt,
         updatedAt);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/seeder/data/FakeDeclaredActivity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/activity/infrastructure/adapter/seeder/data/FakeDeclaredActivity.java
@@ -30,6 +30,7 @@ public class FakeDeclaredActivity {
             hasDate ? LocalDate.now().plusMonths(1) : null,
             hasDate ? LocalDate.now().plusMonths(2) : null,
             hasFinished ? Instant.now() : null,
+            false,
             Instant.now(),
             Instant.now()));
   }

--- a/src/main/resources/db/changelog/generated/changelog_2026-07-24__add-valorized-to-declared-activity.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-07-24__add-valorized-to-declared-activity.xml
@@ -1,0 +1,24 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="iamgreendev" id="add-valorized-to-declared-activity">
+        <addColumn tableName="declared_activity">
+            <column name="valorized" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="declared_activity" columnName="valorized"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
@@ -73,6 +73,7 @@ class DeclaredActivityPresentationDTOMapperTest {
     assertEquals(activity.getId(), dto.activity().id());
     assertEquals(activity.getTitle(), dto.activity().title());
     assertEquals(EDeclaredActivityStatus.SUBSCRIBED, dto.status());
+    assertFalse(dto.valorized());
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityViewDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/application/adapter/mapper/DeclaredActivityViewDTOMapperTest.java
@@ -51,5 +51,6 @@ class DeclaredActivityViewDTOMapperTest {
     assertEquals(activity.getSummary(), dto.summary());
     assertEquals(activity.getDescription(), dto.description());
     assertEquals(EDeclaredActivityStatus.SUBSCRIBED, dto.status());
+    assertFalse(dto.valorized());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.activity.domain.servic
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -600,7 +601,7 @@ class DeclaredActivityServiceImplTest {
 
     // When
     BddLogger.when("The service is called with valid dates.");
-    declaredActivityService.updateDeclaredActivity(declaredActivityId, startDate, endDate);
+    declaredActivityService.updateDeclaredActivity(declaredActivityId, startDate, endDate, null);
 
     // Then
     BddLogger.then("The DeclaredActivity receives the new dates.");
@@ -623,11 +624,51 @@ class DeclaredActivityServiceImplTest {
     when(declaredActivity.getStudent()).thenReturn(student);
 
     BddLogger.when("The service is called without any period field");
-    declaredActivityService.updateDeclaredActivity(declaredActivityId, null, null);
+    declaredActivityService.updateDeclaredActivity(declaredActivityId, null, null, null);
 
     BddLogger.then("The DeclaredActivity dates are left untouched but it is still saved");
     verify(declaredActivity, never()).setStartDate(any());
     verify(declaredActivity, never()).setEndDate(any());
+    verify(declaredActivityRepository).save(declaredActivity);
+  }
+
+  @Test
+  void updateDeclaredActivity_should_update_valorized_when_provided() {
+    BddLogger.given("A logged-in student and his existing declared activity");
+    UUID declaredActivityId = UUID.randomUUID();
+    var student = mock(Student.class);
+    var declaredActivity = mock(DeclaredActivity.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findById(declaredActivityId))
+        .thenReturn(Optional.of(declaredActivity));
+    when(declaredActivity.getStudent()).thenReturn(student);
+
+    BddLogger.when("The service is called with valorized set to true");
+    declaredActivityService.updateDeclaredActivity(declaredActivityId, null, null, true);
+
+    BddLogger.then("The DeclaredActivity valorized flag is updated and it is saved");
+    verify(declaredActivity).setValorized(true);
+    verify(declaredActivityRepository).save(declaredActivity);
+  }
+
+  @Test
+  void updateDeclaredActivity_should_leave_valorized_untouched_when_not_provided() {
+    BddLogger.given("A logged-in student and his existing declared activity");
+    UUID declaredActivityId = UUID.randomUUID();
+    var student = mock(Student.class);
+    var declaredActivity = mock(DeclaredActivity.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
+    when(declaredActivityRepository.findById(declaredActivityId))
+        .thenReturn(Optional.of(declaredActivity));
+    when(declaredActivity.getStudent()).thenReturn(student);
+
+    BddLogger.when("The service is called without the valorized field");
+    declaredActivityService.updateDeclaredActivity(declaredActivityId, null, null, null);
+
+    BddLogger.then("The DeclaredActivity valorized flag is left untouched but it is still saved");
+    verify(declaredActivity, never()).setValorized(anyBoolean());
     verify(declaredActivityRepository).save(declaredActivity);
   }
 
@@ -651,7 +692,7 @@ class DeclaredActivityServiceImplTest {
             FieldValidationException.class,
             () ->
                 declaredActivityService.updateDeclaredActivity(
-                    declaredActivityId, startDate, endDate));
+                    declaredActivityId, startDate, endDate, null));
 
     Assertions.assertEquals(EErrorCode.END_DATE_BEFORE_START_DATE, ex.getErrorCode());
   }
@@ -678,7 +719,7 @@ class DeclaredActivityServiceImplTest {
             BusinessException.class,
             () ->
                 declaredActivityService.updateDeclaredActivity(
-                    declaredActivityId, startDate, endDate));
+                    declaredActivityId, startDate, endDate, null));
 
     Assertions.assertEquals(
         EErrorCode.DECLARED_ACTIVITY_START_DATE_BEFORE_SUBSCRIPTION, ex.getErrorCode());


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a `valorized` boolean field to `DeclaredActivity` (entity, domain model, DTOs) and exposes it in the `PATCH /me/activity-progress/{declaredActivityId}` update endpoint, following the same pattern already used for `DeclaredSkillProgress` and `SelfKnowledgeElement`. The field defaults to `false` and follows patch semantics: it is only updated when explicitly provided in the request body (boxed `Boolean`, `null` = unchanged).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2275

---

### Documentation
> Added a Liquibase changelog (`changelog_2026-07-24__add-valorized-to-declared-activity.xml`) adding the `valorized` column to `declared_activity` (`BOOLEAN NOT NULL DEFAULT false`), with rollback.

---

### Target Branch
> `develop`

---

### Additional Notes
> No explicit `@Column(name = ...)` override was added, matching the corrected convention used for `DeclaredSkillProgress` (previously `isValorized` had to be renamed to `valorized` in a follow-up fix).

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process