### PR TITLE
feat(2237): add experienceType query param to declared experience view

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
@@ -15,6 +15,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.experience.application.
 import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.dto.DeclaredExperienceViewDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.mapper.DeclaredExperienceMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.port.input.DeclaredExperienceService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -70,9 +71,13 @@ public class DeclaredExperienceController {
   public ResponseEntity<PagedResponse<DeclaredExperienceViewDTO>> getDeclaredExperienceView(
       @RequestParam(required = false) Integer page,
       @RequestParam(required = false) Integer pageSize,
-      @RequestParam(required = false) Boolean isValorized) {
+      @RequestParam(required = false) Boolean isValorized,
+      @Parameter(schema = @Schema(ref = "#/components/schemas/EExperienceType"))
+          @RequestParam(required = false)
+          EExperienceType experienceType) {
     PagedResult<DeclaredExperience> pagedExperiences =
-        declaredExperienceService.getView(new PageCriteria(page, pageSize), isValorized);
+        declaredExperienceService.getView(
+            new PageCriteria(page, pageSize), isValorized, experienceType);
 
     return ResponseEntity.ok(
         new PagedResponse<>(

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
@@ -73,7 +73,8 @@ public interface DeclaredExperienceService {
 
   DeclaredExperience get(UUID experienceId);
 
-  PagedResult<DeclaredExperience> getView(PageCriteria pageCriteria, Boolean isValorized);
+  PagedResult<DeclaredExperience> getView(
+      PageCriteria pageCriteria, Boolean isValorized, EExperienceType experienceType);
 
   List<DeclaredExperience> findAllByIds(List<UUID> experienceIds);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/output/repository/DeclaredExperienceRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/output/repository/DeclaredExperienceRepository.java
@@ -4,11 +4,15 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.port.output.repository.GenericRepositoryPort;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 
 public interface DeclaredExperienceRepository extends GenericRepositoryPort<DeclaredExperience> {
   PagedResult<DeclaredExperience> findAllByStudent(
-      Student student, PageCriteria pageCriteria, Boolean isValorized);
+      Student student,
+      PageCriteria pageCriteria,
+      Boolean isValorized,
+      EExperienceType experienceType);
 
   PagedResult<DeclaredExperience> findAllByStudent(
       Student student, PageCriteria pageCriteria, String keyword);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
@@ -313,11 +313,13 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
   }
 
   @Override
-  public PagedResult<DeclaredExperience> getView(PageCriteria pageCriteria, Boolean isValorized) {
+  public PagedResult<DeclaredExperience> getView(
+      PageCriteria pageCriteria, Boolean isValorized, EExperienceType experienceType) {
     Student student = loggedInUserService.getLoggedInStudent();
     log.info("Get experience view by {}", student);
 
-    return experienceRepository.findAllByStudent(student, pageCriteria, isValorized);
+    return experienceRepository.findAllByStudent(
+        student, pageCriteria, isValorized, experienceType);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/repository/DeclaredExperienceDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/repository/DeclaredExperienceDatabaseRepository.java
@@ -3,6 +3,7 @@ package fr.avenirsesr.portfolio.student.progress.declared.experience.infrastruct
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.port.output.repository.DeclaredExperienceRepository;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructure.adapter.mapper.DeclaredExperienceMapper;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructure.adapter.model.DeclaredExperienceEntity;
@@ -27,11 +28,15 @@ public class DeclaredExperienceDatabaseRepository
 
   @Override
   public PagedResult<DeclaredExperience> findAllByStudent(
-      Student student, PageCriteria pageCriteria, Boolean isValorized) {
+      Student student,
+      PageCriteria pageCriteria,
+      Boolean isValorized,
+      EExperienceType experienceType) {
     return findAll(
         hasStudent(student)
             .and(DeclaredExperienceSpecification.ordered())
-            .and(DeclaredExperienceSpecification.isValorized(isValorized)),
+            .and(DeclaredExperienceSpecification.isValorized(isValorized))
+            .and(DeclaredExperienceSpecification.hasExperienceType(experienceType)),
         PageRequest.of(pageCriteria.page(), pageCriteria.pageSize()));
   }
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/specification/DeclaredExperienceSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/infrastructure/adapter/specification/DeclaredExperienceSpecification.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructure.adapter.specification;
 
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.infrastructure.adapter.model.DeclaredExperienceEntity;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Order;
@@ -45,6 +46,16 @@ public class DeclaredExperienceSpecification {
         return criteriaBuilder.conjunction();
       }
       return criteriaBuilder.equal(root.get("valorized"), isValorized);
+    };
+  }
+
+  public static Specification<DeclaredExperienceEntity> hasExperienceType(
+      EExperienceType experienceType) {
+    return (root, query, criteriaBuilder) -> {
+      if (experienceType == null) {
+        return criteriaBuilder.conjunction();
+      }
+      return criteriaBuilder.equal(root.get("experienceType"), experienceType);
     };
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -514,6 +514,7 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
                     uriBuilder
                         .path(BASE_PATH + "/view")
                         .queryParam("experienceType", "PROFESSIONAL")
+                        .queryParam("pageSize", 100)
                         .build())
             .header("X-Signed-Context", studentPayload)
             .header("X-Context-Kid", secretKey)
@@ -543,6 +544,7 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
                     uriBuilder
                         .path(BASE_PATH + "/view")
                         .queryParam("experienceType", "PERSONAL")
+                        .queryParam("pageSize", 100)
                         .build())
             .header("X-Signed-Context", studentPayload)
             .header("X-Context-Kid", secretKey)

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -67,6 +67,24 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
         + "}\n";
   }
 
+  private String buildCreateExperienceJson(String experienceType) {
+    return "{\n"
+        + "  \"title\": \"My Experience\",\n"
+        + "  \"experienceType\": \""
+        + experienceType
+        + "\",\n"
+        + "  \"organization\": \"ACME Inc\",\n"
+        + "  \"activitySector\": \"IT\",\n"
+        + "  \"location\": \"Paris\",\n"
+        + "  \"description\": \"Some description\",\n"
+        + "  \"sourceOfInformation\": \"SELF_DECLARED\",\n"
+        + "  \"summary\": \"Summary text\",\n"
+        + "  \"externalLink\": \"https://example.com\",\n"
+        + "  \"startDate\": \"2024-01-01\",\n"
+        + "  \"endDate\": \"2024-03-01\"\n"
+        + "}\n";
+  }
+
   private String extractIdFromResponse(String responseBody) throws Exception {
     JsonNode jsonNode = objectMapper.readTree(responseBody);
     return jsonNode.get("id").asText();
@@ -445,6 +463,104 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
         .get("data")
         .forEach(node -> nonValorizedIds.add(node.get("id").asText()));
     assertThat(nonValorizedIds).doesNotContain(createdId);
+  }
+
+  @Transactional
+  @Test
+  void shouldFilterDeclaredExperienceViewByExperienceType() throws Exception {
+    BddLogger.given("a professional declared experience and a personal declared experience");
+
+    String professionalResponse =
+        webTestClient
+            .post()
+            .uri(BASE_PATH + "/")
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(buildCreateExperienceJson("PROFESSIONAL"))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+    String professionalId = extractIdFromResponse(professionalResponse);
+
+    String personalResponse =
+        webTestClient
+            .post()
+            .uri(BASE_PATH + "/")
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(buildCreateExperienceJson("PERSONAL"))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+    String personalId = extractIdFromResponse(personalResponse);
+
+    BddLogger.when("performing a GET on /view with experienceType=PROFESSIONAL");
+
+    String professionalOnlyResponse =
+        webTestClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder
+                        .path(BASE_PATH + "/view")
+                        .queryParam("experienceType", "PROFESSIONAL")
+                        .build())
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    BddLogger.then("it should only contain the professional declared experience");
+    List<String> professionalIds = new ArrayList<>();
+    objectMapper
+        .readTree(professionalOnlyResponse)
+        .get("data")
+        .forEach(node -> professionalIds.add(node.get("id").asText()));
+    assertThat(professionalIds).contains(professionalId).doesNotContain(personalId);
+
+    BddLogger.when("performing a GET on /view with experienceType=PERSONAL");
+
+    String personalOnlyResponse =
+        webTestClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder
+                        .path(BASE_PATH + "/view")
+                        .queryParam("experienceType", "PERSONAL")
+                        .build())
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    BddLogger.then("it should only contain the personal declared experience");
+    List<String> personalIds = new ArrayList<>();
+    objectMapper
+        .readTree(personalOnlyResponse)
+        .get("data")
+        .forEach(node -> personalIds.add(node.get("id").asText()));
+    assertThat(personalIds).contains(personalId).doesNotContain(professionalId);
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
@@ -1019,13 +1019,13 @@ class DeclaredExperienceServiceImplTest {
     PagedResult<DeclaredExperience> expected = mock(PagedResult.class);
 
     when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
-    when(experienceRepository.findAllByStudent(loggedIn, criteria, (Boolean) null))
+    when(experienceRepository.findAllByStudent(loggedIn, criteria, null, null))
         .thenReturn(expected);
 
-    PagedResult<DeclaredExperience> result = service.getView(criteria, null);
+    PagedResult<DeclaredExperience> result = service.getView(criteria, null, null);
 
     assertSame(expected, result);
-    verify(experienceRepository).findAllByStudent(loggedIn, criteria, (Boolean) null);
+    verify(experienceRepository).findAllByStudent(loggedIn, criteria, null, null);
   }
 
   @Test
@@ -1035,12 +1035,32 @@ class DeclaredExperienceServiceImplTest {
     PagedResult<DeclaredExperience> expected = mock(PagedResult.class);
 
     when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
-    when(experienceRepository.findAllByStudent(loggedIn, criteria, true)).thenReturn(expected);
+    when(experienceRepository.findAllByStudent(loggedIn, criteria, true, null))
+        .thenReturn(expected);
 
-    PagedResult<DeclaredExperience> result = service.getView(criteria, true);
+    PagedResult<DeclaredExperience> result = service.getView(criteria, true, null);
 
     assertSame(expected, result);
-    verify(experienceRepository).findAllByStudent(loggedIn, criteria, true);
+    verify(experienceRepository).findAllByStudent(loggedIn, criteria, true, null);
+  }
+
+  @Test
+  void getView_shouldDelegateExperienceTypeFilterToRepository() {
+    Student loggedIn = student;
+    PageCriteria criteria = new PageCriteria(1, 8);
+    PagedResult<DeclaredExperience> expected = mock(PagedResult.class);
+
+    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
+    when(experienceRepository.findAllByStudent(
+            loggedIn, criteria, null, EExperienceType.PROFESSIONAL))
+        .thenReturn(expected);
+
+    PagedResult<DeclaredExperience> result =
+        service.getView(criteria, null, EExperienceType.PROFESSIONAL);
+
+    assertSame(expected, result);
+    verify(experienceRepository)
+        .findAllByStudent(loggedIn, criteria, null, EExperienceType.PROFESSIONAL);
   }
 
   @Test


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds an optional `experienceType` query parameter to the `GET /me/declared/experiences/view` endpoint, allowing declared experiences to be filtered by their `EExperienceType` (PERSONAL / PROFESSIONAL) via a JPA Specification, following the same pattern already used for `isValorized` filtering.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2237

---

### Documentation
> No documentation updates needed; the `EExperienceType` OpenAPI schema was already registered for this endpoint's Swagger UI.

---

### Target Branch
> `develop`

---

### Additional Notes
> Added `DeclaredExperienceSpecification.hasExperienceType(...)`, threaded through the repository port/adapter and service layer (`getView`), and added the query param with `@Parameter`/`@Schema` annotations referencing the existing `EExperienceType` schema component.

---

### Known Limitations or Side Effects
> None identified.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process