### PR TITLE
feat(declared-program): add isValorized query param filter

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/application/adapter/controller/DeclaredProgramController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/application/adapter/controller/DeclaredProgramController.java
@@ -32,14 +32,16 @@ public class DeclaredProgramController {
   @GetMapping
   public ResponseEntity<PagedResponse<DeclaredProgramViewDTO>> getDeclaredPrograms(
       @RequestParam(required = false) Integer page,
-      @RequestParam(required = false) Integer pageSize) {
+      @RequestParam(required = false) Integer pageSize,
+      @RequestParam(required = false) Boolean isValorized) {
     var pageCriteria = new PageCriteria(page, pageSize);
     log.debug(
-        "Received request to get declared programs (page= {}, fileSize= {})",
+        "Received request to get declared programs (page= {}, fileSize= {}, isValorized={})",
         pageCriteria.page(),
-        pageCriteria.pageSize());
+        pageCriteria.pageSize(),
+        isValorized);
     PagedResult<DeclaredProgram> declaredProgramPagedResult =
-        declaredProgramService.getDeclaredPrograms(pageCriteria);
+        declaredProgramService.getDeclaredPrograms(pageCriteria, isValorized);
 
     return ResponseEntity.ok(
         new PagedResponse<>(

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/domain/port/input/DeclaredProgramService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/domain/port/input/DeclaredProgramService.java
@@ -31,7 +31,7 @@ public interface DeclaredProgramService {
 
   DeclaredProgram getById(UUID declaredProgramId);
 
-  PagedResult<DeclaredProgram> getDeclaredPrograms(PageCriteria pageCriteria);
+  PagedResult<DeclaredProgram> getDeclaredPrograms(PageCriteria pageCriteria, Boolean isValorized);
 
   DeclaredProgram update(
       UUID declaredProgramId,

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/domain/port/output/DeclaredProgramRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/domain/port/output/DeclaredProgramRepository.java
@@ -9,5 +9,8 @@ import fr.avenirsesr.portfolio.user.domain.model.Student;
 
 public interface DeclaredProgramRepository extends GenericRepositoryPort<DeclaredProgram> {
   PagedResult<DeclaredProgram> findAllByStudent(
-      Student student, PageCriteria pageCriteria, SortCriteria... sortCriterias);
+      Student student,
+      PageCriteria pageCriteria,
+      Boolean isValorized,
+      SortCriteria... sortCriterias);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/domain/service/DeclaredProgramServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/domain/service/DeclaredProgramServiceImpl.java
@@ -138,11 +138,13 @@ public class DeclaredProgramServiceImpl implements DeclaredProgramService {
   }
 
   @Override
-  public PagedResult<DeclaredProgram> getDeclaredPrograms(PageCriteria pageCriteria) {
+  public PagedResult<DeclaredProgram> getDeclaredPrograms(
+      PageCriteria pageCriteria, Boolean isValorized) {
     Student student = loggedInUserService.getLoggedInStudent();
     return declaredProgramRepository.findAllByStudent(
         student,
         pageCriteria,
+        isValorized,
         new SortCriteria(ESortField.DATE, ESortOrder.DESC),
         new SortCriteria(ESortField.NAME, ESortOrder.ASC));
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/infrastructure/adapter/repository/DeclaredProgramDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/infrastructure/adapter/repository/DeclaredProgramDatabaseRepository.java
@@ -26,9 +26,12 @@ public class DeclaredProgramDatabaseRepository
 
   @Override
   public PagedResult<DeclaredProgram> findAllByStudent(
-      Student student, PageCriteria pageCriteria, SortCriteria... sortCriterias) {
+      Student student,
+      PageCriteria pageCriteria,
+      Boolean isValorized,
+      SortCriteria... sortCriterias) {
     return findAll(
-        hasStudent(student),
+        hasStudent(student).and(DeclaredProgramSpecification.isValorized(isValorized)),
         PageRequest.of(
             pageCriteria.page(),
             pageCriteria.pageSize(),

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/infrastructure/adapter/specification/DeclaredProgramSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/program/infrastructure/adapter/specification/DeclaredProgramSpecification.java
@@ -2,7 +2,9 @@ package fr.avenirsesr.portfolio.student.progress.declared.program.infrastructure
 
 import fr.avenirsesr.portfolio.common.data.domain.model.SortCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.ESortOrder;
+import fr.avenirsesr.portfolio.student.progress.declared.program.infrastructure.adapter.model.DeclaredProgramEntity;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 
 public class DeclaredProgramSpecification {
   public static Sort toSort(SortCriteria sortCriteria) {
@@ -16,6 +18,15 @@ public class DeclaredProgramSpecification {
     return switch (sortCriteria.field()) {
       case NAME -> Sort.by(direction, "title");
       case DATE -> Sort.by(direction, "endDate");
+    };
+  }
+
+  public static Specification<DeclaredProgramEntity> isValorized(Boolean isValorized) {
+    return (root, query, criteriaBuilder) -> {
+      if (isValorized == null) {
+        return criteriaBuilder.conjunction();
+      }
+      return criteriaBuilder.equal(root.get("valorized"), isValorized);
     };
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/program/application/adapter/controller/DeclaredProgramControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/program/application/adapter/controller/DeclaredProgramControllerIT.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.progress.declared.program.application.adapter.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,6 +13,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.program.application.ada
 import fr.avenirsesr.portfolio.student.progress.declared.program.domain.model.enums.EProgramStatus;
 import fr.avenirsesr.portfolio.student.progress.declared.program.infrastructure.adapter.repository.DeclaredProgramJpaRepository;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
@@ -446,6 +448,103 @@ class DeclaredProgramControllerIT extends ContainerConfigurationTest {
             .isEqualTo("LeadPro")
             .jsonPath("$.data[?(@.title == 'Séminaire leadership et communication')].result")
             .isEqualTo("Certificat obtenu");
+      }
+
+      @Test
+      void shouldFilterDeclaredProgramsByIsValorized() throws Exception {
+        BddLogger.given("a declared program marked as valorized");
+
+        String id =
+            createDeclaredProgramAndReturnId(
+                new DeclaredProgramRequestDTO(
+                    "Stage isValorized filter",
+                    "Description",
+                    "Tech4Future",
+                    "Result",
+                    "Source",
+                    LocalDate.now().minusMonths(1),
+                    LocalDate.now(),
+                    false),
+                studentPayload,
+                studentSignature);
+
+        DeclaredProgramRequestDTO updateBody =
+            new DeclaredProgramRequestDTO(
+                "Stage isValorized filter",
+                "Description",
+                "Tech4Future",
+                "Result",
+                "Source",
+                LocalDate.now().minusMonths(1),
+                LocalDate.now(),
+                true);
+
+        webTestClient
+            .put()
+            .uri(BASE_PATH + "/" + id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(writeValueAsString(updateBody))
+            .header(HttpHeaders.ACCEPT_LANGUAGE, ELanguage.FRENCH.getCode())
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+        BddLogger.when("performing a GET with isValorized=true");
+
+        String valorizedOnlyResponse =
+            webTestClient
+                .get()
+                .uri(
+                    uriBuilder ->
+                        uriBuilder.path(BASE_PATH).queryParam("isValorized", true).build())
+                .header(HttpHeaders.ACCEPT_LANGUAGE, ELanguage.FRENCH.getCode())
+                .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+                .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+                .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+
+        BddLogger.then("it should contain the valorized declared program");
+        List<String> valorizedIds = new ArrayList<>();
+        objectMapper
+            .readTree(valorizedOnlyResponse)
+            .get("data")
+            .forEach(node -> valorizedIds.add(node.get("id").asText()));
+        assertThat(valorizedIds).contains(id);
+
+        BddLogger.when("performing a GET with isValorized=false");
+
+        String nonValorizedOnlyResponse =
+            webTestClient
+                .get()
+                .uri(
+                    uriBuilder ->
+                        uriBuilder.path(BASE_PATH).queryParam("isValorized", false).build())
+                .header(HttpHeaders.ACCEPT_LANGUAGE, ELanguage.FRENCH.getCode())
+                .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+                .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+                .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+
+        BddLogger.then("it should not contain the valorized declared program");
+        List<String> nonValorizedIds = new ArrayList<>();
+        objectMapper
+            .readTree(nonValorizedOnlyResponse)
+            .get("data")
+            .forEach(node -> nonValorizedIds.add(node.get("id").asText()));
+        assertThat(nonValorizedIds).doesNotContain(id);
       }
     }
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/program/domain/service/DeclaredProgramServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/program/domain/service/DeclaredProgramServiceImplTest.java
@@ -427,16 +427,17 @@ class DeclaredProgramServiceImplTest {
                 .collect(Collectors.toList());
         loggedStudent = mock(Student.class);
         when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedStudent);
-        when(declaredProgramRepository.findAllByStudent(
-                loggedStudent, pageCriteria, sortByDate, sortByName))
-            .thenReturn(new PagedResult<>(declaredProgramList, pageInfo));
       }
 
       @Test
       void thenItShouldReturnDeclaredPrograms() {
-        BddLogger.when("getDeclaredPrograms(PageCriteria pageCriteria) is called");
+        BddLogger.when("getDeclaredPrograms(PageCriteria pageCriteria, null) is called");
+        when(declaredProgramRepository.findAllByStudent(
+                loggedStudent, pageCriteria, null, sortByDate, sortByName))
+            .thenReturn(new PagedResult<>(declaredProgramList, pageInfo));
+
         PagedResult<DeclaredProgram> result =
-            declaredProgramService.getDeclaredPrograms(pageCriteria);
+            declaredProgramService.getDeclaredPrograms(pageCriteria, null);
 
         assertNotNull(result);
 
@@ -455,7 +456,24 @@ class DeclaredProgramServiceImplTest {
 
         verify(loggedInUserService).getLoggedInStudent();
         verify(declaredProgramRepository)
-            .findAllByStudent(loggedStudent, pageCriteria, sortByDate, sortByName);
+            .findAllByStudent(loggedStudent, pageCriteria, null, sortByDate, sortByName);
+      }
+
+      @Test
+      void thenItShouldDelegateIsValorizedFilterToRepository() {
+        BddLogger.when(
+            "getDeclaredPrograms(PageCriteria pageCriteria, Boolean isValorized) is called with"
+                + " isValorized=true");
+        when(declaredProgramRepository.findAllByStudent(
+                loggedStudent, pageCriteria, true, sortByDate, sortByName))
+            .thenReturn(new PagedResult<>(declaredProgramList, pageInfo));
+
+        PagedResult<DeclaredProgram> result =
+            declaredProgramService.getDeclaredPrograms(pageCriteria, true);
+
+        assertNotNull(result);
+        verify(declaredProgramRepository)
+            .findAllByStudent(loggedStudent, pageCriteria, true, sortByDate, sortByName);
       }
     }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds an optional `isValorized` query parameter to the `GET /me/declared/programs` endpoint, allowing clients to filter the student's declared programs (trainings) by their `valorized` flag. The filter is implemented via a new `DeclaredProgramSpecification.isValorized(Boolean)` JPA specification, threaded through the repository, service, and controller layers.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2231

---

### Documentation
> No documentation updates required beyond the OpenAPI-visible new query parameter on the endpoint.

---

### Target Branch
> `develop`

---

### Additional Notes
> When `isValorized` is omitted, the specification returns a no-op conjunction so existing behavior (no filtering) is preserved. Follows the same pattern already applied to `GET /me/declared/skill-progress` (issue #2229) and `GET /me/declared/experiences/view` (issue #2230).

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process