### PR TITLE
feat(self-knowledge): add OpenAPI schema on ESelfKnowledgeCategory params

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/selfknowledge/application/adapter/controller/SelfKnowledgeController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/selfknowledge/application/adapter/controller/SelfKnowledgeController.java
@@ -15,6 +15,11 @@ import fr.avenirsesr.portfolio.student.selfknowledge.domain.data.SelfKnowledgeEl
 import fr.avenirsesr.portfolio.student.selfknowledge.domain.model.SelfKnowledgeElement;
 import fr.avenirsesr.portfolio.student.selfknowledge.domain.model.enums.ESelfKnowledgeCategory;
 import fr.avenirsesr.portfolio.student.selfknowledge.domain.port.input.SelfKnowledgeService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -43,7 +48,12 @@ public class SelfKnowledgeController {
 
   @GetMapping("/elements")
   public ResponseEntity<PagedResponse<SelfKnowledgeElementViewDTO>> getSelfKnowledgeElements(
-      @RequestParam(required = false) List<ESelfKnowledgeCategory> selfKnowledgeCategories,
+      @Parameter(
+              array =
+                  @ArraySchema(
+                      schema = @Schema(ref = "#/components/schemas/ESelfKnowledgeCategory")))
+          @RequestParam(required = false)
+          List<ESelfKnowledgeCategory> selfKnowledgeCategories,
       @RequestParam(required = false) Integer page,
       @RequestParam(required = false) Integer pageSize,
       @RequestParam(required = false) Boolean isValorized) {
@@ -81,7 +91,13 @@ public class SelfKnowledgeController {
 
   @PostMapping("/{selfKnowledgeCategory}/elements")
   public ResponseEntity<SelfKnowledgeElementViewDTO> createSelfKnowledgeElement(
-      @PathVariable("selfKnowledgeCategory") ESelfKnowledgeCategory selfKnowledgeCategory,
+      @Parameter(
+              name = "selfKnowledgeCategory",
+              in = ParameterIn.PATH,
+              required = true,
+              schema = @Schema(ref = "#/components/schemas/ESelfKnowledgeCategory"))
+          @PathVariable("selfKnowledgeCategory")
+          ESelfKnowledgeCategory selfKnowledgeCategory,
       @Valid @RequestBody SelfKnowledgeElementRequest selfKnowledgeElementRequest) {
     log.debug(
         "Received request to create self knowledge element [{}] to category [{}]",
@@ -135,7 +151,15 @@ public class SelfKnowledgeController {
 
   @PostMapping("/categories")
   public ResponseEntity<String> addSelfKnowledgeCategories(
-      @RequestBody List<ESelfKnowledgeCategory> categories) {
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      array =
+                          @ArraySchema(
+                              schema =
+                                  @Schema(ref = "#/components/schemas/ESelfKnowledgeCategory"))))
+          @RequestBody
+          List<ESelfKnowledgeCategory> categories) {
     selfKnowledgeService.addSelfKnowledgeCategories(categories);
     return ResponseEntity.ok("Categories successfully associated with user");
   }
@@ -150,7 +174,13 @@ public class SelfKnowledgeController {
 
   @DeleteMapping("/categories/{selfKnowledgeCategory}")
   public ResponseEntity<String> removeSelfKnowledgeCategory(
-      @PathVariable ESelfKnowledgeCategory selfKnowledgeCategory) {
+      @Parameter(
+              name = "selfKnowledgeCategory",
+              in = ParameterIn.PATH,
+              required = true,
+              schema = @Schema(ref = "#/components/schemas/ESelfKnowledgeCategory"))
+          @PathVariable
+          ESelfKnowledgeCategory selfKnowledgeCategory) {
     selfKnowledgeService.removeSelfKnowledgeCategory(selfKnowledgeCategory);
     return ResponseEntity.ok("Categories successfully deleted");
   }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Add OpenAPI `@Schema` references to the `ESelfKnowledgeCategory` enum parameters in `SelfKnowledgeController` (query param, path variables, and request body) so the generated API documentation reuses the shared `ESelfKnowledgeCategory` component schema instead of an inline enum definition.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2368

---

### Documentation
> No documentation updates needed; this only refines the generated OpenAPI schema for existing endpoints.

---

### Target Branch
> `develop`

---

### Additional Notes
> Follows the existing pattern already used in `UserController`/`DeclaredActivityController` (`@Parameter(schema = @Schema(ref = "#/components/schemas/..."))` for path/query params, `@Content(array = @ArraySchema(...))` for list request bodies).

---

### Known Limitations or Side Effects
> None — documentation-only change, no behavior modification.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process