### PR TITLE
feat(declared-skill-progress): add associations count to DeclaredSkillProgressDTO

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/association/domain/port/input/AssociationService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/domain/port/input/AssociationService.java
@@ -4,6 +4,7 @@ import fr.avenirsesr.portfolio.association.domain.data.AssociationData;
 import fr.avenirsesr.portfolio.association.domain.model.Association;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface AssociationService {
@@ -13,6 +14,8 @@ public interface AssociationService {
 
   List<Association> getAllOf(
       List<UUID> ids, Class<?> clazz, List<EAssociationType> associationTypes);
+
+  Map<UUID, Long> countAllOf(List<UUID> ids, Class<?> clazz, EAssociationType associationType);
 
   void deleteAllByIds(List<UUID> ids);
 

--- a/src/main/java/fr/avenirsesr/portfolio/association/domain/port/output/repository/AssociationRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/domain/port/output/repository/AssociationRepository.java
@@ -5,6 +5,7 @@ import fr.avenirsesr.portfolio.association.domain.model.Association;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.common.data.domain.port.output.repository.GenericRepositoryPort;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface AssociationRepository extends GenericRepositoryPort<Association> {
@@ -16,4 +17,6 @@ public interface AssociationRepository extends GenericRepositoryPort<Association
 
   List<Association> findAllOf(
       List<UUID> ids, Class<?> clazz, List<EAssociationType> associationTypes);
+
+  Map<UUID, Long> countAllOf(List<UUID> ids, Class<?> clazz, EAssociationType associationType);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/association/domain/service/AssociationServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/domain/service/AssociationServiceImpl.java
@@ -9,6 +9,7 @@ import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.association.domain.port.output.repository.AssociationRepository;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 
@@ -47,6 +48,16 @@ public class AssociationServiceImpl implements AssociationService {
     }
 
     return associationRepository.findAllOf(ids, clazz, associationTypes);
+  }
+
+  @Override
+  public Map<UUID, Long> countAllOf(
+      List<UUID> ids, Class<?> clazz, EAssociationType associationType) {
+    if (ids.isEmpty()) {
+      return Map.of();
+    }
+
+    return associationRepository.countAllOf(ids, clazz, associationType);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/association/infrastructure/adapter/repository/AssociationDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/infrastructure/adapter/repository/AssociationDatabaseRepository.java
@@ -9,7 +9,9 @@ import fr.avenirsesr.portfolio.association.infrastructure.adapter.model.Associat
 import fr.avenirsesr.portfolio.association.infrastructure.adapter.specification.AssociationSpecification;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.repository.GenericJpaRepositoryAdapter;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
@@ -71,6 +73,30 @@ public class AssociationDatabaseRepository
     return jpaRepository.findAll(specification, DEFAULT_SORT).stream()
         .map(AssociationMapper.INSTANCE::toDomain)
         .toList();
+  }
+
+  @Override
+  public Map<UUID, Long> countAllOf(
+      List<UUID> ids, Class<?> clazz, EAssociationType associationType) {
+    if (ids.isEmpty()) {
+      return Map.of();
+    }
+
+    List<AssociationJpaRepository.AssociationCountRow> rows;
+    if (associationType.getKey1().equals(clazz)) {
+      rows = jpaRepository.countGroupedById1(associationType, ids);
+    } else if (associationType.getKey2().equals(clazz)) {
+      rows = jpaRepository.countGroupedById2(associationType, ids);
+    } else {
+      throw new IllegalArgumentException(
+          "Class " + clazz + " not compatible with association type " + associationType);
+    }
+
+    return rows.stream()
+        .collect(
+            Collectors.toMap(
+                AssociationJpaRepository.AssociationCountRow::getSubjectId,
+                AssociationJpaRepository.AssociationCountRow::getTotal));
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/association/infrastructure/adapter/repository/AssociationJpaRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/association/infrastructure/adapter/repository/AssociationJpaRepository.java
@@ -1,9 +1,40 @@
 package fr.avenirsesr.portfolio.association.infrastructure.adapter.repository;
 
+import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.infrastructure.adapter.model.AssociationEntity;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AssociationJpaRepository
-    extends JpaRepository<AssociationEntity, UUID>, JpaSpecificationExecutor<AssociationEntity> {}
+    extends JpaRepository<AssociationEntity, UUID>, JpaSpecificationExecutor<AssociationEntity> {
+
+  @Query(
+      """
+      select a.id1 as subjectId, count(a) as total
+      from AssociationEntity a
+      where a.associationType = :associationType and a.id1 in :ids
+      group by a.id1
+      """)
+  List<AssociationCountRow> countGroupedById1(
+      @Param("associationType") EAssociationType associationType, @Param("ids") List<UUID> ids);
+
+  @Query(
+      """
+      select a.id2 as subjectId, count(a) as total
+      from AssociationEntity a
+      where a.associationType = :associationType and a.id2 in :ids
+      group by a.id2
+      """)
+  List<AssociationCountRow> countGroupedById2(
+      @Param("associationType") EAssociationType associationType, @Param("ids") List<UUID> ids);
+
+  interface AssociationCountRow {
+    UUID getSubjectId();
+
+    Long getTotal();
+  }
+}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/dto/DeclaredSkillAssociationCountDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/dto/DeclaredSkillAssociationCountDTO.java
@@ -1,0 +1,7 @@
+package fr.avenirsesr.portfolio.student.progress.declared.skill.application.adapter.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(requiredProperties = {"traceAssociationsCount", "declaredActivityAssociationsCount"})
+public record DeclaredSkillAssociationCountDTO(
+    int traceAssociationsCount, int declaredActivityAssociationsCount) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/dto/DeclaredSkillProgressDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/dto/DeclaredSkillProgressDTO.java
@@ -6,7 +6,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.UUID;
 
-@Schema(requiredProperties = {"id", "title", "pathSegments", "type", "level", "valorized"})
+@Schema(
+    requiredProperties = {
+      "id",
+      "title",
+      "pathSegments",
+      "type",
+      "level",
+      "valorized",
+      "associationsCount"
+    })
 public record DeclaredSkillProgressDTO(
     UUID id,
     String title,
@@ -14,4 +23,5 @@ public record DeclaredSkillProgressDTO(
     @Schema(ref = "#/components/schemas/EExternalSkillType") EExternalSkillType type,
     @Schema(ref = "#/components/schemas/EDeclaredSkillLevel") EDeclaredSkillLevel level,
     String reflection,
-    boolean valorized) {}
+    boolean valorized,
+    DeclaredSkillAssociationCountDTO associationsCount) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/mapper/DeclaredSkillProgressMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/application/adapter/mapper/DeclaredSkillProgressMapper.java
@@ -3,8 +3,11 @@ package fr.avenirsesr.portfolio.student.progress.declared.skill.application.adap
 import fr.avenirsesr.portfolio.common.externalskill.application.adapter.dto.ExternalSkillCategoryDTO;
 import fr.avenirsesr.portfolio.declaredskill.application.adapter.dto.DeclaredSkillCategoryDTO;
 import fr.avenirsesr.portfolio.shared.application.adapter.mapper.OptionalMapper;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.application.adapter.dto.DeclaredSkillAssociationCountDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.application.adapter.dto.DeclaredSkillProgressDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.application.adapter.dto.DeclaredSkillProgressDetailsDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillAssociationCount;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillProgressData;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillProgressDetails;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
 import fr.avenirsesr.portfolio.trace.application.adapter.mapper.TraceOverviewMapper;
@@ -20,6 +23,20 @@ public interface DeclaredSkillProgressMapper {
   @Mapping(source = "skill.pathSegments", target = "pathSegments")
   @Mapping(source = "skill.type", target = "type")
   DeclaredSkillProgressDTO toDeclaredSkillProgressDTO(DeclaredSkillProgress declaredSkillProgress);
+
+  @Mapping(source = "declaredSkillProgress.id", target = "id")
+  @Mapping(source = "declaredSkillProgress.skill.libelle", target = "title")
+  @Mapping(source = "declaredSkillProgress.skill.pathSegments", target = "pathSegments")
+  @Mapping(source = "declaredSkillProgress.skill.type", target = "type")
+  @Mapping(source = "declaredSkillProgress.level", target = "level")
+  @Mapping(source = "declaredSkillProgress.reflection", target = "reflection")
+  @Mapping(source = "declaredSkillProgress.valorized", target = "valorized")
+  @Mapping(source = "associationsCount", target = "associationsCount")
+  DeclaredSkillProgressDTO toDeclaredSkillProgressDTO(
+      DeclaredSkillProgressData declaredSkillProgressData);
+
+  DeclaredSkillAssociationCountDTO toAssociationCountDTO(
+      DeclaredSkillAssociationCount associationsCount);
 
   @Mapping(source = "declaredSkillProgress.id", target = "id")
   @Mapping(source = "declaredSkillProgress.skill.libelle", target = "title")

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/data/DeclaredSkillAssociationCount.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/data/DeclaredSkillAssociationCount.java
@@ -1,0 +1,4 @@
+package fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data;
+
+public record DeclaredSkillAssociationCount(
+    int traceAssociationsCount, int declaredActivityAssociationsCount) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/data/DeclaredSkillProgressData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/data/DeclaredSkillProgressData.java
@@ -1,0 +1,6 @@
+package fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data;
+
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
+
+public record DeclaredSkillProgressData(
+    DeclaredSkillProgress declaredSkillProgress, DeclaredSkillAssociationCount associationsCount) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/port/input/DeclaredSkillProgressService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/port/input/DeclaredSkillProgressService.java
@@ -7,6 +7,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.externalskill.domain.model.enums.EExternalSkillType;
 import fr.avenirsesr.portfolio.declaredskill.domain.model.enums.EDeclaredSkillLevel;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillAssociationsData;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillProgressData;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillProgressDetails;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.UUID;
 
 public interface DeclaredSkillProgressService {
 
-  PagedResult<DeclaredSkillProgress> getDeclaredSkillsProgresses(
+  PagedResult<DeclaredSkillProgressData> getDeclaredSkillsProgresses(
       PageCriteria criteria, Boolean isValorized);
 
   DeclaredSkillProgress createDeclaredSkillProgress(

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImpl.java
@@ -32,7 +32,9 @@ import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.data.De
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.DeclaredActivityNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillAssociationCount;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillAssociationsData;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillProgressData;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillProgressDetails;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.exception.DeclaredSkillProgressNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
@@ -43,6 +45,8 @@ import fr.avenirsesr.portfolio.trace.domain.exception.TraceNotFoundException;
 import fr.avenirsesr.portfolio.trace.domain.port.input.TraceService;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,11 +63,50 @@ public class DeclaredSkillProgressServiceImpl implements DeclaredSkillProgressSe
   private final AssociationSearchHelper associationSearchHelper;
 
   @Override
-  public PagedResult<DeclaredSkillProgress> getDeclaredSkillsProgresses(
+  public PagedResult<DeclaredSkillProgressData> getDeclaredSkillsProgresses(
       PageCriteria pageCriteria, Boolean isValorized) {
     Student student = loggedInUserService.getLoggedInStudent();
-    return declaredSkillProgressRepository.findAllByStudent(
-        student, pageCriteria, isValorized, new SortCriteria(ESortField.NAME, ESortOrder.ASC));
+    var pagedDeclaredSkillProgresses =
+        declaredSkillProgressRepository.findAllByStudent(
+            student, pageCriteria, isValorized, new SortCriteria(ESortField.NAME, ESortOrder.ASC));
+
+    var associationsCountByDeclaredSkillProgress =
+        getAssociationCounts(pagedDeclaredSkillProgresses.content());
+
+    return new PagedResult<>(
+        pagedDeclaredSkillProgresses.content().stream()
+            .map(
+                declaredSkillProgress ->
+                    new DeclaredSkillProgressData(
+                        declaredSkillProgress,
+                        associationsCountByDeclaredSkillProgress.get(declaredSkillProgress)))
+            .toList(),
+        pagedDeclaredSkillProgresses.pageInfo());
+  }
+
+  private Map<DeclaredSkillProgress, DeclaredSkillAssociationCount> getAssociationCounts(
+      List<DeclaredSkillProgress> declaredSkillProgresses) {
+    var ids = declaredSkillProgresses.stream().map(DeclaredSkillProgress::getId).toList();
+
+    var traceAssociationsCountById =
+        associationService.countAllOf(
+            ids, DeclaredSkillProgress.class, EAssociationType.TRACE_DECLARED_SKILL);
+    var declaredActivityAssociationsCountById =
+        associationService.countAllOf(
+            ids, DeclaredSkillProgress.class, EAssociationType.DECLARED_ACTIVITY_DECLARED_SKILL);
+
+    return declaredSkillProgresses.stream()
+        .collect(
+            Collectors.toMap(
+                Function.identity(),
+                declaredSkillProgress ->
+                    new DeclaredSkillAssociationCount(
+                        traceAssociationsCountById
+                            .getOrDefault(declaredSkillProgress.getId(), 0L)
+                            .intValue(),
+                        declaredActivityAssociationsCountById
+                            .getOrDefault(declaredSkillProgress.getId(), 0L)
+                            .intValue())));
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/association/domain/service/AssociationServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/association/domain/service/AssociationServiceImplTest.java
@@ -11,9 +11,11 @@ import fr.avenirsesr.portfolio.association.domain.exception.AssociationDoesNotEx
 import fr.avenirsesr.portfolio.association.domain.model.Association;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.output.repository.AssociationRepository;
+import fr.avenirsesr.portfolio.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -119,5 +121,29 @@ class AssociationServiceImplTest {
         .isInstanceOf(AssociationDoesNotExistException.class);
 
     verify(associationRepository, never()).removeAllFromDatabase(anyList());
+  }
+
+  @Test
+  void countAllOf_should_delegate_to_repository() {
+    UUID traceId = UUID.randomUUID();
+    Map<UUID, Long> expected = Map.of(traceId, 2L);
+
+    when(associationRepository.countAllOf(
+            List.of(traceId), Trace.class, EAssociationType.DECLARED_ACTIVITY_TRACE))
+        .thenReturn(expected);
+
+    var result =
+        service.countAllOf(List.of(traceId), Trace.class, EAssociationType.DECLARED_ACTIVITY_TRACE);
+
+    assertThat(result).isSameAs(expected);
+  }
+
+  @Test
+  void countAllOf_should_return_empty_map_without_querying_when_ids_empty() {
+    var result =
+        service.countAllOf(List.of(), Trace.class, EAssociationType.DECLARED_ACTIVITY_TRACE);
+
+    assertThat(result).isEmpty();
+    verify(associationRepository, never()).countAllOf(any(), any(), any());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/skill/domain/service/DeclaredSkillProgressServiceImplTest.java
@@ -38,7 +38,9 @@ import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.exception.DeclaredActivityNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.progress.declared.activity.domain.port.input.DeclaredActivityService;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillAssociationCount;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillAssociationsData;
+import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillProgressData;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.data.DeclaredSkillProgressDetails;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.exception.DeclaredSkillProgressNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.domain.model.DeclaredSkillProgress;
@@ -82,6 +84,13 @@ public class DeclaredSkillProgressServiceImplTest {
     when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
   }
 
+  private DeclaredSkillProgress buildDeclaredSkillProgress() {
+    DeclaredSkill skill =
+        DeclaredSkill.create(
+            randomUUID(), "Java Programming", EExternalSkillType.ROME4, List.of("Technology"));
+    return DeclaredSkillProgress.create(student, skill, EDeclaredSkillLevel.BEGINNER, null);
+  }
+
   @Nested
   class GivenAStudentProgressService {
 
@@ -97,7 +106,9 @@ public class DeclaredSkillProgressServiceImplTest {
       void getDeclaredSkillsProgresses_shouldDelegateToRepositoryAndReturnResult() {
         BddLogger.given("the method getDeclaredSkillsProgresses");
         PageCriteria criteria = new PageCriteria(1, 8);
-        PagedResult<DeclaredSkillProgress> expected = mock(PagedResult.class);
+        DeclaredSkillProgress declaredSkillProgress = buildDeclaredSkillProgress();
+        PagedResult<DeclaredSkillProgress> repositoryResult =
+            new PagedResult<>(List.of(declaredSkillProgress), new PageInfo(1, 8, 1));
 
         BddLogger.when("calling the method with a given student and no isValorized filter");
         when(declaredSkillProgressRepository.findAllByStudent(
@@ -105,15 +116,19 @@ public class DeclaredSkillProgressServiceImplTest {
                 criteria,
                 (Boolean) null,
                 new SortCriteria(ESortField.NAME, ESortOrder.ASC)))
-            .thenReturn(expected);
+            .thenReturn(repositoryResult);
 
-        PagedResult<DeclaredSkillProgress> result =
+        PagedResult<DeclaredSkillProgressData> result =
             declaredSkillProgressService.getDeclaredSkillsProgresses(criteria, null);
 
         BddLogger.then(
             "it should return the expected paged declared skill progress and delegate to"
                 + " repository");
-        assertThat(result).isSameAs(expected);
+        assertThat(result.pageInfo()).isSameAs(repositoryResult.pageInfo());
+        assertThat(result.content())
+            .containsExactly(
+                new DeclaredSkillProgressData(
+                    declaredSkillProgress, new DeclaredSkillAssociationCount(0, 0)));
         verify(declaredSkillProgressRepository)
             .findAllByStudent(
                 student,
@@ -126,18 +141,24 @@ public class DeclaredSkillProgressServiceImplTest {
       void getDeclaredSkillsProgresses_shouldDelegateIsValorizedFilterToRepository() {
         BddLogger.given("the method getDeclaredSkillsProgresses");
         PageCriteria criteria = new PageCriteria(1, 8);
-        PagedResult<DeclaredSkillProgress> expected = mock(PagedResult.class);
+        DeclaredSkillProgress declaredSkillProgress = buildDeclaredSkillProgress();
+        PagedResult<DeclaredSkillProgress> repositoryResult =
+            new PagedResult<>(List.of(declaredSkillProgress), new PageInfo(1, 8, 1));
 
         BddLogger.when("calling the method with a given student and isValorized=true");
         when(declaredSkillProgressRepository.findAllByStudent(
                 student, criteria, true, new SortCriteria(ESortField.NAME, ESortOrder.ASC)))
-            .thenReturn(expected);
+            .thenReturn(repositoryResult);
 
-        PagedResult<DeclaredSkillProgress> result =
+        PagedResult<DeclaredSkillProgressData> result =
             declaredSkillProgressService.getDeclaredSkillsProgresses(criteria, true);
 
         BddLogger.then("it should delegate the isValorized filter to the repository");
-        assertThat(result).isSameAs(expected);
+        assertThat(result.pageInfo()).isSameAs(repositoryResult.pageInfo());
+        assertThat(result.content())
+            .containsExactly(
+                new DeclaredSkillProgressData(
+                    declaredSkillProgress, new DeclaredSkillAssociationCount(0, 0)));
         verify(declaredSkillProgressRepository)
             .findAllByStudent(
                 student, criteria, true, new SortCriteria(ESortField.NAME, ESortOrder.ASC));


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a `DeclaredSkillAssociationCountDTO` (trace / declared-activity association counts) to `DeclaredSkillProgressDTO`, exposed via the `GET /me/declared/skill-progress` list endpoint. Introduces a `DeclaredSkillProgressData` domain wrapper (declared skill progress + association counts) returned by `getDeclaredSkillsProgresses`, and a new `AssociationService.countAllOf` that computes counts with grouped `COUNT` queries instead of fetching full association rows.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2235

---

### Documentation
> No documentation updates required; this only extends an existing DTO/endpoint response.

---

### Target Branch
> `develop`

---

### Additional Notes
> `countAllOf` is a new generic addition to the association module (port + JPA repository), reusable by other features needing per-subject association counts without loading full entities.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process