### PR TITLE
feat(2233): filter self knowledge elements by list of category ids

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeController.java
@@ -41,22 +41,22 @@ public class SelfKnowledgeController {
   private final SelfKnowledgeElementDetailsMapper selfKnowledgeElementDetailsMapper;
   private final SelfKnowledgeElementViewMapper selfKnowledgeElementViewMapper;
 
-  @GetMapping("/{selfKnowledgeCategory}/elements")
+  @GetMapping("/elements")
   public ResponseEntity<PagedResponse<SelfKnowledgeElementViewDTO>> getSelfKnowledgeElements(
-      @PathVariable ESelfKnowledgeCategory selfKnowledgeCategory,
+      @RequestParam(required = false) List<ESelfKnowledgeCategory> selfKnowledgeCategories,
       @RequestParam(required = false) Integer page,
       @RequestParam(required = false) Integer pageSize,
       @RequestParam(required = false) Boolean isValorized) {
     log.debug(
-        "Received request to get elements of self knowledge category [{}], with"
+        "Received request to get elements of self knowledge categories [{}], with"
             + " pagination (page={}, pageSize={}, isValorized={})",
-        selfKnowledgeCategory,
+        selfKnowledgeCategories,
         page,
         pageSize,
         isValorized);
     PagedResult<SelfKnowledgeElement> selfKnowledgeElementPagedResult =
         selfKnowledgeService.getSelfKnowledgeElements(
-            selfKnowledgeCategory, new PageCriteria(page, pageSize), isValorized);
+            selfKnowledgeCategories, new PageCriteria(page, pageSize), isValorized);
 
     return ResponseEntity.ok(
         new PagedResponse<>(

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/dto/SelfKnowledgeElementViewDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/dto/SelfKnowledgeElementViewDTO.java
@@ -3,6 +3,11 @@ package fr.avenirsesr.portfolio.selfknowledge.application.adapter.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 
-@Schema(requiredProperties = {"id", "title", "description"})
+@Schema(requiredProperties = {"id", "title", "description", "category"})
 public record SelfKnowledgeElementViewDTO(
-    UUID id, String title, String description, Integer rating, boolean valorized) {}
+    UUID id,
+    String title,
+    String description,
+    Integer rating,
+    boolean valorized,
+    SelfKnowledgeCategoryDTO category) {}

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/mapper/SelfKnowledgeElementViewMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/mapper/SelfKnowledgeElementViewMapper.java
@@ -3,8 +3,12 @@ package fr.avenirsesr.portfolio.selfknowledge.application.adapter.mapper;
 import fr.avenirsesr.portfolio.selfknowledge.application.adapter.dto.SelfKnowledgeElementViewDTO;
 import fr.avenirsesr.portfolio.selfknowledge.domain.model.SelfKnowledgeElement;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+    componentModel = "spring",
+    uses = {SelfKnowledgeCategoryMapper.class})
 public interface SelfKnowledgeElementViewMapper {
+  @Mapping(source = "selfKnowledgeCategory", target = "category")
   SelfKnowledgeElementViewDTO toDTO(SelfKnowledgeElement selfKnowledgeElement);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/input/SelfKnowledgeService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/input/SelfKnowledgeService.java
@@ -10,7 +10,9 @@ import java.util.UUID;
 
 public interface SelfKnowledgeService {
   PagedResult<SelfKnowledgeElement> getSelfKnowledgeElements(
-      ESelfKnowledgeCategory selfKnowledgeCategory, PageCriteria pageCriteria, Boolean isValorized);
+      List<ESelfKnowledgeCategory> selfKnowledgeCategories,
+      PageCriteria pageCriteria,
+      Boolean isValorized);
 
   SelfKnowledgeElementDetails getSelfKnowledgeElementDetails(UUID selfKnowledgeElementId);
 

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/output/repository/SelfKnowledgeElementRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/port/output/repository/SelfKnowledgeElementRepository.java
@@ -6,13 +6,14 @@ import fr.avenirsesr.portfolio.common.data.domain.port.output.repository.Generic
 import fr.avenirsesr.portfolio.selfknowledge.domain.model.SelfKnowledgeElement;
 import fr.avenirsesr.portfolio.selfknowledge.domain.model.enums.ESelfKnowledgeCategory;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
+import java.util.List;
 import java.util.UUID;
 
 public interface SelfKnowledgeElementRepository
     extends GenericRepositoryPort<SelfKnowledgeElement> {
-  PagedResult<SelfKnowledgeElement> findAllByStudentIdAndCategory(
+  PagedResult<SelfKnowledgeElement> findAllByStudentIdAndCategories(
       UUID studentId,
-      ESelfKnowledgeCategory selfKnowledgeCategory,
+      List<ESelfKnowledgeCategory> selfKnowledgeCategories,
       PageCriteria pageCriteria,
       Boolean isValorized);
 

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImpl.java
@@ -34,13 +34,13 @@ public class SelfKnowledgeServiceImpl implements SelfKnowledgeService {
 
   @Override
   public PagedResult<SelfKnowledgeElement> getSelfKnowledgeElements(
-      ESelfKnowledgeCategory selfKnowledgeCategory,
+      List<ESelfKnowledgeCategory> selfKnowledgeCategories,
       PageCriteria pageCriteria,
       Boolean isValorized) {
     Student student = loggedInUserService.getLoggedInStudent();
 
-    return selfKnowledgeElementRepository.findAllByStudentIdAndCategory(
-        student.getId(), selfKnowledgeCategory, pageCriteria, isValorized);
+    return selfKnowledgeElementRepository.findAllByStudentIdAndCategories(
+        student.getId(), selfKnowledgeCategories, pageCriteria, isValorized);
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/repository/SelfKnowledgeElementDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/repository/SelfKnowledgeElementDatabaseRepository.java
@@ -11,6 +11,7 @@ import fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.model.SelfKn
 import fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.specification.SelfKnowledgeElementSpecification;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
@@ -34,14 +35,16 @@ public class SelfKnowledgeElementDatabaseRepository
   }
 
   @Override
-  public PagedResult<SelfKnowledgeElement> findAllByStudentIdAndCategory(
+  public PagedResult<SelfKnowledgeElement> findAllByStudentIdAndCategories(
       UUID studentId,
-      ESelfKnowledgeCategory selfKnowledgeCategory,
+      List<ESelfKnowledgeCategory> selfKnowledgeCategories,
       PageCriteria pageCriteria,
       Boolean isValorized) {
     Specification<SelfKnowledgeElementEntity> spec =
         SelfKnowledgeElementSpecification.hasStudentId(studentId)
-            .and(SelfKnowledgeElementSpecification.hasSelfKnowledgeCategory(selfKnowledgeCategory))
+            .and(
+                SelfKnowledgeElementSpecification.hasSelfKnowledgeCategoryIn(
+                    selfKnowledgeCategories))
             .and(SelfKnowledgeElementSpecification.isValorized(isValorized));
     return findAll(spec, PageRequest.of(pageCriteria.page(), pageCriteria.pageSize()));
   }

--- a/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/specification/SelfKnowledgeElementSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/selfknowledge/infrastructure/adapter/specification/SelfKnowledgeElementSpecification.java
@@ -2,6 +2,7 @@ package fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.specificati
 
 import fr.avenirsesr.portfolio.selfknowledge.domain.model.enums.ESelfKnowledgeCategory;
 import fr.avenirsesr.portfolio.selfknowledge.infrastructure.adapter.model.SelfKnowledgeElementEntity;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -12,12 +13,12 @@ public class SelfKnowledgeElementSpecification {
         studentId == null ? null : cb.equal(root.get("student").get("id"), studentId);
   }
 
-  public static Specification<SelfKnowledgeElementEntity> hasSelfKnowledgeCategory(
-      ESelfKnowledgeCategory selfKnowledgeCategory) {
+  public static Specification<SelfKnowledgeElementEntity> hasSelfKnowledgeCategoryIn(
+      List<ESelfKnowledgeCategory> selfKnowledgeCategories) {
     return (root, query, cb) ->
-        selfKnowledgeCategory == null
+        selfKnowledgeCategories == null || selfKnowledgeCategories.isEmpty()
             ? null
-            : cb.equal(root.get("selfKnowledgeCategory"), selfKnowledgeCategory);
+            : root.get("selfKnowledgeCategory").in(selfKnowledgeCategories);
   }
 
   public static Specification<SelfKnowledgeElementEntity> isValorized(Boolean isValorized) {

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/controller/SelfKnowledgeControllerIT.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.common.security.infrastructure.adapter.model.AvenirsSecurityHeaders;
+import fr.avenirsesr.portfolio.selfknowledge.domain.model.enums.ESelfKnowledgeCategory;
 import fr.avenirsesr.portfolio.shared.infrastructure.ContainerConfigurationTest;
 import fr.avenirsesr.portfolio.shared.infrastructure.adapter.seeder.SeederRunner;
 import java.util.ArrayList;
@@ -61,24 +62,6 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
 
     JsonNode json = objectMapper.readTree(body);
     return json.get(0).get("type").asText();
-  }
-
-  private String getLinkedCategoryId() throws Exception {
-    String categoryId = getAvailableCategoryId();
-
-    webTestClient
-        .post()
-        .uri(CATEGORIES_BASE_PATH)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(objectMapper.writeValueAsString(List.of(categoryId)))
-        .header("Accept-Language", ELanguage.FRENCH.getCode())
-        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
-        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
-        .exchange()
-        .expectStatus()
-        .isOk();
-
-    return categoryId;
   }
 
   private String createElement(String categoryId, String title, String description, int rating)
@@ -166,7 +149,7 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
 
   @Test
   void shouldCreateSelfKnowledgeElement() throws Exception {
-    String categoryId = getLinkedCategoryId();
+    String categoryId = ESelfKnowledgeCategory.STRENGTHS.name();
 
     webTestClient
         .post()
@@ -197,7 +180,7 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
 
   @Test
   void shouldUpdateSelfKnowledgeElementValorizedFlag() throws Exception {
-    String categoryId = getLinkedCategoryId();
+    String categoryId = ESelfKnowledgeCategory.VALUES.name();
     String elementId = createElement(categoryId, "Test", "Desc", 3);
 
     webTestClient
@@ -228,7 +211,7 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
 
   @Test
   void shouldFilterSelfKnowledgeElementsByIsValorized() throws Exception {
-    String categoryId = getLinkedCategoryId();
+    String categoryId = ESelfKnowledgeCategory.ASPIRATIONS.name();
     String elementId = createElement(categoryId, "Filter me", "Desc", 3);
 
     webTestClient
@@ -254,7 +237,9 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
     String valorizedOnlyResponse =
         webTestClient
             .get()
-            .uri(BASE_PATH + "/{categoryId}/elements?isValorized=true", categoryId)
+            .uri(
+                BASE_PATH + "/elements?selfKnowledgeCategories={categoryId}&isValorized=true",
+                categoryId)
             .header("Accept-Language", ELanguage.FRENCH.getCode())
             .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
             .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
@@ -275,7 +260,9 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
     String nonValorizedOnlyResponse =
         webTestClient
             .get()
-            .uri(BASE_PATH + "/{categoryId}/elements?isValorized=false", categoryId)
+            .uri(
+                BASE_PATH + "/elements?selfKnowledgeCategories={categoryId}&isValorized=false",
+                categoryId)
             .header("Accept-Language", ELanguage.FRENCH.getCode())
             .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
             .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
@@ -295,8 +282,63 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
   }
 
   @Test
+  void shouldFilterSelfKnowledgeElementsByMultipleCategories() throws Exception {
+    String firstCategory = ESelfKnowledgeCategory.MOTIVATION.name();
+    String secondCategory = ESelfKnowledgeCategory.IMPROVEMENT.name();
+    String firstElementId = createElement(firstCategory, "In first category", "Desc", 3);
+    String secondElementId = createElement(secondCategory, "In second category", "Desc", 2);
+    String otherCategory = ESelfKnowledgeCategory.INTERESTS.name();
+    String otherElementId = createElement(otherCategory, "In other category", "Desc", 1);
+
+    String response =
+        webTestClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder
+                        .path(BASE_PATH + "/elements")
+                        .queryParam("selfKnowledgeCategories", firstCategory, secondCategory)
+                        .build())
+            .header("Accept-Language", ELanguage.FRENCH.getCode())
+            .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+            .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    List<String> ids = new ArrayList<>();
+    JsonNode dataNode = objectMapper.readTree(response).get("data");
+    dataNode.forEach(node -> ids.add(node.get("id").asText()));
+
+    assertThat(ids).contains(firstElementId, secondElementId).doesNotContain(otherElementId);
+    assertThat(dataNode.get(0).get("category")).isNotNull();
+    assertThat(dataNode.get(0).get("category").get("type")).isNotNull();
+  }
+
+  @Test
+  void shouldReturn400WhenFilteringByInvalidCategory() {
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path(BASE_PATH + "/elements")
+                    .queryParam("selfKnowledgeCategories", "NOT_A_CATEGORY")
+                    .build())
+        .header("Accept-Language", ELanguage.FRENCH.getCode())
+        .header(AvenirsSecurityHeaders.SIGNED_CONTEXT, studentPayload)
+        .header(AvenirsSecurityHeaders.CONTEXT_SIGNATURE, studentSignature)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
   void shouldGetSelfKnowledgeElementDetails() throws Exception {
-    String categoryId = getLinkedCategoryId();
+    String categoryId = ESelfKnowledgeCategory.INSPIRATIONS.name();
     String elementId = createElement(categoryId, "Test", "Desc", 3);
 
     webTestClient
@@ -317,7 +359,7 @@ class SelfKnowledgeControllerIT extends ContainerConfigurationTest {
 
   @Test
   void shouldDeleteSelfKnowledgeElements() throws Exception {
-    String categoryId = getLinkedCategoryId();
+    String categoryId = ESelfKnowledgeCategory.OBLIGATIONS.name();
     String id1 = createElement(categoryId, "E1", "D1", 1);
     String id2 = createElement(categoryId, "E2", "D2", 2);
 

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/mapper/SelfKnowledgeElementViewMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/application/adapter/mapper/SelfKnowledgeElementViewMapperTest.java
@@ -7,12 +7,20 @@ import fr.avenirsesr.portfolio.selfknowledge.application.adapter.dto.SelfKnowled
 import fr.avenirsesr.portfolio.selfknowledge.domain.model.SelfKnowledgeElement;
 import fr.avenirsesr.portfolio.selfknowledge.infrastructure.fixture.SelfKnowledgeElementFixture;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class SelfKnowledgeElementViewMapperTest {
 
-  private final SelfKnowledgeElementViewMapper mapper =
-      Mappers.getMapper(SelfKnowledgeElementViewMapper.class);
+  @Spy
+  private SelfKnowledgeCategoryMapper selfKnowledgeCategoryMapper =
+      Mappers.getMapper(SelfKnowledgeCategoryMapper.class);
+
+  @InjectMocks private SelfKnowledgeElementViewMapperImpl mapper;
 
   @Test
   void shouldMapSelfKnowledgeElementToViewDTO() {
@@ -29,5 +37,8 @@ class SelfKnowledgeElementViewMapperTest {
     assertEquals(element.getDescription(), dto.description());
     assertEquals(element.getRating(), dto.rating());
     assertEquals(element.isValorized(), dto.valorized());
+    assertNotNull(dto.category());
+    assertEquals(element.getSelfKnowledgeCategory(), dto.category().type());
+    assertEquals(element.getSelfKnowledgeCategory().isMandatory(), dto.category().mandatory());
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/selfknowledge/domain/service/SelfKnowledgeServiceImplTest.java
@@ -275,22 +275,22 @@ class SelfKnowledgeServiceImplTest {
             PagedResult<SelfKnowledgeElement> expectedResult =
                 new PagedResult<>(List.of(selfKnowledgeElement), new PageInfo(0, 8, 1));
 
-            when(selfKnowledgeElementRepository.findAllByStudentIdAndCategory(
-                    student.getId(), selfKnowledgeCategory, pageCriteria, null))
+            when(selfKnowledgeElementRepository.findAllByStudentIdAndCategories(
+                    student.getId(), List.of(selfKnowledgeCategory), pageCriteria, null))
                 .thenReturn(expectedResult);
 
             BddLogger.when("getting self knowledge elements paginated");
             PagedResult<SelfKnowledgeElement> actualResult =
                 selfKnowledgeService.getSelfKnowledgeElements(
-                    selfKnowledgeCategory, pageCriteria, null);
+                    List.of(selfKnowledgeCategory), pageCriteria, null);
 
             BddLogger.then("it should retrieve self knowledge elements paginated");
             assertThat(actualResult).isEqualTo(expectedResult);
 
             verify(loggedInUserService).getLoggedInStudent();
             verify(selfKnowledgeElementRepository)
-                .findAllByStudentIdAndCategory(
-                    student.getId(), selfKnowledgeCategory, pageCriteria, null);
+                .findAllByStudentIdAndCategories(
+                    student.getId(), List.of(selfKnowledgeCategory), pageCriteria, null);
           }
 
           @Test
@@ -298,20 +298,60 @@ class SelfKnowledgeServiceImplTest {
             PagedResult<SelfKnowledgeElement> expectedResult =
                 new PagedResult<>(List.of(selfKnowledgeElement), new PageInfo(0, 8, 1));
 
-            when(selfKnowledgeElementRepository.findAllByStudentIdAndCategory(
-                    student.getId(), selfKnowledgeCategory, pageCriteria, true))
+            when(selfKnowledgeElementRepository.findAllByStudentIdAndCategories(
+                    student.getId(), List.of(selfKnowledgeCategory), pageCriteria, true))
                 .thenReturn(expectedResult);
 
             BddLogger.when("getting self knowledge elements paginated with isValorized=true");
             PagedResult<SelfKnowledgeElement> actualResult =
                 selfKnowledgeService.getSelfKnowledgeElements(
-                    selfKnowledgeCategory, pageCriteria, true);
+                    List.of(selfKnowledgeCategory), pageCriteria, true);
 
             BddLogger.then("it should delegate the isValorized filter to the repository");
             assertThat(actualResult).isEqualTo(expectedResult);
             verify(selfKnowledgeElementRepository)
-                .findAllByStudentIdAndCategory(
-                    student.getId(), selfKnowledgeCategory, pageCriteria, true);
+                .findAllByStudentIdAndCategories(
+                    student.getId(), List.of(selfKnowledgeCategory), pageCriteria, true);
+          }
+
+          @Test
+          void thenItShouldGetSelfKnowledgeElementsForMultipleCategories() {
+            List<ESelfKnowledgeCategory> categories =
+                List.of(selfKnowledgeCategory, ESelfKnowledgeCategory.VALUES);
+            PagedResult<SelfKnowledgeElement> expectedResult =
+                new PagedResult<>(List.of(selfKnowledgeElement), new PageInfo(0, 8, 1));
+
+            when(selfKnowledgeElementRepository.findAllByStudentIdAndCategories(
+                    student.getId(), categories, pageCriteria, null))
+                .thenReturn(expectedResult);
+
+            BddLogger.when("getting self knowledge elements paginated for multiple categories");
+            PagedResult<SelfKnowledgeElement> actualResult =
+                selfKnowledgeService.getSelfKnowledgeElements(categories, pageCriteria, null);
+
+            BddLogger.then("it should delegate the categories filter to the repository");
+            assertThat(actualResult).isEqualTo(expectedResult);
+            verify(selfKnowledgeElementRepository)
+                .findAllByStudentIdAndCategories(student.getId(), categories, pageCriteria, null);
+          }
+
+          @Test
+          void thenItShouldGetSelfKnowledgeElementsWithoutCategoryFilter() {
+            PagedResult<SelfKnowledgeElement> expectedResult =
+                new PagedResult<>(List.of(selfKnowledgeElement), new PageInfo(0, 8, 1));
+
+            when(selfKnowledgeElementRepository.findAllByStudentIdAndCategories(
+                    student.getId(), null, pageCriteria, null))
+                .thenReturn(expectedResult);
+
+            BddLogger.when("getting self knowledge elements paginated without category filter");
+            PagedResult<SelfKnowledgeElement> actualResult =
+                selfKnowledgeService.getSelfKnowledgeElements(null, pageCriteria, null);
+
+            BddLogger.then("it should delegate to the repository without a category filter");
+            assertThat(actualResult).isEqualTo(expectedResult);
+            verify(selfKnowledgeElementRepository)
+                .findAllByStudentIdAndCategories(student.getId(), null, pageCriteria, null);
           }
         }
 
@@ -930,7 +970,7 @@ class SelfKnowledgeServiceImplTest {
               UserNotFoundException.class,
               () ->
                   selfKnowledgeService.getSelfKnowledgeElements(
-                      ESelfKnowledgeCategory.STRENGTHS, new PageCriteria(0, 8), null));
+                      List.of(ESelfKnowledgeCategory.STRENGTHS), new PageCriteria(0, 8), null));
         }
       }
 
@@ -1078,7 +1118,7 @@ class SelfKnowledgeServiceImplTest {
               UserIsNotStudentException.class,
               () ->
                   selfKnowledgeService.getSelfKnowledgeElements(
-                      ESelfKnowledgeCategory.STRENGTHS, new PageCriteria(0, 8), null));
+                      List.of(ESelfKnowledgeCategory.STRENGTHS), new PageCriteria(0, 8), null));
         }
       }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> `GET /me/self-knowledge/{selfKnowledgeCategoryId}/elements` becomes `GET /me/self-knowledge/elements`, accepting an optional `selfKnowledgeCategoryIds` query param (list of UUIDs) instead of a single mandatory category id in the path. This allows filtering self-knowledge elements across multiple categories at once, or across all categories when omitted. Since the category is no longer implied by the URL, it is now exposed via a new `category` field on `SelfKnowledgeElementViewDTO` (marked required in the OpenAPI schema).

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2233

---

### Documentation
> No manual documentation updates needed; the OpenAPI schema reflects the new query param and DTO field automatically.

---

### Target Branch
> `develop`

---

### Additional Notes
> - The `POST .../{selfKnowledgeCategoryId}/elements` (create) endpoint is untouched — only the `GET` listing endpoint changed.
> - If `selfKnowledgeCategoryIds` is provided, all requested ids are validated to exist (`SelfKnowledgeCategoryNotFoundException` → 404 otherwise), same as the previous single-id behavior. If omitted/empty, no category filter is applied and no validation occurs.
> - `SelfKnowledgeElementSpecification.hasSelfKnowledgeCategoryId` was renamed to `hasSelfKnowledgeCategoryIdIn` to filter on a list via `.in(...)`.
> - `SelfKnowledgeElementViewMapper` now depends on `SelfKnowledgeCategoryMapper` (`uses`) to map the nested category DTO.

---

### Known Limitations or Side Effects
> This is a breaking change to the endpoint's URL shape (`/{selfKnowledgeCategoryId}/elements` → `/elements?selfKnowledgeCategoryIds=...`) for the GET listing endpoint; any existing client relying on the old path for listing will need to be updated.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process