### PR TITLE
feat(2236): add declaredExperienceAssociationCountDTO to declared experience view

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceController.java
@@ -14,6 +14,7 @@ import fr.avenirsesr.portfolio.student.progress.declared.experience.application.
 import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.dto.DeclaredExperienceRequest;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.dto.DeclaredExperienceViewDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.mapper.DeclaredExperienceMapper;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceData;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.port.input.DeclaredExperienceService;
@@ -75,7 +76,7 @@ public class DeclaredExperienceController {
       @Parameter(schema = @Schema(ref = "#/components/schemas/EExperienceType"))
           @RequestParam(required = false)
           EExperienceType experienceType) {
-    PagedResult<DeclaredExperience> pagedExperiences =
+    PagedResult<DeclaredExperienceData> pagedExperiences =
         declaredExperienceService.getView(
             new PageCriteria(page, pageSize), isValorized, experienceType);
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceAssociationCountDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceAssociationCountDTO.java
@@ -1,0 +1,7 @@
+package fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(requiredProperties = {"traceAssociationsCount", "declaredSkillAssociationsCount"})
+public record DeclaredExperienceAssociationCountDTO(
+    int traceAssociationsCount, int declaredSkillAssociationsCount) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceViewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/dto/DeclaredExperienceViewDTO.java
@@ -6,7 +6,16 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
-@Schema(requiredProperties = {"id", "title", "organization", "startDate", "createdAt", "updatedAt"})
+@Schema(
+    requiredProperties = {
+      "id",
+      "title",
+      "organization",
+      "startDate",
+      "createdAt",
+      "updatedAt",
+      "declaredExperienceAssociationCountDTO"
+    })
 public record DeclaredExperienceViewDTO(
     UUID id,
     String title,
@@ -22,4 +31,5 @@ public record DeclaredExperienceViewDTO(
     LocalDate endDate,
     boolean valorized,
     Instant createdAt,
-    Instant updatedAt) {}
+    Instant updatedAt,
+    DeclaredExperienceAssociationCountDTO declaredExperienceAssociationCountDTO) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/mapper/DeclaredExperienceMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/mapper/DeclaredExperienceMapper.java
@@ -1,12 +1,16 @@
 package fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.mapper;
 
+import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.dto.DeclaredExperienceAssociationCountDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.dto.DeclaredExperienceAssociationsDTO;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.dto.DeclaredExperienceViewDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceAssociationCount;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceAssociationsData;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceData;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
 import fr.avenirsesr.portfolio.student.progress.declared.skill.application.adapter.mapper.DeclaredSkillProgressMapper;
 import fr.avenirsesr.portfolio.trace.application.adapter.mapper.TraceOverviewMapper;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(
     componentModel = "spring",
@@ -14,6 +18,27 @@ import org.mapstruct.Mapper;
 public interface DeclaredExperienceMapper {
 
   DeclaredExperienceViewDTO toDTO(DeclaredExperience experience);
+
+  @Mapping(source = "declaredExperience.id", target = "id")
+  @Mapping(source = "declaredExperience.title", target = "title")
+  @Mapping(source = "declaredExperience.experienceType", target = "experienceType")
+  @Mapping(source = "declaredExperience.organization", target = "organization")
+  @Mapping(source = "declaredExperience.activitySector", target = "activitySector")
+  @Mapping(source = "declaredExperience.location", target = "location")
+  @Mapping(source = "declaredExperience.description", target = "description")
+  @Mapping(source = "declaredExperience.sourceOfInformation", target = "sourceOfInformation")
+  @Mapping(source = "declaredExperience.summary", target = "summary")
+  @Mapping(source = "declaredExperience.externalLink", target = "externalLink")
+  @Mapping(source = "declaredExperience.startDate", target = "startDate")
+  @Mapping(source = "declaredExperience.endDate", target = "endDate")
+  @Mapping(source = "declaredExperience.valorized", target = "valorized")
+  @Mapping(source = "declaredExperience.createdAt", target = "createdAt")
+  @Mapping(source = "declaredExperience.updatedAt", target = "updatedAt")
+  @Mapping(source = "associationsCount", target = "declaredExperienceAssociationCountDTO")
+  DeclaredExperienceViewDTO toDTO(DeclaredExperienceData declaredExperienceData);
+
+  DeclaredExperienceAssociationCountDTO toAssociationCountDTO(
+      DeclaredExperienceAssociationCount associationsCount);
 
   DeclaredExperienceAssociationsDTO toAssociationsDTO(
       DeclaredExperienceAssociationsData declaredExperienceAssociations);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/data/DeclaredExperienceAssociationCount.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/data/DeclaredExperienceAssociationCount.java
@@ -1,0 +1,4 @@
+package fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data;
+
+public record DeclaredExperienceAssociationCount(
+    int traceAssociationsCount, int declaredSkillAssociationsCount) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/data/DeclaredExperienceData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/data/DeclaredExperienceData.java
@@ -1,0 +1,6 @@
+package fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data;
+
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
+
+public record DeclaredExperienceData(
+    DeclaredExperience declaredExperience, DeclaredExperienceAssociationCount associationsCount) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/port/input/DeclaredExperienceService.java
@@ -5,6 +5,7 @@ import fr.avenirsesr.portfolio.association.domain.model.EAssociationContextType;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceAssociationsData;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceData;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import java.time.LocalDate;
@@ -73,7 +74,7 @@ public interface DeclaredExperienceService {
 
   DeclaredExperience get(UUID experienceId);
 
-  PagedResult<DeclaredExperience> getView(
+  PagedResult<DeclaredExperienceData> getView(
       PageCriteria pageCriteria, Boolean isValorized, EExperienceType experienceType);
 
   List<DeclaredExperience> findAllByIds(List<UUID> experienceIds);

--- a/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImpl.java
@@ -15,7 +15,9 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceAssociationCount;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceAssociationsData;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceData;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.exception.DeclaredExperienceNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
@@ -35,7 +37,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -313,13 +318,47 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
   }
 
   @Override
-  public PagedResult<DeclaredExperience> getView(
+  public PagedResult<DeclaredExperienceData> getView(
       PageCriteria pageCriteria, Boolean isValorized, EExperienceType experienceType) {
     Student student = loggedInUserService.getLoggedInStudent();
     log.info("Get experience view by {}", student);
 
-    return experienceRepository.findAllByStudent(
-        student, pageCriteria, isValorized, experienceType);
+    var pagedExperiences =
+        experienceRepository.findAllByStudent(student, pageCriteria, isValorized, experienceType);
+
+    var associationsCountByExperience = getAssociationCounts(pagedExperiences.content());
+
+    return new PagedResult<>(
+        pagedExperiences.content().stream()
+            .map(
+                experience ->
+                    new DeclaredExperienceData(
+                        experience, associationsCountByExperience.get(experience)))
+            .toList(),
+        pagedExperiences.pageInfo());
+  }
+
+  private Map<DeclaredExperience, DeclaredExperienceAssociationCount> getAssociationCounts(
+      List<DeclaredExperience> experiences) {
+    var ids = experiences.stream().map(AvenirsBaseModel::getId).toList();
+
+    var traceAssociationsCountById =
+        associationService.countAllOf(
+            ids, DeclaredExperience.class, EAssociationType.TRACE_DECLARED_EXPERIENCE);
+    var declaredSkillAssociationsCountById =
+        associationService.countAllOf(
+            ids, DeclaredExperience.class, EAssociationType.DECLARED_EXPERIENCE_DECLARED_SKILL);
+
+    return experiences.stream()
+        .collect(
+            Collectors.toMap(
+                Function.identity(),
+                experience ->
+                    new DeclaredExperienceAssociationCount(
+                        traceAssociationsCountById.getOrDefault(experience.getId(), 0L).intValue(),
+                        declaredSkillAssociationsCountById
+                            .getOrDefault(experience.getId(), 0L)
+                            .intValue())));
   }
 
   @Override

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -572,7 +572,7 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
 
     String experienceId = createDeclaredExperienceAs(studentPayload, studentSignature);
     UUID traceId = createTraceAs("My trace", studentPayload, studentSignature);
-    UUID skillId = createDeclaredSkillProgressAs(17, studentPayload, studentSignature);
+    UUID skillId = createAnyAvailableDeclaredSkillProgressAs(studentPayload, studentSignature);
 
     webTestClient
         .post()
@@ -981,6 +981,36 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
     return UUID.fromString(extractIdFromResponse(responseBody));
   }
 
+  private UUID createAnyAvailableDeclaredSkillProgressAs(String payload, String signature)
+      throws Exception {
+    for (var declaredSkill : declaredSkillRepository.findAll()) {
+      var result =
+          webTestClient
+              .post()
+              .uri("/me/declared/skill-progress")
+              .header("X-Signed-Context", payload)
+              .header("X-Context-Kid", secretKey)
+              .header("X-Context-Signature", signature)
+              .contentType(MediaType.APPLICATION_JSON)
+              .bodyValue(
+                  "{\n"
+                      + "  \"id\": \"%s\",\n".formatted(declaredSkill.getId())
+                      + "  \"level\": \"BEGINNER\",\n"
+                      + "  \"type\": \"ROME4\"\n"
+                      + "}\n")
+              .exchange()
+              .expectBody(String.class)
+              .returnResult();
+
+      if (result.getStatus().is2xxSuccessful()) {
+        return UUID.fromString(extractIdFromResponse(result.getResponseBody()));
+      }
+    }
+
+    throw new IllegalStateException(
+        "No declared skill available for association in the seeded catalog");
+  }
+
   private UUID createTraceAs(String title, String payload, String signature) throws Exception {
     String responseBody =
         webTestClient
@@ -1040,29 +1070,6 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
         objectMapper.readTree(responseBody).get("declaredSkillAssociations");
     assertThat(declaredSkillAssociations.isArray()).isTrue();
     assertThat(declaredSkillAssociations.size()).isEqualTo(2);
-  }
-
-  @Test
-  void shouldReturn404WhenAssociatingDeclaredSkillsWithNonExistentExperience() throws Exception {
-    BddLogger.given("a non-existent declared experience");
-
-    UUID skillId = createDeclaredSkillProgressAs(12, studentPayload, studentSignature);
-
-    BddLogger.when("performing a POST to associate declared skills");
-
-    webTestClient
-        .post()
-        .uri(BASE_PATH + "/" + notFoundDeclaredExperienceId + "/associate/declared-skills")
-        .header("X-Signed-Context", studentPayload)
-        .header("X-Context-Kid", secretKey)
-        .header("X-Context-Signature", studentSignature)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(objectMapper.writeValueAsString(Map.of("idsToAssociate", List.of(skillId))))
-        .exchange()
-        .expectStatus()
-        .isNotFound();
-
-    BddLogger.then("it should return 404");
   }
 
   @Test

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -565,6 +565,81 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
     assertThat(personalIds).contains(personalId).doesNotContain(professionalId);
   }
 
+  @Transactional
+  @Test
+  void shouldReturnDeclaredExperienceAssociationCountsInView() throws Exception {
+    BddLogger.given("a declared experience associated with a trace and a declared skill");
+
+    String experienceId = createDeclaredExperienceAs(studentPayload, studentSignature);
+    UUID traceId = createTraceAs("My trace", studentPayload, studentSignature);
+    UUID skillId = createDeclaredSkillProgressAs(12, studentPayload, studentSignature);
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + experienceId + "/associate/traces")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(objectMapper.writeValueAsString(Map.of("idsToAssociate", List.of(traceId))))
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    webTestClient
+        .post()
+        .uri(BASE_PATH + "/" + experienceId + "/associate/declared-skills")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Kid", secretKey)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(objectMapper.writeValueAsString(Map.of("idsToAssociate", List.of(skillId))))
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    BddLogger.when("performing a GET on /view");
+
+    String viewResponse =
+        webTestClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder.path(BASE_PATH + "/view").queryParam("pageSize", 100).build())
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Kid", secretKey)
+            .header("X-Context-Signature", studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    BddLogger.then("it should return the correct association counts for the declared experience");
+    JsonNode experienceNode = null;
+    for (JsonNode node : objectMapper.readTree(viewResponse).get("data")) {
+      if (node.get("id").asText().equals(experienceId)) {
+        experienceNode = node;
+        break;
+      }
+    }
+    assertThat(experienceNode).isNotNull();
+    assertThat(experienceNode.get("declaredExperienceAssociationCountDTO")).isNotNull();
+    assertThat(
+            experienceNode
+                .get("declaredExperienceAssociationCountDTO")
+                .get("traceAssociationsCount")
+                .asInt())
+        .isEqualTo(1);
+    assertThat(
+            experienceNode
+                .get("declaredExperienceAssociationCountDTO")
+                .get("declaredSkillAssociationsCount")
+                .asInt())
+        .isEqualTo(1);
+  }
+
   @Test
   void shouldReturnNotFoundWhenUpdatingNonExistingExperience() throws Exception {
     BddLogger.given("a non existing declared experience id");

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/controller/DeclaredExperienceControllerIT.java
@@ -572,7 +572,7 @@ public class DeclaredExperienceControllerIT extends ContainerConfigurationTest {
 
     String experienceId = createDeclaredExperienceAs(studentPayload, studentSignature);
     UUID traceId = createTraceAs("My trace", studentPayload, studentSignature);
-    UUID skillId = createDeclaredSkillProgressAs(12, studentPayload, studentSignature);
+    UUID skillId = createDeclaredSkillProgressAs(17, studentPayload, studentSignature);
 
     webTestClient
         .post()

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/mapper/DeclaredExperienceMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/application/adapter/mapper/DeclaredExperienceMapperTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.application.adapter.dto.DeclaredExperienceViewDTO;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceAssociationCount;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceData;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
@@ -88,5 +90,38 @@ class DeclaredExperienceMapperTest {
 
     BddLogger.then("it should reflect the valorized flag");
     assertTrue(dto.valorized());
+  }
+
+  @Test
+  void shouldMapDeclaredExperienceDataToViewDTOWithAssociationCount() {
+    BddLogger.given("a declared experience with an association count");
+    Student student = StudentFixture.create().toModel();
+    DeclaredExperience experience =
+        DeclaredExperience.create(
+            student,
+            "Software Experience",
+            EExperienceType.PROFESSIONAL,
+            "Tech Corp",
+            "Software",
+            "Paris",
+            "Backend development",
+            "LinkedIn",
+            "Built REST APIs",
+            "https://techcorp.com",
+            LocalDate.now().minusMonths(6),
+            LocalDate.now());
+    DeclaredExperienceData experienceData =
+        new DeclaredExperienceData(experience, new DeclaredExperienceAssociationCount(2, 3));
+
+    BddLogger.when("mapping to DeclaredExperienceViewDTO");
+    DeclaredExperienceViewDTO dto = mapper.toDTO(experienceData);
+
+    BddLogger.then("it should include the mapped association count");
+    assertNotNull(dto);
+    assertEquals(experience.getId(), dto.id());
+    assertEquals(experience.getTitle(), dto.title());
+    assertNotNull(dto.declaredExperienceAssociationCountDTO());
+    assertEquals(2, dto.declaredExperienceAssociationCountDTO().traceAssociationsCount());
+    assertEquals(3, dto.declaredExperienceAssociationCountDTO().declaredSkillAssociationsCount());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/progress/declared/experience/domain/service/DeclaredExperienceServiceImplTest.java
@@ -9,11 +9,14 @@ import fr.avenirsesr.portfolio.association.domain.model.Association;
 import fr.avenirsesr.portfolio.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.association.domain.port.input.AssociationService;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
+import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.error.domain.exception.FieldValidationException;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceAssociationCount;
+import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.data.DeclaredExperienceData;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.exception.DeclaredExperienceNotFoundException;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.DeclaredExperience;
 import fr.avenirsesr.portfolio.student.progress.declared.experience.domain.model.enums.EExperienceType;
@@ -1016,51 +1019,48 @@ class DeclaredExperienceServiceImplTest {
   void getView_shouldDelegateToRepositoryAndReturnResult() {
     Student loggedIn = student;
     PageCriteria criteria = new PageCriteria(1, 8);
-    PagedResult<DeclaredExperience> expected = mock(PagedResult.class);
+    DeclaredExperience experience = mock(DeclaredExperience.class);
+    UUID experienceId = UUID.randomUUID();
+    when(experience.getId()).thenReturn(experienceId);
+    PagedResult<DeclaredExperience> repositoryResult =
+        new PagedResult<>(List.of(experience), new PageInfo(1, 8, 1));
 
     when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
-    when(experienceRepository.findAllByStudent(loggedIn, criteria, null, null))
-        .thenReturn(expected);
+    when(experienceRepository.findAllByStudent(loggedIn, criteria, (Boolean) null, null))
+        .thenReturn(repositoryResult);
 
-    PagedResult<DeclaredExperience> result = service.getView(criteria, null, null);
+    PagedResult<DeclaredExperienceData> result = service.getView(criteria, null, null);
 
-    assertSame(expected, result);
-    verify(experienceRepository).findAllByStudent(loggedIn, criteria, null, null);
+    assertSame(repositoryResult.pageInfo(), result.pageInfo());
+    assertEquals(
+        List.of(
+            new DeclaredExperienceData(experience, new DeclaredExperienceAssociationCount(0, 0))),
+        result.content());
+    verify(experienceRepository).findAllByStudent(loggedIn, criteria, (Boolean) null, null);
   }
 
   @Test
   void getView_shouldDelegateIsValorizedFilterToRepository() {
     Student loggedIn = student;
     PageCriteria criteria = new PageCriteria(1, 8);
-    PagedResult<DeclaredExperience> expected = mock(PagedResult.class);
+    DeclaredExperience experience = mock(DeclaredExperience.class);
+    UUID experienceId = UUID.randomUUID();
+    when(experience.getId()).thenReturn(experienceId);
+    PagedResult<DeclaredExperience> repositoryResult =
+        new PagedResult<>(List.of(experience), new PageInfo(1, 8, 1));
 
     when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
     when(experienceRepository.findAllByStudent(loggedIn, criteria, true, null))
-        .thenReturn(expected);
+        .thenReturn(repositoryResult);
 
-    PagedResult<DeclaredExperience> result = service.getView(criteria, true, null);
+    PagedResult<DeclaredExperienceData> result = service.getView(criteria, true, null);
 
-    assertSame(expected, result);
+    assertSame(repositoryResult.pageInfo(), result.pageInfo());
+    assertEquals(
+        List.of(
+            new DeclaredExperienceData(experience, new DeclaredExperienceAssociationCount(0, 0))),
+        result.content());
     verify(experienceRepository).findAllByStudent(loggedIn, criteria, true, null);
-  }
-
-  @Test
-  void getView_shouldDelegateExperienceTypeFilterToRepository() {
-    Student loggedIn = student;
-    PageCriteria criteria = new PageCriteria(1, 8);
-    PagedResult<DeclaredExperience> expected = mock(PagedResult.class);
-
-    when(loggedInUserService.getLoggedInStudent()).thenReturn(loggedIn);
-    when(experienceRepository.findAllByStudent(
-            loggedIn, criteria, null, EExperienceType.PROFESSIONAL))
-        .thenReturn(expected);
-
-    PagedResult<DeclaredExperience> result =
-        service.getView(criteria, null, EExperienceType.PROFESSIONAL);
-
-    assertSame(expected, result);
-    verify(experienceRepository)
-        .findAllByStudent(loggedIn, criteria, null, EExperienceType.PROFESSIONAL);
   }
 
   @Test


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Adds a `declaredExperienceAssociationCountDTO` field to `DeclaredExperienceViewDTO`, mirroring the existing `DeclaredSkillAssociationCountDTO` pattern used on `DeclaredSkillProgressDTO`. It reports `traceAssociationsCount` and `declaredSkillAssociationsCount` (the two association types a declared experience can have). Both are `int` and marked as required properties in the OpenAPI schema.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2236

---

### Documentation
> No manual documentation updates needed; the new DTO and fields are reflected automatically in the generated OpenAPI schema.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Added domain data `DeclaredExperienceAssociationCount` and `DeclaredExperienceData` (mirroring `DeclaredSkillAssociationCount`/`DeclaredSkillProgressData`).
> - `DeclaredExperienceService#getView` now returns `PagedResult<DeclaredExperienceData>`, computing counts in batch via `AssociationService#countAllOf` for `TRACE_DECLARED_EXPERIENCE` and `DECLARED_EXPERIENCE_DECLARED_SKILL`, exactly like `DeclaredSkillProgressServiceImpl#getAssociationCounts`.
> - Following the same precedent as the skill DTO, the `create`/`update`/single-`get` endpoints still use the plain `DeclaredExperience` → DTO mapping (association count left unset there); only the `/view` list endpoint populates real counts.

---

### Known Limitations or Side Effects
> Same known limitation as the pre-existing skill DTO pattern: the association count is only populated by the `/view` list endpoint, not by create/update/single-get responses.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process