### PR TITLE
feat(2334): move external user config to back-office

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/client/ExternalUserClientImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/client/ExternalUserClientImpl.java
@@ -15,10 +15,10 @@ public class ExternalUserClientImpl implements ExternalUserClient {
 
   private final WebClient webClient;
 
-  @Value("${avenirs.interoperability.api-key}")
+  @Value("${avenirs.back-office.api-key}")
   private String apiKey;
 
-  @Value("${avenirs.interoperability.external-user.get-by-eppn}")
+  @Value("${avenirs.back-office.external-user.get-by-eppn}")
   private String getByEppnEndpoint;
 
   public ExternalUserClientImpl(WebClient webClient) {
@@ -47,7 +47,7 @@ public class ExternalUserClientImpl implements ExternalUserClient {
   @Override
   public void activateByEppn(String eppn) {
     try {
-      log.debug("Activating external user in interoperability for eppn {}", eppn);
+      log.debug("Activating external user in back-office for eppn {}", eppn);
 
       webClient
           .patch()
@@ -59,9 +59,7 @@ public class ExternalUserClientImpl implements ExternalUserClient {
 
     } catch (Exception e) {
       log.error(
-          "Failed to activate external user {} in interoperability. Error: {}",
-          eppn,
-          e.getMessage());
+          "Failed to activate external user {} in back-office. Error: {}", eppn, e.getMessage());
       log.debug("Full error details:", e);
       throw e;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -89,12 +89,12 @@ seeder.schema=dev
 avenirs.back-office.base-url=http://localhost:10010/back-office
 avenirs.back-office.trace.config.endpoint=${avenirs.back-office.base-url}/config/traces
 avenirs.back-office.institution.config.endpoint=${avenirs.back-office.base-url}/config/institution
+avenirs.back-office.external-user.endpoint=${avenirs.back-office.base-url}/external-users
+avenirs.back-office.external-user.get-by-eppn=${avenirs.back-office.external-user.endpoint}/eppn
 avenirs.back-office.api-key=ENC(tfNG7vGZMGuUCwfLTfcuIcRY6zp5yg3sHsUrG+3Ys7uEOGE+swRhezj4/jmWJzg4dmoGxH6RhMQ=)
 # Interoperability
 avenirs.interoperability.base-url=http://localhost:10020/interoperability
 avenirs.interoperability.external-skill.endpoint=${avenirs.interoperability.base-url}/external-skills
-avenirs.interoperability.external-user.endpoint=${avenirs.interoperability.base-url}/external-users
-avenirs.interoperability.external-user.get-by-eppn=${avenirs.interoperability.external-user.endpoint}/eppn
 avenirs.interoperability.api-key=ENC(tfNG7vGZMGuUCwfLTfcuIcRY6zp5yg3sHsUrG+3Ys7uEOGE+swRhezj4/jmWJzg4dmoGxH6RhMQ=)
 avenirs.interoperability.actuator.health=http://localhost:10020/actuator/health
 avenirs.microservice.dependency.behaviour=WAIT


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Moves the external user client configuration (API key and get-by-eppn endpoint) from the `avenirs.interoperability` namespace to `avenirs.back-office`, since external user lookups are now served by the back-office service instead of the interoperability service. Updates `ExternalUserClientImpl` property bindings and log messages accordingly, and bumps the `avenirs-portfolio-common` submodule reference.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2334

---

### Documentation
> No documentation updates needed beyond the `application.properties` config change itself.

---

### Target Branch
> `develop`

---

### Additional Notes
> Configuration keys `avenirs.interoperability.external-user.endpoint` and `avenirs.interoperability.external-user.get-by-eppn` are replaced by `avenirs.back-office.external-user.endpoint` and `avenirs.back-office.external-user.get-by-eppn`. The interoperability API key is still used for other interoperability calls (external skills), so it was left in place.

---

### Known Limitations or Side Effects
> Any external configuration/deployment referencing the old `avenirs.interoperability.external-user.*` properties will need to be updated to the new `avenirs.back-office.external-user.*` keys.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process