### PR TITLE
feat(declared-skill-progress): add isValorized query param filter

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/controller/DeclaredSkillProgressController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/controller/DeclaredSkillProgressController.java
@@ -45,14 +45,17 @@ public class DeclaredSkillProgressController {
   public ResponseEntity<PagedResponse<DeclaredSkillProgressDTO>> getDeclaredSkillsProgresses(
       Principal principal,
       @RequestParam(required = false) Integer page,
-      @RequestParam(required = false) Integer pageSize) {
+      @RequestParam(required = false) Integer pageSize,
+      @RequestParam(required = false) Boolean isValorized) {
     var pageCriteria = new PageCriteria(page, pageSize);
     log.debug(
-        "Received request to trace overview of user [{}] (page= {}, fileSize= {})",
+        "Received request to trace overview of user [{}] (page= {}, fileSize= {}, isValorized={})",
         principal.getName(),
         pageCriteria.page(),
-        pageCriteria.pageSize());
-    var result = declaredSkillProgressService.getDeclaredSkillsProgresses(pageCriteria);
+        pageCriteria.pageSize(),
+        isValorized);
+    var result =
+        declaredSkillProgressService.getDeclaredSkillsProgresses(pageCriteria, isValorized);
     return ResponseEntity.ok(
         new PagedResponse<>(
             result.content().stream()

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/port/input/DeclaredSkillProgressService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/port/input/DeclaredSkillProgressService.java
@@ -14,7 +14,8 @@ import java.util.UUID;
 
 public interface DeclaredSkillProgressService {
 
-  PagedResult<DeclaredSkillProgress> getDeclaredSkillsProgresses(PageCriteria criteria);
+  PagedResult<DeclaredSkillProgress> getDeclaredSkillsProgresses(
+      PageCriteria criteria, Boolean isValorized);
 
   DeclaredSkillProgress createDeclaredSkillProgress(
       UUID declaredSkillId, EExternalSkillType type, EDeclaredSkillLevel level, String reflection);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/port/output/repository/DeclaredSkillProgressRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/port/output/repository/DeclaredSkillProgressRepository.java
@@ -13,7 +13,7 @@ public interface DeclaredSkillProgressRepository
   boolean declaredSkillProgressAlreadyExists(DeclaredSkillProgress declaredSkillProgress);
 
   PagedResult<DeclaredSkillProgress> findAllByStudent(
-      Student student, PageCriteria pageCriteria, SortCriteria sortCriteria);
+      Student student, PageCriteria pageCriteria, Boolean isValorized, SortCriteria sortCriteria);
 
   PagedResult<DeclaredSkillProgress> findAllByStudent(
       Student student, PageCriteria pageCriteria, String keyword, SortCriteria sortCriteria);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImpl.java
@@ -59,10 +59,11 @@ public class DeclaredSkillProgressServiceImpl implements DeclaredSkillProgressSe
   private final AssociationSearchHelper associationSearchHelper;
 
   @Override
-  public PagedResult<DeclaredSkillProgress> getDeclaredSkillsProgresses(PageCriteria pageCriteria) {
+  public PagedResult<DeclaredSkillProgress> getDeclaredSkillsProgresses(
+      PageCriteria pageCriteria, Boolean isValorized) {
     Student student = loggedInUserService.getLoggedInStudent();
     return declaredSkillProgressRepository.findAllByStudent(
-        student, pageCriteria, new SortCriteria(ESortField.NAME, ESortOrder.ASC));
+        student, pageCriteria, isValorized, new SortCriteria(ESortField.NAME, ESortOrder.ASC));
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/infrastructure/adapter/repository/DeclaredSkillProgressDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/infrastructure/adapter/repository/DeclaredSkillProgressDatabaseRepository.java
@@ -48,8 +48,9 @@ public class DeclaredSkillProgressDatabaseRepository
 
   @Override
   public PagedResult<DeclaredSkillProgress> findAllByStudent(
-      Student student, PageCriteria pageCriteria, SortCriteria sortCriteria) {
-    var specification = hasStudent(student);
+      Student student, PageCriteria pageCriteria, Boolean isValorized, SortCriteria sortCriteria) {
+    var specification =
+        hasStudent(student).and(DeclaredSkillProgressSpecification.isValorized(isValorized));
     return findAll(
         specification,
         PageRequest.of(

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/infrastructure/adapter/specification/DeclaredSkillProgressSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/infrastructure/adapter/specification/DeclaredSkillProgressSpecification.java
@@ -30,6 +30,15 @@ public class DeclaredSkillProgressSpecification {
     };
   }
 
+  public static Specification<DeclaredSkillProgressEntity> isValorized(Boolean isValorized) {
+    return (root, query, criteriaBuilder) -> {
+      if (isValorized == null) {
+        return criteriaBuilder.conjunction();
+      }
+      return criteriaBuilder.equal(root.get("valorized"), isValorized);
+    };
+  }
+
   public static Sort toSort(SortCriteria sortCriteria) {
     if (sortCriteria == null) {
       return Sort.unsorted();

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/controller/DeclaredSkillProgressControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/controller/DeclaredSkillProgressControllerIT.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.progress.declared.skill.application.adapter.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -8,6 +9,7 @@ import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.declaredskill.domain.port.output.repository.DeclaredSkillRepository;
 import fr.avenirsesr.portfolio.shared.infrastructure.ContainerConfigurationTest;
 import fr.avenirsesr.portfolio.shared.infrastructure.adapter.seeder.SeederRunner;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -65,6 +67,95 @@ public class DeclaredSkillProgressControllerIT extends ContainerConfigurationTes
         .expectBody()
         .jsonPath("$.data")
         .exists();
+  }
+
+  @Test
+  void shouldFilterDeclaredSkillProgressesByIsValorized() throws Exception {
+    BddLogger.given("a declared skill progress marked as valorized");
+
+    var declaredSkill =
+        declaredSkillRepository.findAll().stream().skip(2).findFirst().orElseThrow();
+
+    var createResponse =
+        webTestClient
+            .post()
+            .uri(BASE_PATH)
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(buildDeclaredSkillsJson(declaredSkill.getId()))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    UUID createdSkillId =
+        objectMapper.readTree(createResponse).get("id").textValue().transform(UUID::fromString);
+
+    webTestClient
+        .put()
+        .uri(BASE_PATH + "/" + createdSkillId)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            objectMapper.writeValueAsString(
+                Map.of("level", "BEGINNER", "reflection", "reflection", "valorized", true)))
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    BddLogger.when("performing a GET with isValorized=true");
+
+    var valorizedOnlyResponse =
+        webTestClient
+            .get()
+            .uri(BASE_PATH + "?isValorized=true")
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    BddLogger.then("it should contain the valorized declared skill progress");
+    List<String> valorizedIds = new ArrayList<>();
+    objectMapper
+        .readTree(valorizedOnlyResponse)
+        .get("data")
+        .forEach(node -> valorizedIds.add(node.get("id").asText()));
+    assertThat(valorizedIds).contains(createdSkillId.toString());
+
+    BddLogger.when("performing a GET with isValorized=false");
+
+    var nonValorizedOnlyResponse =
+        webTestClient
+            .get()
+            .uri(BASE_PATH + "?isValorized=false")
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    BddLogger.then("it should not contain the valorized declared skill progress");
+    List<String> nonValorizedIds = new ArrayList<>();
+    objectMapper
+        .readTree(nonValorizedOnlyResponse)
+        .get("data")
+        .forEach(node -> nonValorizedIds.add(node.get("id").asText()));
+    assertThat(nonValorizedIds).doesNotContain(createdSkillId.toString());
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImplTest.java
@@ -99,20 +99,48 @@ public class DeclaredSkillProgressServiceImplTest {
         PageCriteria criteria = new PageCriteria(1, 8);
         PagedResult<DeclaredSkillProgress> expected = mock(PagedResult.class);
 
-        BddLogger.when("calling the method with a given student");
+        BddLogger.when("calling the method with a given student and no isValorized filter");
         when(declaredSkillProgressRepository.findAllByStudent(
-                student, criteria, new SortCriteria(ESortField.NAME, ESortOrder.ASC)))
+                student,
+                criteria,
+                (Boolean) null,
+                new SortCriteria(ESortField.NAME, ESortOrder.ASC)))
             .thenReturn(expected);
 
         PagedResult<DeclaredSkillProgress> result =
-            declaredSkillProgressService.getDeclaredSkillsProgresses(criteria);
+            declaredSkillProgressService.getDeclaredSkillsProgresses(criteria, null);
 
         BddLogger.then(
             "it should return the expected paged declared skill progress and delegate to"
                 + " repository");
         assertThat(result).isSameAs(expected);
         verify(declaredSkillProgressRepository)
-            .findAllByStudent(student, criteria, new SortCriteria(ESortField.NAME, ESortOrder.ASC));
+            .findAllByStudent(
+                student,
+                criteria,
+                (Boolean) null,
+                new SortCriteria(ESortField.NAME, ESortOrder.ASC));
+      }
+
+      @Test
+      void getDeclaredSkillsProgresses_shouldDelegateIsValorizedFilterToRepository() {
+        BddLogger.given("the method getDeclaredSkillsProgresses");
+        PageCriteria criteria = new PageCriteria(1, 8);
+        PagedResult<DeclaredSkillProgress> expected = mock(PagedResult.class);
+
+        BddLogger.when("calling the method with a given student and isValorized=true");
+        when(declaredSkillProgressRepository.findAllByStudent(
+                student, criteria, true, new SortCriteria(ESortField.NAME, ESortOrder.ASC)))
+            .thenReturn(expected);
+
+        PagedResult<DeclaredSkillProgress> result =
+            declaredSkillProgressService.getDeclaredSkillsProgresses(criteria, true);
+
+        BddLogger.then("it should delegate the isValorized filter to the repository");
+        assertThat(result).isSameAs(expected);
+        verify(declaredSkillProgressRepository)
+            .findAllByStudent(
+                student, criteria, true, new SortCriteria(ESortField.NAME, ESortOrder.ASC));
       }
 
       @Test


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds an optional `isValorized` query parameter to the `GET /me/declared/skill-progress` endpoint, allowing clients to filter the student's declared skill progresses by their `valorized` flag. The filter is implemented via a new `DeclaredSkillProgressSpecification.isValorized(Boolean)` JPA specification, threaded through the repository, service, and controller layers.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2229

---

### Documentation
> No documentation updates required beyond the OpenAPI-visible new query parameter on the endpoint.

---

### Target Branch
> `develop`

---

### Additional Notes
> When `isValorized` is omitted, the specification returns a no-op conjunction so existing behavior (no filtering) is preserved.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process