### PR TITLE
feat(2348): propagate institution and group ids to student/staff

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/model/Staff.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/model/Staff.java
@@ -5,6 +5,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.file.domain.model.File;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,6 +18,8 @@ public class Staff extends AvenirsBaseModel {
 
   private String bio;
   private String institutionEmail;
+  private UUID institutionId;
+  private UUID groupId;
   private boolean hasUnseenNotification;
 
   @Getter(AccessLevel.NONE)
@@ -28,6 +31,8 @@ public class Staff extends AvenirsBaseModel {
   private Staff(
       User user,
       String institutionEmail,
+      UUID institutionId,
+      UUID groupId,
       String bio,
       boolean hasUnseenNotification,
       File coverPicture,
@@ -38,18 +43,33 @@ public class Staff extends AvenirsBaseModel {
     this.user = user;
     this.bio = bio;
     this.institutionEmail = institutionEmail;
+    this.institutionId = institutionId;
+    this.groupId = groupId;
     this.hasUnseenNotification = hasUnseenNotification;
     this.coverPicture = coverPicture;
     this.profilePicture = profilePicture;
   }
 
-  public static Staff create(User user, String institutionEmail, String bio) {
-    return new Staff(user, institutionEmail, bio, false, null, null, Instant.now(), Instant.now());
+  public static Staff create(
+      User user, String institutionEmail, UUID institutionId, UUID groupId, String bio) {
+    return new Staff(
+        user,
+        institutionEmail,
+        institutionId,
+        groupId,
+        bio,
+        false,
+        null,
+        null,
+        Instant.now(),
+        Instant.now());
   }
 
   public static Staff toDomain(
       User user,
       String institutionEmail,
+      UUID institutionId,
+      UUID groupId,
       String bio,
       boolean hasUnseenNotification,
       File coverPicture,
@@ -59,6 +79,8 @@ public class Staff extends AvenirsBaseModel {
     return new Staff(
         user,
         institutionEmail,
+        institutionId,
+        groupId,
         bio,
         hasUnseenNotification,
         coverPicture,

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/model/Student.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/model/Student.java
@@ -5,6 +5,7 @@ import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.file.domain.model.File;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,6 +18,10 @@ public class Student extends AvenirsBaseModel {
 
   @Setter(AccessLevel.NONE)
   private String institutionEmail;
+
+  private UUID institutionId;
+
+  private UUID groupId;
 
   private String bio;
 
@@ -31,6 +36,8 @@ public class Student extends AvenirsBaseModel {
   private Student(
       User user,
       String institutionEmail,
+      UUID institutionId,
+      UUID groupId,
       String bio,
       boolean hasUnseenNotification,
       File coverPicture,
@@ -40,20 +47,34 @@ public class Student extends AvenirsBaseModel {
     super(user.getId(), createdAt, updatedAt);
     this.user = user;
     this.institutionEmail = institutionEmail;
+    this.institutionId = institutionId;
+    this.groupId = groupId;
     this.bio = bio;
     this.hasUnseenNotification = hasUnseenNotification;
     this.coverPicture = coverPicture;
     this.profilePicture = profilePicture;
   }
 
-  public static Student create(User user, String institutionEmail, String bio) {
+  public static Student create(
+      User user, String institutionEmail, UUID institutionId, UUID groupId, String bio) {
     return new Student(
-        user, institutionEmail, bio, false, null, null, Instant.now(), Instant.now());
+        user,
+        institutionEmail,
+        institutionId,
+        groupId,
+        bio,
+        false,
+        null,
+        null,
+        Instant.now(),
+        Instant.now());
   }
 
   public static Student toDomain(
       User user,
       String institutionEmail,
+      UUID institutionId,
+      UUID groupId,
       String bio,
       boolean hasUnseenNotification,
       File coverPicture,
@@ -63,6 +84,8 @@ public class Student extends AvenirsBaseModel {
     return new Student(
         user,
         institutionEmail,
+        institutionId,
+        groupId,
         bio,
         hasUnseenNotification,
         coverPicture,

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/port/input/StaffService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/port/input/StaffService.java
@@ -13,7 +13,8 @@ public interface StaffService {
 
   void updateProfile(User user, String bio);
 
-  Staff createStaff(UUID userId, String institutionEmail, String bio);
+  Staff createStaff(
+      UUID userId, String institutionEmail, UUID institutionId, UUID groupId, String bio);
 
   File uploadProfilePicture(String fileName, String mimeType, long size, byte[] content);
 

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/port/input/StudentService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/port/input/StudentService.java
@@ -15,7 +15,8 @@ public interface StudentService {
 
   void updateProfile(User user, String bio);
 
-  Student createStudent(UUID userId, String institutionEmail, String bio);
+  Student createStudent(
+      UUID userId, String institutionEmail, UUID institutionId, UUID groupId, String bio);
 
   void addSelfKnowledgeCategories(Student student, List<SelfKnowledgeCategory> categories);
 

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImpl.java
@@ -64,9 +64,10 @@ public class StaffServiceImpl implements StaffService {
   }
 
   @Override
-  public Staff createStaff(UUID userId, String institutionEmail, String bio) {
+  public Staff createStaff(
+      UUID userId, String institutionEmail, UUID institutionId, UUID groupId, String bio) {
     var user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-    var staff = Staff.create(user, institutionEmail, bio);
+    var staff = Staff.create(user, institutionEmail, institutionId, groupId, bio);
     staffRepository.save(staff);
     if (user.getEmail() == null) {
       user.setEmail(institutionEmail);

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StudentServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/StudentServiceImpl.java
@@ -69,9 +69,10 @@ public class StudentServiceImpl implements StudentService {
   }
 
   @Override
-  public Student createStudent(UUID userId, String institutionEmail, String bio) {
+  public Student createStudent(
+      UUID userId, String institutionEmail, UUID institutionId, UUID groupId, String bio) {
     var user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-    var student = Student.create(user, institutionEmail, bio);
+    var student = Student.create(user, institutionEmail, institutionId, groupId, bio);
     if (user.getEmail() == null) {
       user.setEmail(institutionEmail);
       userRepository.save(user);

--- a/src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImpl.java
@@ -165,8 +165,20 @@ public class UserServiceImpl implements UserService {
             externalUser.eppn());
 
     switch (externalUser.category()) {
-      case STUDENT -> studentService.createStudent(user.getId(), externalUser.email(), null);
-      case STAFF -> staffService.createStaff(user.getId(), externalUser.email(), null);
+      case STUDENT ->
+          studentService.createStudent(
+              user.getId(),
+              externalUser.email(),
+              externalUser.institutionId(),
+              externalUser.groupId(),
+              null);
+      case STAFF ->
+          staffService.createStaff(
+              user.getId(),
+              externalUser.email(),
+              externalUser.institutionId(),
+              externalUser.groupId(),
+              null);
     }
 
     externalUserClient.activateByEppn(externalUser.eppn());

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/StaffMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/StaffMapper.java
@@ -13,6 +13,8 @@ public class StaffMapper implements Mapper<StaffEntity, Staff> {
     return StaffEntity.of(
         UserMapper.INSTANCE.fromDomain(staff.getUser()),
         staff.getInstitutionEmail(),
+        staff.getInstitutionId(),
+        staff.getGroupId(),
         staff.getBio(),
         staff.isHasUnseenNotification(),
         staff.getCoverPicture().map(FileMapper.INSTANCE::fromDomain).orElse(null),
@@ -26,6 +28,8 @@ public class StaffMapper implements Mapper<StaffEntity, Staff> {
     return Staff.toDomain(
         UserMapper.INSTANCE.toDomain(staffEntity.getUser()),
         staffEntity.getInstitutionEmail(),
+        staffEntity.getInstitutionId(),
+        staffEntity.getGroupId(),
         staffEntity.getBio(),
         staffEntity.isHasUnseenNotification(),
         staffEntity.getCoverPicture() == null

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/StudentMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/mapper/StudentMapper.java
@@ -14,6 +14,8 @@ public class StudentMapper implements Mapper<StudentEntity, Student> {
     return StudentEntity.of(
         UserMapper.INSTANCE.fromDomain(student.getUser()),
         student.getInstitutionEmail(),
+        student.getInstitutionId(),
+        student.getGroupId(),
         student.getBio(),
         student.isHasUnseenNotification(),
         student.getCoverPicture().map(FileMapper.INSTANCE::fromDomain).orElse(null),
@@ -27,6 +29,8 @@ public class StudentMapper implements Mapper<StudentEntity, Student> {
     return Student.toDomain(
         UserMapper.INSTANCE.toDomain(studentEntity.getUser()),
         studentEntity.getInstitutionEmail(),
+        studentEntity.getInstitutionId(),
+        studentEntity.getGroupId(),
         studentEntity.getBio(),
         studentEntity.isHasUnseenNotification(),
         studentEntity.getCoverPicture() == null
@@ -45,6 +49,8 @@ public class StudentMapper implements Mapper<StudentEntity, Student> {
     return Student.toDomain(
         attributes.contains("user") ? UserMapper.INSTANCE.toDomain(studentEntity.getUser()) : null,
         studentEntity.getInstitutionEmail(),
+        studentEntity.getInstitutionId(),
+        studentEntity.getGroupId(),
         studentEntity.getBio(),
         studentEntity.isHasUnseenNotification(),
         studentEntity.getCoverPicture() == null || !attributes.contains("coverPicture")

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/model/StaffEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/model/StaffEntity.java
@@ -27,6 +27,12 @@ public class StaffEntity extends AvenirsBaseEntity {
   @Column(nullable = false, name = "institution_email")
   private String institutionEmail;
 
+  @Column(name = "institution_id")
+  private UUID institutionId;
+
+  @Column(name = "group_id")
+  private UUID groupId;
+
   @Column(name = "has_unseen_notification", nullable = false)
   private boolean hasUnseenNotification;
 
@@ -42,6 +48,8 @@ public class StaffEntity extends AvenirsBaseEntity {
       UUID id,
       UserEntity user,
       String institutionEmail,
+      UUID institutionId,
+      UUID groupId,
       String bio,
       boolean hasUnseenNotification,
       FileEntity coverPicture,
@@ -52,6 +60,8 @@ public class StaffEntity extends AvenirsBaseEntity {
     this.user = user;
     this.bio = bio;
     this.institutionEmail = institutionEmail;
+    this.institutionId = institutionId;
+    this.groupId = groupId;
     this.hasUnseenNotification = hasUnseenNotification;
     this.coverPicture = coverPicture;
     this.profilePicture = profilePicture;
@@ -62,6 +72,8 @@ public class StaffEntity extends AvenirsBaseEntity {
   public static StaffEntity of(
       UserEntity user,
       String institutionEmail,
+      UUID institutionId,
+      UUID groupId,
       String bio,
       boolean hasUnseenNotification,
       FileEntity coverPicture,
@@ -72,6 +84,8 @@ public class StaffEntity extends AvenirsBaseEntity {
         user.getId(),
         user,
         institutionEmail,
+        institutionId,
+        groupId,
         bio,
         hasUnseenNotification,
         coverPicture,

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/model/StudentEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/model/StudentEntity.java
@@ -27,6 +27,12 @@ public class StudentEntity extends AvenirsBaseEntity {
   @Column(nullable = false, name = "institution_email")
   private String institutionEmail;
 
+  @Column(name = "institution_id")
+  private UUID institutionId;
+
+  @Column(name = "group_id")
+  private UUID groupId;
+
   @Column(length = BIO_LENGTH)
   private String bio;
 
@@ -52,6 +58,8 @@ public class StudentEntity extends AvenirsBaseEntity {
       UUID id,
       UserEntity user,
       String institutionEmail,
+      UUID institutionId,
+      UUID groupId,
       String bio,
       boolean hasUnseenNotification,
       FileEntity coverPicture,
@@ -62,6 +70,8 @@ public class StudentEntity extends AvenirsBaseEntity {
     this.user = user;
     this.bio = bio;
     this.institutionEmail = institutionEmail;
+    this.institutionId = institutionId;
+    this.groupId = groupId;
     this.hasUnseenNotification = hasUnseenNotification;
     this.coverPicture = coverPicture;
     this.profilePicture = profilePicture;
@@ -72,6 +82,8 @@ public class StudentEntity extends AvenirsBaseEntity {
   public static StudentEntity of(
       UserEntity user,
       String institutionEmail,
+      UUID institutionId,
+      UUID groupId,
       String bio,
       boolean hasUnseenNotification,
       FileEntity coverPicture,
@@ -82,6 +94,8 @@ public class StudentEntity extends AvenirsBaseEntity {
         user.getId(),
         user,
         institutionEmail,
+        institutionId,
+        groupId,
         bio,
         hasUnseenNotification,
         coverPicture,

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/StaffSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/StaffSeeder.java
@@ -52,14 +52,22 @@ public class StaffSeeder {
                           new StaffCreationData(
                               fakeStaff.getUser().getId(),
                               fakeStaff.getInstitutionEmail(),
-                              fakeStaff.getBio()))
+                              fakeStaff.getBio(),
+                              fakeStaff.getInstitutionId(),
+                              fakeStaff.getGroupId()))
                   .toList();
         };
 
     List<Staff> staffs = new ArrayList<>();
     creationData.forEach(
         data -> {
-          var staff = staffService.createStaff(data.userId(), data.institutionEmail(), data.bio());
+          var staff =
+              staffService.createStaff(
+                  data.userId(),
+                  data.institutionEmail(),
+                  data.institutionId(),
+                  data.groupId(),
+                  data.bio());
           staffs.add(staff);
         });
 

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/StudentSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/StudentSeeder.java
@@ -59,7 +59,9 @@ public class StudentSeeder {
                           new StudentCreationData(
                               fakeStudent.getUser().getId(),
                               fakeStudent.getBio(),
-                              fakeStudent.getInstitutionEmail()))
+                              fakeStudent.getInstitutionEmail(),
+                              fakeStudent.getInstitutionId(),
+                              fakeStudent.getGroupId()))
                   .toList();
         };
 
@@ -67,7 +69,12 @@ public class StudentSeeder {
     creationData.forEach(
         data -> {
           var student =
-              studentService.createStudent(data.userId(), data.institutionEmail(), data.bio());
+              studentService.createStudent(
+                  data.userId(),
+                  data.institutionEmail(),
+                  data.institutionId(),
+                  data.groupId(),
+                  data.bio());
           students.add(student);
         });
 

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/data/StaffCreationData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/data/StaffCreationData.java
@@ -2,4 +2,5 @@ package fr.avenirsesr.portfolio.user.infrastructure.adapter.seeder.data;
 
 import java.util.UUID;
 
-public record StaffCreationData(UUID userId, String bio, String institutionEmail) {}
+public record StaffCreationData(
+    UUID userId, String bio, String institutionEmail, UUID institutionId, UUID groupId) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/data/StudentCreationData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/data/StudentCreationData.java
@@ -2,4 +2,5 @@ package fr.avenirsesr.portfolio.user.infrastructure.adapter.seeder.data;
 
 import java.util.UUID;
 
-public record StudentCreationData(UUID userId, String bio, String institutionEmail) {}
+public record StudentCreationData(
+    UUID userId, String bio, String institutionEmail, UUID institutionId, UUID groupId) {}

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/fake/FakeStaff.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/fake/FakeStaff.java
@@ -15,7 +15,16 @@ public class FakeStaff {
   public static FakeStaff create(UserEntity user) {
     return new FakeStaff(
         StaffEntity.of(
-            user, user.getEmail(), "fake bio", false, null, null, Instant.now(), Instant.now()));
+            user,
+            user.getEmail(),
+            null,
+            null,
+            "fake bio",
+            false,
+            null,
+            null,
+            Instant.now(),
+            Instant.now()));
   }
 
   public FakeStaff withBio(String bio) {

--- a/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/fake/FakeStudent.java
+++ b/src/main/java/fr/avenirsesr/portfolio/user/infrastructure/adapter/seeder/fake/FakeStudent.java
@@ -25,6 +25,8 @@ public class FakeStudent {
         StudentEntity.of(
             user,
             userDataGenerator.with("student-email").email(),
+            null,
+            null,
             studentDataGenerator.with("student-bio").studentDescription(),
             false,
             null,

--- a/src/main/resources/db/changelog/generated/changelog_2026-07-30__add-institution-and-group-to-student-and-staff.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-07-30__add-institution-and-group-to-student-and-staff.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="iamgreendev (generated)" id="1785405600000-1">
+        <addColumn tableName="student">
+            <column name="institution_id" type="UUID"/>
+            <column name="group_id" type="UUID"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="iamgreendev (generated)" id="1785405600000-2">
+        <addColumn tableName="staff">
+            <column name="institution_id" type="UUID"/>
+            <column name="group_id" type="UUID"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityOverviewDtoMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/activity/application/adapter/mapper/ActivityOverviewDtoMapperTest.java
@@ -37,7 +37,7 @@ class ActivityOverviewDtoMapperTest {
             .withFirstName("firstname")
             .withLastName("Lastname")
             .toModel();
-    var staff = Staff.create(user, "staff@email.com", "bio");
+    var staff = Staff.create(user, "staff@email.com", null, null, "bio");
     Activity activity = ActivityFixture.create().withAuthor(staff).toModel();
     ActivityWithStudentStatusData data =
         new ActivityWithStudentStatusData(activity, true, EDeclaredActivityStatus.SUBSCRIBED);

--- a/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
@@ -208,7 +208,16 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
   private StudentEntity persistStudent(UserEntity u) {
     StudentEntity s =
         StudentEntity.of(
-            u, "student@univ.com", "student", false, null, null, Instant.now(), Instant.now());
+            u,
+            "student@univ.com",
+            null,
+            null,
+            "student",
+            false,
+            null,
+            null,
+            Instant.now(),
+            Instant.now());
     entityManager.persist(s);
     return s;
   }

--- a/src/test/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/domain/service/StaffServiceImplTest.java
@@ -51,6 +51,8 @@ class StaffServiceImplTest {
           Staff.toDomain(
               user,
               "marie@university.com",
+              null,
+              null,
               "My staff bio",
               false,
               null,

--- a/src/test/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/domain/service/UserServiceImplTest.java
@@ -140,7 +140,13 @@ class UserServiceImplTest {
       verify(userPrincipalRepository).saveOrUpdate(savedUser, eppn);
 
       BddLogger.then("it should create the student profile");
-      verify(studentService).createStudent(savedUser.getId(), externalUser.email(), null);
+      verify(studentService)
+          .createStudent(
+              savedUser.getId(),
+              externalUser.email(),
+              externalUser.institutionId(),
+              externalUser.groupId(),
+              null);
       verifyNoInteractions(staffService);
 
       BddLogger.then("it should activate the external user");
@@ -169,7 +175,13 @@ class UserServiceImplTest {
       assertEquals(savedUser, result);
 
       BddLogger.then("it should create the staff profile");
-      verify(staffService).createStaff(savedUser.getId(), externalUser.email(), null);
+      verify(staffService)
+          .createStaff(
+              savedUser.getId(),
+              externalUser.email(),
+              externalUser.institutionId(),
+              externalUser.groupId(),
+              null);
       verifyNoInteractions(studentService);
 
       BddLogger.then("it should activate the external user");
@@ -477,6 +489,16 @@ class UserServiceImplTest {
   }
 
   private ExternalUserDTO externalUser(EUserCategory category, EUserStatus status, String eppn) {
-    return new ExternalUserDTO(eppn, "Lucas", "Tessier", eppn, category, eppn, "PEGASE", status);
+    return new ExternalUserDTO(
+        eppn,
+        "Lucas",
+        "Tessier",
+        eppn,
+        category,
+        eppn,
+        "PEGASE",
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        status);
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/user/infrastructure/fixture/StaffFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/infrastructure/fixture/StaffFixture.java
@@ -10,6 +10,8 @@ public class StaffFixture {
   private UUID id;
   private String bio;
   private User user;
+  private UUID institutionId;
+  private UUID groupId;
   private File profilePicture;
   private File coverPicture;
   private boolean hasUnseenNotification;
@@ -60,10 +62,22 @@ public class StaffFixture {
     return this;
   }
 
+  public StaffFixture withInstitutionId(UUID institutionId) {
+    this.institutionId = institutionId;
+    return this;
+  }
+
+  public StaffFixture withGroupId(UUID groupId) {
+    this.groupId = groupId;
+    return this;
+  }
+
   public Staff toModel() {
     return Staff.toDomain(
         user,
         user.getEmail(),
+        institutionId,
+        groupId,
         bio,
         hasUnseenNotification,
         coverPicture,

--- a/src/test/java/fr/avenirsesr/portfolio/user/infrastructure/fixture/StudentFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/user/infrastructure/fixture/StudentFixture.java
@@ -10,6 +10,8 @@ public class StudentFixture {
   private UUID id;
   private String bio;
   private User user;
+  private UUID institutionId;
+  private UUID groupId;
   private File profilePicture;
   private File coverPicture;
   private boolean hasUnseenNotification;
@@ -60,10 +62,22 @@ public class StudentFixture {
     return this;
   }
 
+  public StudentFixture withInstitutionId(UUID institutionId) {
+    this.institutionId = institutionId;
+    return this;
+  }
+
+  public StudentFixture withGroupId(UUID groupId) {
+    this.groupId = groupId;
+    return this;
+  }
+
   public Student toModel() {
     return Student.toDomain(
         user,
         user.getEmail(),
+        institutionId,
+        groupId,
         bio,
         hasUnseenNotification,
         coverPicture,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> `UserServiceImpl.createUserFromExternalUser` now passes the `institutionId`/`groupId` carried by the shared `ExternalUserDTO` through to `StudentService.createStudent`/`StaffService.createStaff`. Both `Student`/`Staff` domain models and their JPA entities (`StudentEntity`/`StaffEntity`) gain nullable `institutionId`/`groupId` UUID columns, threaded through the mappers, seeders (`StudentSeeder`/`StaffSeeder`, `StudentCreationData`/`StaffCreationData`, `FakeStudent`/`FakeStaff`) and test fixtures (`StudentFixture`/`StaffFixture`).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2348
>
> Depends on https://github.com/avenirs-esr/avenirs-portfolio-common/pull/82 (adds the two fields to `ExternalUserDTO`) and pairs with https://github.com/avenirs-esr/avenirs-portfolio-back-office/pull/22 (adds the same linkage to `ExternalUser` in back-office).

---

### Documentation
> New Liquibase changelog `changelog_2026-07-30__add-institution-and-group-to-student-and-staff.xml` adds nullable `institution_id`/`group_id` UUID columns to both `student` and `staff` tables.

---

### Target Branch
> `develop`

---

### Additional Notes
> `institutionId`/`groupId` are stored as plain nullable UUID columns (no local FK entity to validate against in this service, mirroring the existing `institutionEmail` column precedent) rather than JPA relations.

---

### Known Limitations or Side Effects
> None.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process