### PR TITLE
feat(declared-experience): add isValorized query param filter

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
@@ -67,9 +67,10 @@ public class DeclaredExperienceController {
   @GetMapping("/view")
   public ResponseEntity<PagedResponse<DeclaredExperienceViewDTO>> getDeclaredExperienceView(
       @RequestParam(required = false) Integer page,
-      @RequestParam(required = false) Integer pageSize) {
+      @RequestParam(required = false) Integer pageSize,
+      @RequestParam(required = false) Boolean isValorized) {
     PagedResult<DeclaredExperience> pagedExperiences =
-        declaredExperienceService.getView(new PageCriteria(page, pageSize));
+        declaredExperienceService.getView(new PageCriteria(page, pageSize), isValorized);
 
     return ResponseEntity.ok(
         new PagedResponse<>(

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
@@ -58,7 +58,7 @@ public interface DeclaredExperienceService {
 
   DeclaredExperience get(UUID experienceId);
 
-  PagedResult<DeclaredExperience> getView(PageCriteria pageCriteria);
+  PagedResult<DeclaredExperience> getView(PageCriteria pageCriteria, Boolean isValorized);
 
   List<DeclaredExperience> findAllByIds(List<UUID> experienceIds);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/output/repository/DeclaredExperienceRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/output/repository/DeclaredExperienceRepository.java
@@ -7,7 +7,8 @@ import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 
 public interface DeclaredExperienceRepository extends GenericRepositoryPort<DeclaredExperience> {
-  PagedResult<DeclaredExperience> findAllByStudent(Student student, PageCriteria pageCriteria);
+  PagedResult<DeclaredExperience> findAllByStudent(
+      Student student, PageCriteria pageCriteria, Boolean isValorized);
 
   PagedResult<DeclaredExperience> findAllByStudent(
       Student student, PageCriteria pageCriteria, String keyword);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
@@ -267,11 +267,11 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
   }
 
   @Override
-  public PagedResult<DeclaredExperience> getView(PageCriteria pageCriteria) {
+  public PagedResult<DeclaredExperience> getView(PageCriteria pageCriteria, Boolean isValorized) {
     Student student = loggedInUserService.getLoggedInStudent();
     log.info("Get experience view by {}", student);
 
-    return experienceRepository.findAllByStudent(student, pageCriteria);
+    return experienceRepository.findAllByStudent(student, pageCriteria, isValorized);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/repository/DeclaredExperienceDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/repository/DeclaredExperienceDatabaseRepository.java
@@ -27,9 +27,11 @@ public class DeclaredExperienceDatabaseRepository
 
   @Override
   public PagedResult<DeclaredExperience> findAllByStudent(
-      Student student, PageCriteria pageCriteria) {
+      Student student, PageCriteria pageCriteria, Boolean isValorized) {
     return findAll(
-        hasStudent(student).and(DeclaredExperienceSpecification.ordered()),
+        hasStudent(student)
+            .and(DeclaredExperienceSpecification.ordered())
+            .and(DeclaredExperienceSpecification.isValorized(isValorized)),
         PageRequest.of(pageCriteria.page(), pageCriteria.pageSize()));
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/specification/DeclaredExperienceSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/specification/DeclaredExperienceSpecification.java
@@ -38,4 +38,13 @@ public class DeclaredExperienceSpecification {
           criteriaBuilder.lower(root.get("title")), "%" + keyword.toLowerCase() + "%");
     };
   }
+
+  public static Specification<DeclaredExperienceEntity> isValorized(Boolean isValorized) {
+    return (root, query, criteriaBuilder) -> {
+      if (isValorized == null) {
+        return criteriaBuilder.conjunction();
+      }
+      return criteriaBuilder.equal(root.get("valorized"), isValorized);
+    };
+  }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -1,10 +1,14 @@
 package fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.shared.infrastructure.ContainerConfigurationTest;
 import fr.avenirsesr.portfolio.shared.infrastructure.adapter.seeder.SeederRunner;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -333,6 +337,110 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
         .isEqualTo(createdId)
         .jsonPath("$.valorized")
         .isEqualTo(true);
+  }
+
+  @Transactional
+  @Test
+  void shouldFilterDeclaredExperienceViewByIsValorized() throws Exception {
+    BddLogger.given("a declared experience marked as valorized");
+
+    String createResponse =
+        webTestClient
+            .post()
+            .uri(BASE_PATH + "/")
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(buildCreateExperienceJson())
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    String createdId = extractIdFromResponse(createResponse);
+
+    String updateJson =
+        "{\n"
+            + "  \"title\": \"My Experience\",\n"
+            + "  \"experienceType\": \"PROFESSIONAL\",\n"
+            + "  \"organization\": \"ACME Inc\",\n"
+            + "  \"activitySector\": \"IT\",\n"
+            + "  \"location\": \"Paris\",\n"
+            + "  \"description\": \"Some description\",\n"
+            + "  \"sourceOfInformation\": \"SELF_DECLARED\",\n"
+            + "  \"summary\": \"Summary text\",\n"
+            + "  \"externalLink\": \"https://example.com\",\n"
+            + "  \"startDate\": \"2024-01-01\",\n"
+            + "  \"endDate\": \"2024-03-01\",\n"
+            + "  \"valorized\": true\n"
+            + "}\n";
+
+    webTestClient
+        .put()
+        .uri(BASE_PATH + "/" + createdId)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(updateJson)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    BddLogger.when("performing a GET on /view with isValorized=true");
+
+    String valorizedOnlyResponse =
+        webTestClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder.path(BASE_PATH + "/view").queryParam("isValorized", true).build())
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    BddLogger.then("it should contain the valorized declared experience");
+    List<String> valorizedIds = new ArrayList<>();
+    objectMapper
+        .readTree(valorizedOnlyResponse)
+        .get("data")
+        .forEach(node -> valorizedIds.add(node.get("id").asText()));
+    assertThat(valorizedIds).contains(createdId);
+
+    BddLogger.when("performing a GET on /view with isValorized=false");
+
+    String nonValorizedOnlyResponse =
+        webTestClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder.path(BASE_PATH + "/view").queryParam("isValorized", false).build())
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    BddLogger.then("it should not contain the valorized declared experience");
+    List<String> nonValorizedIds = new ArrayList<>();
+    objectMapper
+        .readTree(nonValorizedOnlyResponse)
+        .get("data")
+        .forEach(node -> nonValorizedIds.add(node.get("id").asText()));
+    assertThat(nonValorizedIds).doesNotContain(createdId);
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.*;
 import fr.avenirsesr.portfolio.association.domain.model.Association;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
+import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
+import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.error.domain.exception.FieldValidationException;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
@@ -994,6 +996,37 @@ class DeclaredExperienceServiceImplTest {
     service.delete(List.of(id));
 
     verify(experienceRepository).removeAllFromDatabase(List.of(exp));
+  }
+
+  @Test
+  void getView_shouldDelegateToRepositoryAndReturnResult() {
+    Student loggedIn = student;
+    PageCriteria criteria = new PageCriteria(1, 8);
+    PagedResult<DeclaredExperience> expected = mock(PagedResult.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(experienceRepository.findAllByStudent(loggedIn, criteria, (Boolean) null))
+        .thenReturn(expected);
+
+    PagedResult<DeclaredExperience> result = service.getView(criteria, null);
+
+    assertSame(expected, result);
+    verify(experienceRepository).findAllByStudent(loggedIn, criteria, (Boolean) null);
+  }
+
+  @Test
+  void getView_shouldDelegateIsValorizedFilterToRepository() {
+    Student loggedIn = student;
+    PageCriteria criteria = new PageCriteria(1, 8);
+    PagedResult<DeclaredExperience> expected = mock(PagedResult.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(experienceRepository.findAllByStudent(loggedIn, criteria, true)).thenReturn(expected);
+
+    PagedResult<DeclaredExperience> result = service.getView(criteria, true);
+
+    assertSame(expected, result);
+    verify(experienceRepository).findAllByStudent(loggedIn, criteria, true);
   }
 
   @Test


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds an optional `isValorized` query parameter to the `GET /me/declared/experiences/view` endpoint, allowing clients to filter the student's declared professional experiences by their `valorized` flag. The filter is implemented via a new `DeclaredExperienceSpecification.isValorized(Boolean)` JPA specification, threaded through the repository, service, and controller layers.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2230

---

### Documentation
> No documentation updates required beyond the OpenAPI-visible new query parameter on the endpoint.

---

### Target Branch
> `develop`

---

### Additional Notes
> When `isValorized` is omitted, the specification returns a no-op conjunction so existing behavior (no filtering) is preserved. Follows the same pattern already applied to `GET /me/declared/skill-progress` (issue #2229).

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process