### PR TITLE
feat(self-knowledge): add isValorized query param filter

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeController.java
@@ -44,16 +44,18 @@ public class SelfKnowledgeController {
   public ResponseEntity<PagedResponse<SelfKnowledgeElementViewDTO>> getSelfKnowledgeElements(
       @PathVariable("selfKnowledgeCategoryId") UUID selfKnowledgeCategoryId,
       @RequestParam(required = false) Integer page,
-      @RequestParam(required = false) Integer pageSize) {
+      @RequestParam(required = false) Integer pageSize,
+      @RequestParam(required = false) Boolean isValorized) {
     log.debug(
         "Received request to get elements of self knowledge category [{}], with"
-            + " pagination (page={}, pageSize={})",
+            + " pagination (page={}, pageSize={}, isValorized={})",
         selfKnowledgeCategoryId,
         page,
-        pageSize);
+        pageSize,
+        isValorized);
     PagedResult<SelfKnowledgeElement> selfKnowledgeElementPagedResult =
         selfKnowledgeService.getSelfKnowledgeElements(
-            selfKnowledgeCategoryId, new PageCriteria(page, pageSize));
+            selfKnowledgeCategoryId, new PageCriteria(page, pageSize), isValorized);
 
     return ResponseEntity.ok(
         new PagedResponse<>(

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/input/SelfKnowledgeService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/input/SelfKnowledgeService.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 public interface SelfKnowledgeService {
   PagedResult<SelfKnowledgeElement> getSelfKnowledgeElements(
-      UUID selfKnowledgeCategoryId, PageCriteria pageCriteria);
+      UUID selfKnowledgeCategoryId, PageCriteria pageCriteria, Boolean isValorized);
 
   SelfKnowledgeElementDetails getSelfKnowledgeElementDetails(UUID selfKnowledgeElementId);
 

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/output/repository/SelfKnowledgeElementRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/output/repository/SelfKnowledgeElementRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public interface SelfKnowledgeElementRepository
     extends GenericRepositoryPort<SelfKnowledgeElement> {
   PagedResult<SelfKnowledgeElement> findAllByStudentIdAndCategoryId(
-      UUID studentId, UUID selfKnowledgeCategoryId, PageCriteria pageCriteria);
+      UUID studentId, UUID selfKnowledgeCategoryId, PageCriteria pageCriteria, Boolean isValorized);
 
   void deleteAllByStudentAndCategory(Student student, SelfKnowledgeCategory category);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImpl.java
@@ -37,7 +37,7 @@ public class SelfKnowledgeServiceImpl implements SelfKnowledgeService {
 
   @Override
   public PagedResult<SelfKnowledgeElement> getSelfKnowledgeElements(
-      UUID selfKnowledgeCategoryId, PageCriteria pageCriteria) {
+      UUID selfKnowledgeCategoryId, PageCriteria pageCriteria, Boolean isValorized) {
     Student student = loggedInUserService.getLoggedInStudent();
 
     selfKnowledgeCategoryRepository
@@ -45,7 +45,7 @@ public class SelfKnowledgeServiceImpl implements SelfKnowledgeService {
         .orElseThrow(SelfKnowledgeCategoryNotFoundException::new);
 
     return selfKnowledgeElementRepository.findAllByStudentIdAndCategoryId(
-        student.getId(), selfKnowledgeCategoryId, pageCriteria);
+        student.getId(), selfKnowledgeCategoryId, pageCriteria, isValorized);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/repository/SelfKnowledgeElementDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/repository/SelfKnowledgeElementDatabaseRepository.java
@@ -36,12 +36,16 @@ public class SelfKnowledgeElementDatabaseRepository
 
   @Override
   public PagedResult<SelfKnowledgeElement> findAllByStudentIdAndCategoryId(
-      UUID studentId, UUID selfKnowledgeCategoryId, PageCriteria pageCriteria) {
+      UUID studentId,
+      UUID selfKnowledgeCategoryId,
+      PageCriteria pageCriteria,
+      Boolean isValorized) {
     Specification<SelfKnowledgeElementEntity> spec =
         SelfKnowledgeElementSpecification.hasStudentId(studentId)
             .and(
                 SelfKnowledgeElementSpecification.hasSelfKnowledgeCategoryId(
-                    selfKnowledgeCategoryId));
+                    selfKnowledgeCategoryId))
+            .and(SelfKnowledgeElementSpecification.isValorized(isValorized));
     return findAll(spec, PageRequest.of(pageCriteria.page(), pageCriteria.pageSize()));
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/specification/SelfKnowledgeElementSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/specification/SelfKnowledgeElementSpecification.java
@@ -18,4 +18,13 @@ public class SelfKnowledgeElementSpecification {
             ? null
             : cb.equal(root.get("selfKnowledgeCategory").get("id"), categoryId);
   }
+
+  public static Specification<SelfKnowledgeElementEntity> isValorized(Boolean isValorized) {
+    return (root, query, criteriaBuilder) -> {
+      if (isValorized == null) {
+        return criteriaBuilder.conjunction();
+      }
+      return criteriaBuilder.equal(root.get("valorized"), isValorized);
+    };
+  }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeControllerIT.java
@@ -1,11 +1,14 @@
 package fr.avenirsesr.portfolio.selfknowledge.application.adapter.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.common.security.infrastructure.adapter.model.AvenirsSecurityHeaders;
 import fr.avenirsesr.portfolio.shared.infrastructure.ContainerConfigurationTest;
 import fr.avenirsesr.portfolio.shared.infrastructure.adapter.seeder.SeederRunner;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -232,6 +235,77 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
         .isEqualTo(elementId)
         .jsonPath("$.valorized")
         .isEqualTo(true);
+  }
+
+  @Test
+  void shouldFilterSelfKnowledgeElementsByIsValorized() throws Exception {
+    String categoryId = getLinkedCategoryId();
+    String elementId = createElement(categoryId, "Filter me", "Desc", 3);
+
+    webTestClient
+        .put()
+        .uri(BASE_PATH + "/element/{elementId}", elementId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "title": "Filter me",
+              "description": "Desc",
+              "rating": 3,
+              "valorized": true
+            }
+            """)
+        .header("Accept-Language", ELanguage.FRENCH.getCode())
+        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+        .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    String valorizedOnlyResponse =
+        webTestClient
+            .get()
+            .uri(BASE_PATH + "/{categoryId}/elements?isValorized=true", categoryId)
+            .header("Accept-Language", ELanguage.FRENCH.getCode())
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    List<String> valorizedIds = new ArrayList<>();
+    objectMapper
+        .readTree(valorizedOnlyResponse)
+        .get("data")
+        .forEach(node -> valorizedIds.add(node.get("id").asText()));
+    assertThat(valorizedIds).contains(elementId);
+
+    String nonValorizedOnlyResponse =
+        webTestClient
+            .get()
+            .uri(BASE_PATH + "/{categoryId}/elements?isValorized=false", categoryId)
+            .header("Accept-Language", ELanguage.FRENCH.getCode())
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_KID, secretKey)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    List<String> nonValorizedIds = new ArrayList<>();
+    objectMapper
+        .readTree(nonValorizedOnlyResponse)
+        .get("data")
+        .forEach(node -> nonValorizedIds.add(node.get("id").asText()));
+    assertThat(nonValorizedIds).doesNotContain(elementId);
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImplTest.java
@@ -266,7 +266,7 @@ class SelfKnowledgeServiceImplTest {
                 SelfKnowledgeCategoryNotFoundException.class,
                 () ->
                     selfKnowledgeService.getSelfKnowledgeElements(
-                        unknownId, new PageCriteria(0, 8)));
+                        unknownId, new PageCriteria(0, 8), null));
           }
         }
 
@@ -317,13 +317,13 @@ class SelfKnowledgeServiceImplTest {
             when(selfKnowledgeCategoryRepository.findById(selfKnowledgeCategoryId))
                 .thenReturn(Optional.of(selfKnowledgeCategory));
             when(selfKnowledgeElementRepository.findAllByStudentIdAndCategoryId(
-                    student.getId(), selfKnowledgeCategoryId, pageCriteria))
+                    student.getId(), selfKnowledgeCategoryId, pageCriteria, null))
                 .thenReturn(expectedResult);
 
             BddLogger.when("getting self knowledge elements paginated");
             PagedResult<SelfKnowledgeElement> actualResult =
                 selfKnowledgeService.getSelfKnowledgeElements(
-                    selfKnowledgeCategoryId, pageCriteria);
+                    selfKnowledgeCategoryId, pageCriteria, null);
 
             BddLogger.then("it should retrieve self knowledge elements paginated");
             assertThat(actualResult).isEqualTo(expectedResult);
@@ -332,7 +332,30 @@ class SelfKnowledgeServiceImplTest {
             verify(selfKnowledgeCategoryRepository).findById(selfKnowledgeCategoryId);
             verify(selfKnowledgeElementRepository)
                 .findAllByStudentIdAndCategoryId(
-                    student.getId(), selfKnowledgeCategoryId, pageCriteria);
+                    student.getId(), selfKnowledgeCategoryId, pageCriteria, null);
+          }
+
+          @Test
+          void thenItShouldDelegateIsValorizedFilterToRepository() {
+            PagedResult<SelfKnowledgeElement> expectedResult =
+                new PagedResult<>(List.of(selfKnowledgeElement), new PageInfo(0, 8, 1));
+
+            when(selfKnowledgeCategoryRepository.findById(selfKnowledgeCategoryId))
+                .thenReturn(Optional.of(selfKnowledgeCategory));
+            when(selfKnowledgeElementRepository.findAllByStudentIdAndCategoryId(
+                    student.getId(), selfKnowledgeCategoryId, pageCriteria, true))
+                .thenReturn(expectedResult);
+
+            BddLogger.when("getting self knowledge elements paginated with isValorized=true");
+            PagedResult<SelfKnowledgeElement> actualResult =
+                selfKnowledgeService.getSelfKnowledgeElements(
+                    selfKnowledgeCategoryId, pageCriteria, true);
+
+            BddLogger.then("it should delegate the isValorized filter to the repository");
+            assertThat(actualResult).isEqualTo(expectedResult);
+            verify(selfKnowledgeElementRepository)
+                .findAllByStudentIdAndCategoryId(
+                    student.getId(), selfKnowledgeCategoryId, pageCriteria, true);
           }
         }
 
@@ -1049,7 +1072,7 @@ class SelfKnowledgeServiceImplTest {
               UserNotFoundException.class,
               () ->
                   selfKnowledgeService.getSelfKnowledgeElements(
-                      UUID.randomUUID(), new PageCriteria(0, 8)));
+                      UUID.randomUUID(), new PageCriteria(0, 8), null));
         }
       }
 
@@ -1211,7 +1234,7 @@ class SelfKnowledgeServiceImplTest {
               UserIsNotStudentException.class,
               () ->
                   selfKnowledgeService.getSelfKnowledgeElements(
-                      UUID.randomUUID(), new PageCriteria(0, 8)));
+                      UUID.randomUUID(), new PageCriteria(0, 8), null));
         }
       }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds an optional `isValorized` query parameter to the `GET /me/self-knowledge/{selfKnowledgeCategoryId}/elements` endpoint, allowing clients to filter the student's self-knowledge elements by their `valorized` flag. The filter is implemented via a new `SelfKnowledgeElementSpecification.isValorized(Boolean)` JPA specification, threaded through the repository, service, and controller layers.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2234

---

### Documentation
> No documentation updates required beyond the OpenAPI-visible new query parameter on the endpoint.

---

### Target Branch
> `develop`

---

### Additional Notes
> When `isValorized` is omitted, the specification returns a no-op conjunction so existing behavior (no filtering) is preserved. Follows the same pattern already applied to `GET /me/declared/skill-progress` (issue #2229), `GET /me/declared/experiences/view` (issue #2230), and `GET /me/declared/programs` (issue #2231).

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process