### PR TITLE
refactor(trace): relink traces to student instead of user

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/seeder/fake/FakeTraceAttachment.java
+++ b/src/main/java/fr/avenirsesr/portfolio/file/infrastructure/adapter/seeder/fake/FakeTraceAttachment.java
@@ -52,7 +52,7 @@ public class FakeTraceAttachment {
                     FileStorageConstants.STORAGE_PATH,
                     FileStorageConstants.PLACEHOLDER_FILE_UUID,
                     fileType.name().toLowerCase()),
-            trace.getUser(),
+            trace.getStudent().getUser(),
             trace.getCreatedAt(),
             false,
             trace.getCreatedAt(),

--- a/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/seeder/SeederOrchestrator.java
+++ b/src/main/java/fr/avenirsesr/portfolio/shared/infrastructure/adapter/seeder/SeederOrchestrator.java
@@ -22,7 +22,6 @@ import fr.avenirsesr.portfolio.student.selfknowledge.infrastructure.adapter.seed
 import fr.avenirsesr.portfolio.student.skill.infrastructure.adapter.seeder.DeclaredSkillProgressSeeder;
 import fr.avenirsesr.portfolio.student.skill.infrastructure.adapter.seeder.DeclaredSkillSeeder;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.seeder.TraceSeeder;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.StudentEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.seeder.StaffSeeder;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.seeder.StudentSeeder;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.seeder.UserPrincipalSeeder;
@@ -118,8 +117,7 @@ public class SeederOrchestrator {
 
       studentProgressSeeder.seed(savedTrainingPaths, savedStudents, savedSkillLevels);
 
-      var savedTraces =
-          traceSeeder.seed(savedStudents.stream().map(StudentEntity::getUser).toList());
+      var savedTraces = traceSeeder.seed(savedStudents);
 
       selfKnowledgeElementSeeder.seed();
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/service/DeclaredActivityServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/service/DeclaredActivityServiceImpl.java
@@ -271,7 +271,7 @@ public class DeclaredActivityServiceImpl implements DeclaredActivityService {
       throw new TraceNotFoundException();
     }
 
-    if (!traces.stream().allMatch(trace -> trace.getUser().equals(student.getUser()))) {
+    if (!traces.stream().allMatch(trace -> trace.getStudent().equals(student))) {
       throw new UserNotAuthorizedException();
     }
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/mapper/FeedbackMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/mapper/FeedbackMapper.java
@@ -1,6 +1,5 @@
 package fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.mapper;
 
-import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.file.domain.model.File;
@@ -40,7 +39,7 @@ public class FeedbackMapper implements Mapper<FeedbackEntity, Feedback> {
                 t ->
                     new AssociationsJson.TraceSnapshot(
                         t.getId(),
-                        t.getUser().getId(),
+                        t.getStudent().getId(),
                         t.getAttachment().map(File::getId).orElse(null),
                         t.getTitle(),
                         t.getLanguage(),
@@ -72,19 +71,17 @@ public class FeedbackMapper implements Mapper<FeedbackEntity, Feedback> {
   @Override
   public Feedback toDomain(FeedbackEntity entity) {
     throw new UnsupportedOperationException(
-        "FeedbackMapper.toDomain requiers ths objects User, File, Student and DeclaredSkill loaded."
-            + " Use toDomain(entity, users, files, students, skills).");
+        "FeedbackMapper.toDomain requiers ths objects File, Student and DeclaredSkill loaded."
+            + " Use toDomain(entity, files, students, skills).");
   }
 
   @Override
   public Feedback toDomain(FeedbackEntity entity, EntityGrapher<?> graph) {
-    throw new UnsupportedOperationException(
-        "Use toDomain(entity, users, files, students, skills).");
+    throw new UnsupportedOperationException("Use toDomain(entity, files, students, skills).");
   }
 
   public Feedback toDomain(
       FeedbackEntity entity,
-      Map<UUID, User> users,
       Map<UUID, File> files,
       Map<UUID, Student> students,
       Map<UUID, DeclaredSkill> skills) {
@@ -97,7 +94,7 @@ public class FeedbackMapper implements Mapper<FeedbackEntity, Feedback> {
                 snap ->
                     Trace.toDomain(
                         snap.id(),
-                        users.get(snap.userId()),
+                        students.get(snap.studentId()),
                         snap.title(),
                         snap.authorType(),
                         snap.aiUseJustification(),

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/model/AssociationsJson.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/model/AssociationsJson.java
@@ -11,7 +11,7 @@ public record AssociationsJson(
     List<TraceSnapshot> traces, List<DeclaredSkillProgressSnapshot> declaredSkillProgresses) {
   public record TraceSnapshot(
       UUID id,
-      UUID userId,
+      UUID studentId,
       UUID attachmentId,
       String title,
       ELanguage language,

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/repository/FeedbackDatabaseRepository.java
@@ -4,7 +4,6 @@ import fr.avenirsesr.portfolio.common.data.domain.FetchGraph;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
-import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.model.AvenirsBaseEntity;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.repository.GenericJpaRepositoryAdapter;
 import fr.avenirsesr.portfolio.file.domain.model.File;
@@ -24,12 +23,11 @@ import fr.avenirsesr.portfolio.student.skill.infrastructure.adapter.repository.D
 import fr.avenirsesr.portfolio.user.domain.model.Staff;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.repository.StudentJpaRepository;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.repository.UserJpaRepository;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -40,20 +38,17 @@ public class FeedbackDatabaseRepository
     extends GenericJpaRepositoryAdapter<Feedback, FeedbackEntity> implements FeedbackRepository {
 
   private final FeedbackJpaRepository jpaRepository;
-  private final UserJpaRepository userJpaRepository;
   private final FileJpaRepository fileJpaRepository;
   private final StudentJpaRepository studentJpaRepository;
   private final DeclaredSkillJpaRepository declaredSkillJpaRepository;
 
   public FeedbackDatabaseRepository(
       FeedbackJpaRepository jpaRepository,
-      UserJpaRepository userJpaRepository,
       FileJpaRepository fileJpaRepository,
       StudentJpaRepository studentJpaRepository,
       DeclaredSkillJpaRepository declaredSkillJpaRepository) {
     super(jpaRepository, jpaRepository, FeedbackEntity.class, FeedbackMapper.INSTANCE);
     this.jpaRepository = jpaRepository;
-    this.userJpaRepository = userJpaRepository;
     this.fileJpaRepository = fileJpaRepository;
     this.studentJpaRepository = studentJpaRepository;
     this.declaredSkillJpaRepository = declaredSkillJpaRepository;
@@ -184,22 +179,11 @@ public class FeedbackDatabaseRepository
   private Feedback toDomainWithDependencies(FeedbackEntity entity) {
     AssociationsJson associations = entity.getAssociations();
 
-    Map<UUID, User> users = resolveUsers(associations);
     Map<UUID, File> files = resolveFiles(associations);
     Map<UUID, Student> students = resolveStudents(associations);
     Map<UUID, DeclaredSkill> skills = resolveSkills(associations);
 
-    return FeedbackMapper.INSTANCE.toDomain(entity, users, files, students, skills);
-  }
-
-  private Map<UUID, User> resolveUsers(AssociationsJson associations) {
-    Set<UUID> ids =
-        associations.traces().stream()
-            .map(AssociationsJson.TraceSnapshot::userId)
-            .collect(Collectors.toSet());
-
-    return userJpaRepository.findAllById(ids).stream()
-        .collect(Collectors.toMap(AvenirsBaseEntity::getId, UserMapper.INSTANCE::toDomain));
+    return FeedbackMapper.INSTANCE.toDomain(entity, files, students, skills);
   }
 
   private Map<UUID, File> resolveFiles(AssociationsJson associations) {
@@ -217,8 +201,10 @@ public class FeedbackDatabaseRepository
 
   private Map<UUID, Student> resolveStudents(AssociationsJson associations) {
     Set<UUID> ids =
-        associations.declaredSkillProgresses().stream()
-            .map(AssociationsJson.DeclaredSkillProgressSnapshot::studentId)
+        Stream.concat(
+                associations.traces().stream().map(AssociationsJson.TraceSnapshot::studentId),
+                associations.declaredSkillProgresses().stream()
+                    .map(AssociationsJson.DeclaredSkillProgressSnapshot::studentId))
             .collect(Collectors.toSet());
 
     return studentJpaRepository.findAllById(ids).stream()

--- a/src/main/java/fr/avenirsesr/portfolio/student/experience/domain/service/DeclaredExperienceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/experience/domain/service/DeclaredExperienceServiceImpl.java
@@ -508,7 +508,7 @@ public class DeclaredExperienceServiceImpl implements DeclaredExperienceService 
       throw new TraceNotFoundException();
     }
 
-    if (!traces.stream().allMatch(trace -> trace.getUser().equals(student.getUser()))) {
+    if (!traces.stream().allMatch(trace -> trace.getStudent().equals(student))) {
       throw new UserNotAuthorizedException();
     }
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/domain/model/Trace.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/domain/model/Trace.java
@@ -1,10 +1,10 @@
 package fr.avenirsesr.portfolio.student.trace.domain.model;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.AvenirsBaseModel;
-import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.file.domain.model.File;
 import fr.avenirsesr.portfolio.student.trace.domain.model.enums.ETraceAuthorType;
+import fr.avenirsesr.portfolio.user.domain.model.Student;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -15,7 +15,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class Trace extends AvenirsBaseModel {
-  private final User user;
+  private final Student student;
   private String title;
   private ETraceAuthorType authorType;
   private ELanguage language;
@@ -35,7 +35,7 @@ public class Trace extends AvenirsBaseModel {
 
   private Trace(
       UUID id,
-      User user,
+      Student student,
       String title,
       ELanguage language,
       ETraceAuthorType authorType,
@@ -47,7 +47,7 @@ public class Trace extends AvenirsBaseModel {
       Instant createdAt,
       Instant updatedAt) {
     super(id, createdAt, updatedAt);
-    this.user = user;
+    this.student = student;
     this.title = title;
     this.language = language;
     this.authorType = authorType;
@@ -60,7 +60,7 @@ public class Trace extends AvenirsBaseModel {
 
   public static Trace create(
       UUID id,
-      User user,
+      Student student,
       String title,
       ELanguage language,
       ETraceAuthorType authorType,
@@ -71,7 +71,7 @@ public class Trace extends AvenirsBaseModel {
 
     return new Trace(
         id,
-        user,
+        student,
         title,
         language,
         authorType,
@@ -86,7 +86,7 @@ public class Trace extends AvenirsBaseModel {
 
   public static Trace toDomain(
       UUID id,
-      User user,
+      Student student,
       String title,
       ETraceAuthorType authorType,
       String aiUseJustification,
@@ -99,7 +99,7 @@ public class Trace extends AvenirsBaseModel {
       boolean valorized) {
     return new Trace(
         id,
-        user,
+        student,
         title,
         language,
         authorType,

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/domain/port/input/TraceService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/domain/port/input/TraceService.java
@@ -42,7 +42,7 @@ public interface TraceService {
 
   Trace createTrace(
       UUID traceId,
-      UUID userId,
+      UUID studentId,
       String title,
       ELanguage language,
       ETraceAuthorType authorType,

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/domain/port/output/repository/TraceRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/domain/port/output/repository/TraceRepository.java
@@ -3,24 +3,24 @@ package fr.avenirsesr.portfolio.student.trace.domain.port.output.repository;
 import fr.avenirsesr.portfolio.common.data.domain.model.DateFilter;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
-import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.port.output.repository.GenericRepositoryPort;
 import fr.avenirsesr.portfolio.student.trace.domain.filter.TraceFilter;
 import fr.avenirsesr.portfolio.student.trace.domain.model.Trace;
+import fr.avenirsesr.portfolio.user.domain.model.Student;
 import java.util.List;
 import java.util.Map;
 
 public interface TraceRepository extends GenericRepositoryPort<Trace> {
-  List<Trace> findLastsOf(User user, int limit);
+  List<Trace> findLastsOf(Student student, int limit);
 
   PagedResult<Trace> findAll(
-      User user,
+      Student student,
       String keyword,
       TraceFilter filter,
       DateFilter dateFilter,
       PageCriteria pageCriteria);
 
-  List<Trace> findAll(User user, boolean isAssociated);
+  List<Trace> findAll(Student student, boolean isAssociated);
 
   Map<Trace, Boolean> isAssociated(List<Trace> traces);
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/domain/service/TraceServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/domain/service/TraceServiceImpl.java
@@ -47,7 +47,8 @@ import fr.avenirsesr.portfolio.student.trace.domain.model.enums.ETraceAuthorType
 import fr.avenirsesr.portfolio.student.trace.domain.port.input.TraceService;
 import fr.avenirsesr.portfolio.student.trace.domain.port.output.repository.TraceRepository;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.client.TraceConfigurationClient;
-import fr.avenirsesr.portfolio.user.domain.port.input.UserService;
+import fr.avenirsesr.portfolio.user.domain.model.Student;
+import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -61,7 +62,7 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class TraceServiceImpl implements TraceService {
   private final TraceRepository traceRepository;
-  private final UserService userService;
+  private final StudentService studentService;
   private final DeclaredActivityService declaredActivityService;
   private final DeclaredSkillProgressService declaredSkillProgressService;
   private final DeclaredExperienceService declaredExperienceService;
@@ -89,18 +90,18 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public List<Trace> lastTracesOf() {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
-    return traceRepository.findLastsOf(loggedInUser, MAX_TRACES_OVERVIEW);
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
+    return traceRepository.findLastsOf(loggedInStudent, MAX_TRACES_OVERVIEW);
   }
 
   @Override
   public PagedResult<TraceViewData> getTracesView(
       String keyword, TraceFilter filter, DateFilter dateFilter, PageCriteria pageCriteria) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     var config = traceConfigurationClient.getTraceConfiguration();
 
     PagedResult<Trace> pagedResult =
-        traceRepository.findAll(loggedInUser, keyword, filter, dateFilter, pageCriteria);
+        traceRepository.findAll(loggedInStudent, keyword, filter, dateFilter, pageCriteria);
 
     List<Trace> traces = pagedResult.content();
 
@@ -141,7 +142,7 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public void deleteAllByIds(List<UUID> traceIds) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
 
     var traces = traceRepository.findAllById(traceIds);
 
@@ -149,7 +150,7 @@ public class TraceServiceImpl implements TraceService {
       throw new TraceNotFoundException();
     }
 
-    traces.forEach(trace -> checkIfUserIsAuthorizedOnTrace(loggedInUser, trace));
+    traces.forEach(trace -> checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace));
 
     var traceIdsToDelete = traces.stream().map(Trace::getId).toList();
 
@@ -184,9 +185,9 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public TracesSummaryData getTracesSummary() {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
-    List<Trace> associatedTraces = traceRepository.findAll(loggedInUser, true);
-    List<Trace> unassociatedTraces = traceRepository.findAll(loggedInUser, false);
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
+    List<Trace> associatedTraces = traceRepository.findAll(loggedInStudent, true);
+    List<Trace> unassociatedTraces = traceRepository.findAll(loggedInStudent, false);
     TraceConfiguration traceConfiguration = traceConfigurationClient.getTraceConfiguration();
 
     int criticalCount =
@@ -217,9 +218,9 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public TraceDetailData getTraceDetail(UUID id) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     Trace trace = traceRepository.findById(id).orElseThrow(TraceNotFoundException::new);
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
     var isTraceAssociated = traceRepository.isAssociated(List.of(trace)).get(trace);
     return buildTraceDetailData(trace, isTraceAssociated);
   }
@@ -242,10 +243,10 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public TraceAssociationsData getTraceAssociations(UUID traceId, boolean onlyNotCompleted) {
-    var userLoggedIn = loggedInUserService.getLoggedInUser();
+    var studentLoggedIn = loggedInUserService.getLoggedInStudent();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
 
-    checkIfUserIsAuthorizedOnTrace(userLoggedIn, trace);
+    checkIfStudentIsAuthorizedOnTrace(studentLoggedIn, trace);
 
     var associations =
         associationService.getAllOf(
@@ -299,7 +300,7 @@ public class TraceServiceImpl implements TraceService {
   @Override
   public Trace createTrace(
       UUID traceId,
-      UUID userId,
+      UUID studentId,
       String title,
       ELanguage language,
       ETraceAuthorType authorType,
@@ -309,7 +310,7 @@ public class TraceServiceImpl implements TraceService {
       boolean valorized) {
     return createTrace(
         traceId,
-        userService.getUser(userId),
+        studentService.getStudentById(studentId),
         title,
         language,
         authorType,
@@ -327,10 +328,10 @@ public class TraceServiceImpl implements TraceService {
       String personalNote,
       String aiJustification,
       String link) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     return createTrace(
         UUID.randomUUID(),
-        loggedInUser,
+        loggedInStudent,
         title,
         language,
         authorType,
@@ -342,7 +343,7 @@ public class TraceServiceImpl implements TraceService {
 
   private Trace createTrace(
       UUID traceId,
-      User user,
+      Student student,
       String title,
       ELanguage language,
       ETraceAuthorType authorType,
@@ -355,7 +356,15 @@ public class TraceServiceImpl implements TraceService {
     validateUrl(link);
     var trace =
         Trace.create(
-            traceId, user, title, language, authorType, aiJustification, personalNote, link, null);
+            traceId,
+            student,
+            title,
+            language,
+            authorType,
+            aiJustification,
+            personalNote,
+            link,
+            null);
     trace.setValorized(valorized);
 
     return traceRepository.save(trace);
@@ -371,9 +380,9 @@ public class TraceServiceImpl implements TraceService {
       String aiJustification,
       String link,
       boolean valorized) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
 
     trace.setTitle(title);
     trace.setLanguage(language);
@@ -419,9 +428,9 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public TraceAssociationsData associateTraceWithActivities(UUID traceId, List<UUID> activityIds) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
 
     var activities = declaredActivityService.findAllDeclaredActivitiesByIds(activityIds);
 
@@ -430,7 +439,7 @@ public class TraceServiceImpl implements TraceService {
       throw new DeclaredActivityNotFoundException();
     }
 
-    if (!activities.stream().allMatch(a -> a.getStudent().getUser().equals(loggedInUser))) {
+    if (!activities.stream().allMatch(a -> a.getStudent().equals(loggedInStudent))) {
       throw new UserNotAuthorizedException();
     }
 
@@ -482,9 +491,9 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public TraceAssociationsData associateTraceWithDeclaredSkill(UUID traceId, List<UUID> skillIds) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
 
     var declaredSkills = declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(skillIds);
 
@@ -493,7 +502,7 @@ public class TraceServiceImpl implements TraceService {
       throw new DeclaredSkillProgressNotFoundException();
     }
 
-    if (!declaredSkills.stream().allMatch(a -> a.getStudent().getUser().equals(loggedInUser))) {
+    if (!declaredSkills.stream().allMatch(a -> a.getStudent().equals(loggedInStudent))) {
       throw new UserNotAuthorizedException();
     }
 
@@ -510,9 +519,9 @@ public class TraceServiceImpl implements TraceService {
   @Override
   public TraceAssociationsData associateTraceWithDeclaredExperience(
       UUID traceId, List<UUID> experienceIds) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
 
     var declaredExperiences = declaredExperienceService.findAllByIds(experienceIds);
 
@@ -521,8 +530,7 @@ public class TraceServiceImpl implements TraceService {
       throw new DeclaredExperienceNotFoundException();
     }
 
-    if (!declaredExperiences.stream()
-        .allMatch(a -> a.getStudent().getUser().equals(loggedInUser))) {
+    if (!declaredExperiences.stream().allMatch(a -> a.getStudent().equals(loggedInStudent))) {
       throw new UserNotAuthorizedException();
     }
 
@@ -539,10 +547,10 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public void unassociate(UUID traceId, List<UUID> associationIds) {
-    User loggedInUser = loggedInUserService.getLoggedInUser();
+    Student loggedInStudent = loggedInUserService.getLoggedInStudent();
     Trace trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
 
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
 
     List<Association> associationList =
         associationService
@@ -641,7 +649,8 @@ public class TraceServiceImpl implements TraceService {
     }
 
     traces.forEach(
-        trace -> checkIfUserIsAuthorizedOnTrace(loggedInUserService.getLoggedInUser(), trace));
+        trace ->
+            checkIfStudentIsAuthorizedOnTrace(loggedInUserService.getLoggedInStudent(), trace));
 
     Map<UUID, List<UUID>> associatedDeclaredActivityIdsByTraceId =
         getAssociatedDeclaredActivityIdsByTraceId(traceIds);
@@ -691,16 +700,16 @@ public class TraceServiceImpl implements TraceService {
         .toList();
   }
 
-  private void checkIfUserIsAuthorizedOnTrace(User user, Trace trace) {
-    if (!trace.getUser().equals(user)) {
-      throw new TraceNotFoundException("%s does not own this %s".formatted(user, trace));
+  private void checkIfStudentIsAuthorizedOnTrace(Student student, Trace trace) {
+    if (!trace.getStudent().equals(student)) {
+      throw new TraceNotFoundException("%s does not own this %s".formatted(student, trace));
     }
   }
 
   private void checkTraceOwnership(UUID traceId) {
-    var loggedInUser = loggedInUserService.getLoggedInUser();
+    var loggedInStudent = loggedInUserService.getLoggedInStudent();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
   }
 
   private Map<UUID, List<UUID>> getAssociatedDeclaredActivityIdsByTraceId(List<UUID> traceIds) {
@@ -748,9 +757,9 @@ public class TraceServiceImpl implements TraceService {
   @Override
   public File uploadAttachment(
       UUID traceId, String fileName, String mimeType, long size, byte[] content) {
-    var loggedInUser = loggedInUserService.getLoggedInUser();
+    var loggedInStudent = loggedInUserService.getLoggedInStudent();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
     if (trace.getLink().isPresent()) {
       throw new InvalidTraceTypeException();
     }
@@ -763,9 +772,9 @@ public class TraceServiceImpl implements TraceService {
 
   @Override
   public FileDownload downloadAttachment(UUID traceId) {
-    var loggedInUser = loggedInUserService.getLoggedInUser();
+    var loggedInStudent = loggedInUserService.getLoggedInStudent();
     var trace = traceRepository.findById(traceId).orElseThrow(TraceNotFoundException::new);
-    checkIfUserIsAuthorizedOnTrace(loggedInUser, trace);
+    checkIfStudentIsAuthorizedOnTrace(loggedInStudent, trace);
     if (trace.getLink().isPresent()) {
       throw new InvalidTraceTypeException();
     }

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/mapper/TraceMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/mapper/TraceMapper.java
@@ -5,7 +5,7 @@ import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.mapper.FileMapper;
 import fr.avenirsesr.portfolio.student.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.model.TraceEntity;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
+import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
 
 public class TraceMapper implements Mapper<TraceEntity, Trace> {
   public static final TraceMapper INSTANCE = new TraceMapper();
@@ -14,7 +14,7 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
   public TraceEntity fromDomain(Trace trace) {
     return TraceEntity.of(
         trace.getId(),
-        UserMapper.INSTANCE.fromDomain(trace.getUser()),
+        StudentMapper.INSTANCE.fromDomain(trace.getStudent()),
         trace.getTitle(),
         trace.getLanguage(),
         trace.getAuthorType(),
@@ -31,7 +31,7 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
   public Trace toDomain(TraceEntity traceEntity) {
     return Trace.toDomain(
         traceEntity.getId(),
-        UserMapper.INSTANCE.toDomain(traceEntity.getUser()),
+        StudentMapper.INSTANCE.toDomain(traceEntity.getStudent()),
         traceEntity.getTitle(),
         traceEntity.getAuthorType(),
         traceEntity.getAiUseJustification(),
@@ -51,7 +51,9 @@ public class TraceMapper implements Mapper<TraceEntity, Trace> {
     var attributes = graph.attributes();
     return Trace.toDomain(
         traceEntity.getId(),
-        attributes.contains("user") ? UserMapper.INSTANCE.toDomain(traceEntity.getUser()) : null,
+        attributes.contains("student")
+            ? StudentMapper.INSTANCE.toDomain(traceEntity.getStudent())
+            : null,
         traceEntity.getTitle(),
         traceEntity.getAuthorType(),
         traceEntity.getAiUseJustification(),

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/model/TraceEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/model/TraceEntity.java
@@ -6,7 +6,7 @@ import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.model.AvenirsB
 import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.file.infrastructure.adapter.model.FileEntity;
 import fr.avenirsesr.portfolio.student.trace.domain.model.enums.ETraceAuthorType;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.UserEntity;
+import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.StudentEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
@@ -19,16 +19,16 @@ import lombok.Setter;
 @Table(
     name = "trace",
     indexes = {
-      @Index(name = "idx_trace_user_created", columnList = "user_id, created_at"),
-      @Index(name = "idx_trace_user_updated", columnList = "user_id, updated_at, created_at")
+      @Index(name = "idx_trace_student_created", columnList = "student_id, created_at"),
+      @Index(name = "idx_trace_student_updated", columnList = "student_id, updated_at, created_at")
     })
 @NoArgsConstructor
 @Getter
 @Setter
 public class TraceEntity extends AvenirsBaseEntity {
   @ManyToOne(optional = false)
-  @JoinColumn(name = "user_id", nullable = false)
-  private UserEntity user;
+  @JoinColumn(name = "student_id", nullable = false)
+  private StudentEntity student;
 
   @Column(nullable = false, length = TITLE_LENGTH)
   private String title;
@@ -62,7 +62,7 @@ public class TraceEntity extends AvenirsBaseEntity {
 
   private TraceEntity(
       UUID id,
-      UserEntity user,
+      StudentEntity student,
       String title,
       ELanguage language,
       ETraceAuthorType authorType,
@@ -76,7 +76,7 @@ public class TraceEntity extends AvenirsBaseEntity {
     this.setId(id);
     this.setCreatedAt(createdAt);
     this.setUpdatedAt(updatedAt);
-    this.user = user;
+    this.student = student;
     this.title = title;
     this.language = language;
     this.authorType = authorType;
@@ -89,7 +89,7 @@ public class TraceEntity extends AvenirsBaseEntity {
 
   public static TraceEntity of(
       UUID id,
-      UserEntity user,
+      StudentEntity student,
       String title,
       ELanguage language,
       ETraceAuthorType authorType,
@@ -102,7 +102,7 @@ public class TraceEntity extends AvenirsBaseEntity {
       Instant updatedAt) {
     return new TraceEntity(
         id,
-        user,
+        student,
         title,
         language,
         authorType,

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/repository/TraceDatabaseRepository.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/repository/TraceDatabaseRepository.java
@@ -3,8 +3,6 @@ package fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.repository;
 import fr.avenirsesr.portfolio.common.data.domain.model.DateFilter;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
-import fr.avenirsesr.portfolio.common.data.domain.model.User;
-import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.repository.GenericJpaRepositoryAdapter;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.specification.DateFilterSpecificationBuilder;
 import fr.avenirsesr.portfolio.common.language.infrastructure.adapter.utils.TranslationUtil;
 import fr.avenirsesr.portfolio.student.trace.domain.filter.TraceFilter;
@@ -14,6 +12,8 @@ import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.mapper.Trace
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.model.TraceEntity;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.specification.TraceFilterSpecificationBuilder;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.specification.TraceSpecification;
+import fr.avenirsesr.portfolio.user.domain.model.Student;
+import fr.avenirsesr.portfolio.user.infrastructure.adapter.repository.GenericUserJpaRepositoryAdapter;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @Repository
 @SQLRestriction("deleted_at IS NULL")
-public class TraceDatabaseRepository extends GenericJpaRepositoryAdapter<Trace, TraceEntity>
+public class TraceDatabaseRepository extends GenericUserJpaRepositoryAdapter<Trace, TraceEntity>
     implements TraceRepository {
   private final TraceJpaRepository jpaRepository;
 
@@ -38,9 +38,9 @@ public class TraceDatabaseRepository extends GenericJpaRepositoryAdapter<Trace, 
   }
 
   @Override
-  public List<Trace> findLastsOf(User user, int limit) {
+  public List<Trace> findLastsOf(Student student, int limit) {
     return findAll(
-            TraceSpecification.ofUser(user),
+            hasStudent(student),
             PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt")))
         .content();
   }
@@ -69,13 +69,13 @@ public class TraceDatabaseRepository extends GenericJpaRepositoryAdapter<Trace, 
 
   @Override
   public PagedResult<Trace> findAll(
-      User user,
+      Student student,
       String keyword,
       TraceFilter filter,
       DateFilter dateFilter,
       PageCriteria pageCriteria) {
 
-    Specification<TraceEntity> specification = TraceSpecification.ofUser(user);
+    Specification<TraceEntity> specification = hasStudent(student);
 
     var filterSpecification = new TraceFilterSpecificationBuilder().build(filter.toMap());
     if (filterSpecification.isPresent()) {
@@ -106,8 +106,8 @@ public class TraceDatabaseRepository extends GenericJpaRepositoryAdapter<Trace, 
   }
 
   @Override
-  public List<Trace> findAll(User user, boolean isAssociated) {
-    Specification<TraceEntity> specification = TraceSpecification.ofUser(user);
+  public List<Trace> findAll(Student student, boolean isAssociated) {
+    Specification<TraceEntity> specification = hasStudent(student);
 
     specification =
         specification.and(

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/seeder/FakeTrace.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/seeder/FakeTrace.java
@@ -3,7 +3,7 @@ package fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.seeder;
 import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.student.trace.domain.model.enums.ETraceAuthorType;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.model.TraceEntity;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.UserEntity;
+import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.StudentEntity;
 import java.time.Instant;
 import java.util.Random;
 import java.util.UUID;
@@ -20,12 +20,12 @@ public class FakeTrace {
     this.trace = trace;
   }
 
-  public static FakeTrace of(UserEntity user) {
+  public static FakeTrace of(StudentEntity student) {
     var fakeTrace =
         new FakeTrace(
             TraceEntity.of(
                 UUID.randomUUID(),
-                user,
+                student,
                 "Trace %s".formatted(faker().lorem().word()),
                 ELanguage.FALLBACK,
                 ETraceAuthorType.PERSONAL,

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/seeder/TraceSeeder.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/seeder/TraceSeeder.java
@@ -19,7 +19,8 @@ import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.mapper.Trace
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.model.TraceEntity;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.seeder.data.TraceAttachementCreationData;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.seeder.data.TraceCreationData;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.UserEntity;
+import fr.avenirsesr.portfolio.user.domain.model.Student;
+import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.StudentEntity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -58,8 +59,8 @@ public class TraceSeeder {
   }
 
   @Transactional
-  public List<TraceEntity> seed(List<UserEntity> users) {
-    ValidationUtils.requireNonEmpty(users, "users cannot be empty");
+  public List<TraceEntity> seed(List<StudentEntity> students) {
+    ValidationUtils.requireNonEmpty(students, "students cannot be empty");
 
     log.info("Seeding Traces...");
 
@@ -67,7 +68,7 @@ public class TraceSeeder {
         switch (seederSource) {
           case CSV ->
               fileReader.readJSON(PATH_FILE, new TypeReference<List<TraceCreationData>>() {});
-          case FAKER -> buildFakeTraces(users);
+          case FAKER -> buildFakeTraces(students);
         };
 
     List<Trace> traces = new ArrayList<>();
@@ -77,7 +78,7 @@ public class TraceSeeder {
           var trace =
               traceService.createTrace(
                   data.traceId(),
-                  data.userId(),
+                  data.studentId(),
                   data.title(),
                   data.language(),
                   data.authorType(),
@@ -88,7 +89,8 @@ public class TraceSeeder {
           traces.add(trace);
 
           RequestContext.set(
-              new RequestData(Optional.ofNullable(trace.getUser()), ELanguage.FRENCH));
+              new RequestData(
+                  Optional.ofNullable(trace.getStudent()).map(Student::getUser), ELanguage.FRENCH));
           data.attachements()
               .forEach(
                   attachment -> {
@@ -108,15 +110,15 @@ public class TraceSeeder {
     return traces.stream().map(TraceMapper.INSTANCE::fromDomain).toList();
   }
 
-  private List<TraceCreationData> buildFakeTraces(List<UserEntity> users) {
+  private List<TraceCreationData> buildFakeTraces(List<StudentEntity> students) {
     return IntStream.range(0, SeederConfig.TRACES_NB_MAX)
-        .mapToObj(i -> users.get(new Random().nextInt(users.size())))
-        .map(u -> FakeTrace.of(u).toEntity())
+        .mapToObj(i -> students.get(new Random().nextInt(students.size())))
+        .map(s -> FakeTrace.of(s).toEntity())
         .map(
             entity ->
                 new TraceCreationData(
                     entity.getId(),
-                    entity.getUser().getId(),
+                    entity.getStudent().getId(),
                     entity.getTitle(),
                     entity.getAuthorType(),
                     entity.getLanguage(),

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/seeder/data/TraceCreationData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/seeder/data/TraceCreationData.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public record TraceCreationData(
     UUID traceId,
-    UUID userId,
+    UUID studentId,
     String title,
     ETraceAuthorType authorType,
     ELanguage language,

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/service/TraceServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/service/TraceServiceConfig.java
@@ -12,7 +12,7 @@ import fr.avenirsesr.portfolio.student.trace.domain.port.input.TraceService;
 import fr.avenirsesr.portfolio.student.trace.domain.service.TraceServiceImpl;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.client.TraceConfigurationClient;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.repository.TraceDatabaseRepository;
-import fr.avenirsesr.portfolio.user.domain.port.input.UserService;
+import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
 import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Configuration;
 @AllArgsConstructor
 public class TraceServiceConfig {
   private final TraceDatabaseRepository traceRepository;
-  private final UserService userService;
+  private final StudentService studentService;
   private final DeclaredActivityService declaredActivityService;
   private final DeclaredSkillProgressService declaredSkillProgressService;
   private final DeclaredExperienceService declaredExperienceService;
@@ -36,7 +36,7 @@ public class TraceServiceConfig {
   public TraceService traceService() {
     return new TraceServiceImpl(
         traceRepository,
-        userService,
+        studentService,
         declaredActivityService,
         declaredSkillProgressService,
         declaredExperienceService,

--- a/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/specification/TraceSpecification.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/specification/TraceSpecification.java
@@ -1,22 +1,15 @@
 package fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.specification;
 
-import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.student.association.domain.model.EAssociationType;
 import fr.avenirsesr.portfolio.student.association.infrastructure.adapter.model.AssociationEntity;
 import fr.avenirsesr.portfolio.student.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.model.TraceEntity;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
 import jakarta.persistence.criteria.*;
 import java.util.UUID;
 import org.springframework.data.jpa.domain.Specification;
 
 public class TraceSpecification {
-  public static Specification<TraceEntity> ofUser(User user) {
-    return (root, query, criteriaBuilder) ->
-        criteriaBuilder.equal(root.get("user"), UserMapper.INSTANCE.fromDomain(user));
-  }
-
   public static Specification<TraceEntity> unassociated() {
     return (root, query, criteriaBuilder) ->
         criteriaBuilder.not(associated().toPredicate(root, query, criteriaBuilder));

--- a/src/main/resources/db/changelog/generated/changelog_2026-08-06__relink-trace-to-student.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-08-06__relink-trace-to-student.xml
@@ -1,0 +1,129 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Traces used to be linked directly to the user table. They are only ever created by
+        students (see TraceServiceImpl), and the student table's id is always equal to the id of
+        its underlying user (StudentEntity.of sets id = user.getId()), so trace.user_id already
+        holds valid student ids: no row data backfill is required, only relinking the column and
+        its constraints.
+    -->
+    <changeSet author="iamgreendev" id="relink-trace-to-student">
+        <dropIndex indexName="idx_trace_user_created" tableName="trace"/>
+        <dropIndex indexName="idx_trace_user_updated" tableName="trace"/>
+
+        <dropForeignKeyConstraint
+                baseTableName="trace"
+                constraintName="FKjiaa32cs961r7ly0idfap9soi"/>
+
+        <renameColumn
+                tableName="trace"
+                oldColumnName="user_id"
+                newColumnName="student_id"
+                columnDataType="UUID"/>
+
+        <addForeignKeyConstraint
+                baseColumnNames="student_id"
+                baseTableName="trace"
+                constraintName="FK_trace_student_id"
+                referencedColumnNames="id"
+                referencedTableName="student"
+                deferrable="false"
+                initiallyDeferred="false"
+                validate="true"/>
+
+        <createIndex indexName="idx_trace_student_created" tableName="trace">
+            <column name="student_id"/>
+            <column name="created_at"/>
+        </createIndex>
+        <createIndex indexName="idx_trace_student_updated" tableName="trace">
+            <column name="student_id"/>
+            <column name="updated_at"/>
+            <column name="created_at"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_trace_student_created" tableName="trace"/>
+            <dropIndex indexName="idx_trace_student_updated" tableName="trace"/>
+
+            <dropForeignKeyConstraint baseTableName="trace" constraintName="FK_trace_student_id"/>
+
+            <renameColumn
+                    tableName="trace"
+                    oldColumnName="student_id"
+                    newColumnName="user_id"
+                    columnDataType="UUID"/>
+
+            <addForeignKeyConstraint
+                    baseColumnNames="user_id"
+                    baseTableName="trace"
+                    constraintName="FKjiaa32cs961r7ly0idfap9soi"
+                    referencedColumnNames="id"
+                    referencedTableName="user"
+                    deferrable="false"
+                    initiallyDeferred="false"
+                    validate="true"/>
+
+            <createIndex indexName="idx_trace_user_created" tableName="trace">
+                <column name="user_id"/>
+                <column name="created_at"/>
+            </createIndex>
+            <createIndex indexName="idx_trace_user_updated" tableName="trace">
+                <column name="user_id"/>
+                <column name="updated_at"/>
+                <column name="created_at"/>
+            </createIndex>
+        </rollback>
+    </changeSet>
+
+    <!--
+        feedback.associations stores a JSONB snapshot of each associated trace, keyed by
+        "userId" (see AssociationsJson.TraceSnapshot). Now that traces are relinked to students,
+        the snapshot key must be renamed to "studentId" to match the new FeedbackMapper. The
+        stored id value itself does not change (student.id == user.id), only the JSON key.
+    -->
+    <changeSet author="iamgreendev" id="rename-trace-snapshot-userid-to-studentid-in-feedback-associations">
+        <sql>
+            UPDATE feedback
+            SET associations = jsonb_set(
+                associations,
+                '{traces}',
+                COALESCE(
+                    (
+                        SELECT jsonb_agg((t.elem - 'userId') || jsonb_build_object('studentId', t.elem -> 'userId'))
+                        FROM jsonb_array_elements(associations -> 'traces') AS t(elem)
+                    ),
+                    '[]'::jsonb
+                )
+            )
+            WHERE jsonb_typeof(associations -> 'traces') = 'array';
+        </sql>
+
+        <rollback>
+            <sql>
+                UPDATE feedback
+                SET associations = jsonb_set(
+                    associations,
+                    '{traces}',
+                    COALESCE(
+                        (
+                            SELECT jsonb_agg((t.elem - 'studentId') || jsonb_build_object('userId', t.elem -> 'studentId'))
+                            FROM jsonb_array_elements(associations -> 'traces') AS t(elem)
+                        ),
+                        '[]'::jsonb
+                    )
+                )
+                WHERE jsonb_typeof(associations -> 'traces') = 'array';
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/seeder/traces.json
+++ b/src/main/resources/seeder/traces.json
@@ -1,7 +1,7 @@
 [
   {
     "traceId": "4453f884-9081-43cb-95c6-d76c2bb59fd7",
-    "userId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
     "title": "Compte rendu",
     "authorType": "THIRD_PARTY",
     "language": "FRENCH",
@@ -18,7 +18,7 @@
   },
   {
     "traceId": "f3d22e78-e827-4bae-8831-44168c176198",
-    "userId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
     "title": "Rapport de stage – Analyse organisationnelle",
     "authorType": "PERSONAL",
     "language": "FRENCH",
@@ -41,7 +41,7 @@
   },
   {
     "traceId": "54ab9e1c-473d-4227-9c3e-c8c6adad6d88",
-    "userId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
     "title": "Rendu de TD – Chimie organique",
     "authorType": "COLLECTIVE",
     "language": "FRENCH",
@@ -58,7 +58,7 @@
   },
   {
     "traceId": "163b8f77-276f-4e96-bc49-e50c53f88d03",
-    "userId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
     "title": "Projet tutoré – Audit d’un poste de travail",
     "authorType": "COLLECTIVE",
     "language": "FRENCH",
@@ -87,7 +87,7 @@
   },
   {
     "traceId": "efb1f0ce-e531-49af-8031-949f3d68b354",
-    "userId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
     "title": "Rendu final – Mémoire de recherche",
     "authorType": "PERSONAL",
     "language": "FRENCH",
@@ -104,7 +104,7 @@
   },
   {
     "traceId": "4b02b225-998a-4996-be52-8d9b2a5ab327",
-    "userId": "d999193b-1835-43ee-b739-bd3209e95756",
+    "studentId": "d999193b-1835-43ee-b739-bd3209e95756",
     "title": "Rendu final – Mémoire de recherche",
     "authorType": "PERSONAL",
     "language": "FRENCH",
@@ -121,7 +121,7 @@
   },
   {
     "traceId": "3f9d7c52-8a4e-4d1f-b6a1-2c9e7b5f8d13",
-    "userId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
     "title": "Bilan fin de projet",
     "authorType": "PERSONAL",
     "language": "FRENCH",
@@ -138,7 +138,7 @@
   },
   {
     "traceId": "ca745573-544c-4c4c-9768-724f02c690a1",
-    "userId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
+    "studentId": "0a8700ab-90b6-4a38-8338-acbdd4fbcd3d",
     "title": "Lien vers travaux personnels",
     "authorType": "PERSONAL",
     "language": "FRENCH",

--- a/src/test/java/fr/avenirsesr/portfolio/student/activity/domain/service/DeclaredActivityServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/activity/domain/service/DeclaredActivityServiceImplTest.java
@@ -1607,7 +1607,7 @@ class DeclaredActivityServiceImplTest {
 
     Trace trace = mock(Trace.class);
     when(trace.getId()).thenReturn(traceId);
-    when(trace.getUser()).thenReturn(student.getUser());
+    when(trace.getStudent()).thenReturn(student);
 
     Association existingAssociation = mock(Association.class);
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/experience/domain/service/DeclaredExperienceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/experience/domain/service/DeclaredExperienceServiceImplTest.java
@@ -1452,8 +1452,8 @@ class DeclaredExperienceServiceImplTest {
       when(experience.getId()).thenReturn(experienceId);
       when(experience.getStudent()).thenReturn(student);
 
-      Trace trace1 = TraceFixture.create().withUser(student.getUser()).toModel();
-      Trace trace2 = TraceFixture.create().withUser(student.getUser()).toModel();
+      Trace trace1 = TraceFixture.create().withStudent(student).toModel();
+      Trace trace2 = TraceFixture.create().withStudent(student).toModel();
 
       when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
       when(experienceRepository.findById(experienceId)).thenReturn(Optional.of(experience));
@@ -1549,7 +1549,7 @@ class DeclaredExperienceServiceImplTest {
       DeclaredExperience experience = mock(DeclaredExperience.class);
       when(experience.getStudent()).thenReturn(student);
 
-      Trace trace1 = TraceFixture.create().withUser(student.getUser()).toModel();
+      Trace trace1 = TraceFixture.create().withStudent(student).toModel();
       UUID missingTraceId = UUID.randomUUID();
 
       when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
@@ -1579,7 +1579,7 @@ class DeclaredExperienceServiceImplTest {
       when(experience.getStudent()).thenReturn(student);
 
       Student anotherStudent = StudentFixture.create().toModel();
-      Trace trace = TraceFixture.create().withUser(anotherStudent.getUser()).toModel();
+      Trace trace = TraceFixture.create().withStudent(anotherStudent).toModel();
 
       when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
       when(experienceRepository.findById(experienceId)).thenReturn(Optional.of(experience));
@@ -1636,7 +1636,7 @@ class DeclaredExperienceServiceImplTest {
       when(experience.getId()).thenReturn(experienceId);
       when(experience.getStudent()).thenReturn(student);
 
-      Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+      Trace trace = TraceFixture.create().withStudent(student).toModel();
 
       when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
       when(experienceRepository.findById(experienceId)).thenReturn(Optional.of(experience));
@@ -1676,7 +1676,7 @@ class DeclaredExperienceServiceImplTest {
       when(experience.getId()).thenReturn(experienceId);
       when(experience.getStudent()).thenReturn(student);
 
-      Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+      Trace trace = TraceFixture.create().withStudent(student).toModel();
 
       when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
       when(experienceRepository.findById(experienceId)).thenReturn(Optional.of(experience));

--- a/src/test/java/fr/avenirsesr/portfolio/student/trace/application/adapter/controller/TraceControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/trace/application/adapter/controller/TraceControllerTest.java
@@ -22,6 +22,7 @@ import fr.avenirsesr.portfolio.student.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.student.trace.domain.model.enums.ETraceAuthorType;
 import fr.avenirsesr.portfolio.student.trace.domain.port.input.TraceService;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.fixture.TraceFixture;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.security.Principal;
 import java.util.*;
@@ -50,7 +51,10 @@ class TraceControllerTest {
   void setUp() {
     userId = UUID.randomUUID();
     user = UserFixture.create().withId(userId).toModel();
-    trace = TraceFixture.create().withUser(user).toModel();
+    trace =
+        TraceFixture.create()
+            .withStudent(StudentFixture.create().withUser(user).toModel())
+            .toModel();
     principal = () -> userId.toString();
   }
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/trace/domain/service/TraceServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/trace/domain/service/TraceServiceImplTest.java
@@ -41,9 +41,8 @@ import fr.avenirsesr.portfolio.student.trace.domain.port.output.repository.Trace
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.client.TraceConfigurationClient;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.fixture.TraceFixture;
 import fr.avenirsesr.portfolio.user.domain.model.Student;
-import fr.avenirsesr.portfolio.user.domain.port.input.UserService;
+import fr.avenirsesr.portfolio.user.domain.port.input.StudentService;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
-import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -66,7 +65,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TraceServiceImplTest {
 
   @Mock private TraceRepository traceRepository;
-  @Mock private UserService userService;
+  @Mock private StudentService studentService;
   @Mock private DeclaredActivityService declaredActivityService;
   @Mock private DeclaredSkillProgressService declaredSkillProgressService;
   @Mock private DeclaredExperienceService declaredExperienceService;
@@ -110,7 +109,7 @@ class TraceServiceImplTest {
     @BeforeEach
     void setupGiven() {
       BddLogger.given("a connected student");
-      lenient().when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
+      lenient().when(loggedInUserService.getLoggedInStudent()).thenReturn(student);
     }
 
     @Nested
@@ -127,18 +126,18 @@ class TraceServiceImplTest {
         List<Trace> traces =
             List.of(
                 TraceFixture.create()
-                    .withUser(student.getUser())
+                    .withStudent(student)
                     .withCreatedAt(Instant.now().minus(83, ChronoUnit.DAYS))
                     .toModel(),
                 TraceFixture.create()
-                    .withUser(student.getUser())
+                    .withStudent(student)
                     .withCreatedAt(Instant.now().minus(84, ChronoUnit.DAYS))
                     .toModel());
 
         var filter = new TraceFilter(false, null, null, null, null);
         var pageCriteria = new PageCriteria(pageNumber, pageSize);
 
-        when(traceRepository.findAll(student.getUser(), null, filter, null, pageCriteria))
+        when(traceRepository.findAll(student, null, filter, null, pageCriteria))
             .thenReturn(
                 new PagedResult<>(traces, new PageInfo(pageNumber, pageSize, totalElement)));
         when(traceConfigurationClient.getTraceConfiguration()).thenReturn(DEFAULT_CONFIG);
@@ -161,14 +160,13 @@ class TraceServiceImplTest {
         BddLogger.when("getting traces view with an unassociated trace");
 
         Instant createdAt = Instant.now().minus(10, ChronoUnit.DAYS);
-        Trace trace =
-            TraceFixture.create().withUser(student.getUser()).withCreatedAt(createdAt).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withCreatedAt(createdAt).toModel();
 
         var filter = new TraceFilter(false, null, null, null, null);
         var pageCriteria = new PageCriteria(0, 8);
 
         when(traceConfigurationClient.getTraceConfiguration()).thenReturn(DEFAULT_CONFIG);
-        when(traceRepository.findAll(student.getUser(), null, filter, null, pageCriteria))
+        when(traceRepository.findAll(student, null, filter, null, pageCriteria))
             .thenReturn(new PagedResult<>(List.of(trace), new PageInfo(0, 8, 1)));
         when(traceRepository.isAssociated(List.of(trace))).thenReturn(Map.of(trace, false));
 
@@ -193,13 +191,13 @@ class TraceServiceImplTest {
       void thenItShouldReturnEmptyWillBeDeletedAtWhenTraceIsAssociated() {
         BddLogger.when("getting traces view with an associated trace");
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
 
         var filter = new TraceFilter(false, null, null, null, null);
         var pageCriteria = new PageCriteria(0, 8);
 
         when(traceConfigurationClient.getTraceConfiguration()).thenReturn(DEFAULT_CONFIG);
-        when(traceRepository.findAll(student.getUser(), null, filter, null, pageCriteria))
+        when(traceRepository.findAll(student, null, filter, null, pageCriteria))
             .thenReturn(new PagedResult<>(List.of(trace), new PageInfo(0, 8, 1)));
         when(traceRepository.isAssociated(List.of(trace))).thenReturn(Map.of(trace, true));
 
@@ -224,29 +222,29 @@ class TraceServiceImplTest {
         List<Trace> unassociatedTraces =
             List.of(
                 TraceFixture.create()
-                    .withUser(student.getUser())
+                    .withStudent(student)
                     .withCreatedAt(Instant.now().minus(12, ChronoUnit.DAYS))
                     .toModel(),
                 TraceFixture.create()
-                    .withUser(student.getUser())
+                    .withStudent(student)
                     .withCreatedAt(Instant.now().minus(72, ChronoUnit.DAYS))
                     .toModel(),
                 TraceFixture.create()
-                    .withUser(student.getUser())
+                    .withStudent(student)
                     .withCreatedAt(Instant.now().minus(84, ChronoUnit.DAYS))
                     .toModel(),
                 TraceFixture.create()
-                    .withUser(student.getUser())
+                    .withStudent(student)
                     .withCreatedAt(Instant.now().minus(86, ChronoUnit.DAYS))
                     .toModel());
 
         List<Trace> associatedTraces =
             List.of(
-                TraceFixture.create().withUser(student.getUser()).toModel(),
-                TraceFixture.create().withUser(student.getUser()).toModel());
+                TraceFixture.create().withStudent(student).toModel(),
+                TraceFixture.create().withStudent(student).toModel());
 
-        when(traceRepository.findAll(student.getUser(), false)).thenReturn(unassociatedTraces);
-        when(traceRepository.findAll(student.getUser(), true)).thenReturn(associatedTraces);
+        when(traceRepository.findAll(student, false)).thenReturn(unassociatedTraces);
+        when(traceRepository.findAll(student, true)).thenReturn(associatedTraces);
         when(traceConfigurationClient.getTraceConfiguration()).thenReturn(DEFAULT_CONFIG);
 
         TracesSummaryData result = traceService.getTracesSummary();
@@ -283,7 +281,7 @@ class TraceServiceImplTest {
 
         Trace trace = captor.getValue();
 
-        assertEquals(student.getUser(), trace.getUser());
+        assertEquals(student, trace.getStudent());
         assertNotNull(trace.getId());
         assertEquals(title, trace.getTitle());
         assertEquals(language, trace.getLanguage());
@@ -348,7 +346,7 @@ class TraceServiceImplTest {
 
         Trace trace =
             TraceFixture.create()
-                .withUser(student.getUser())
+                .withStudent(student)
                 .withTitle("Test Title")
                 .withLanguage(ELanguage.ENGLISH)
                 .withAuthorType(ETraceAuthorType.PERSONAL)
@@ -375,7 +373,7 @@ class TraceServiceImplTest {
 
         Trace updatedTrace = captor.getValue();
 
-        assertEquals(student.getUser(), updatedTrace.getUser());
+        assertEquals(student, updatedTrace.getStudent());
         assertEquals("Test Title - Updated", updatedTrace.getTitle());
         assertEquals(ELanguage.FRENCH, updatedTrace.getLanguage());
         assertEquals(ETraceAuthorType.COLLECTIVE, updatedTrace.getAuthorType());
@@ -390,10 +388,7 @@ class TraceServiceImplTest {
         BddLogger.when("updating a trace with link");
 
         Trace trace =
-            TraceFixture.create()
-                .withUser(student.getUser())
-                .withLink("https://example.com")
-                .toModel();
+            TraceFixture.create().withStudent(student).withLink("https://example.com").toModel();
 
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
         when(traceRepository.save(trace)).thenReturn(trace);
@@ -425,7 +420,7 @@ class TraceServiceImplTest {
 
         Trace trace =
             TraceFixture.create()
-                .withUser(student.getUser())
+                .withStudent(student)
                 .withPersonalNote("Some personal note")
                 .withAiUseJustification("Justified by AI")
                 .toModel();
@@ -460,7 +455,7 @@ class TraceServiceImplTest {
       void thenItShouldReturnDeletableFalseWhenAssociatedTraceIsLocked() {
         BddLogger.when("updating an associated locked trace");
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
 
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
         when(traceRepository.save(trace)).thenReturn(trace);
@@ -479,7 +474,7 @@ class TraceServiceImplTest {
       void thenItShouldReturnDeletableTrueWhenAssociatedTraceIsUnlocked() {
         BddLogger.when("updating an associated unlocked trace");
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
 
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
         when(traceRepository.save(trace)).thenReturn(trace);
@@ -498,8 +493,7 @@ class TraceServiceImplTest {
       void thenItShouldUpdateValorizedFieldToTrue() {
         BddLogger.when("updating a trace and setting valorized to true");
 
-        Trace trace =
-            TraceFixture.create().withUser(student.getUser()).withValorized(false).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withValorized(false).toModel();
 
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
         when(traceRepository.save(trace)).thenReturn(trace);
@@ -527,8 +521,7 @@ class TraceServiceImplTest {
       void thenItShouldUpdateValorizedFieldToFalse() {
         BddLogger.when("updating a trace and setting valorized to false");
 
-        Trace trace =
-            TraceFixture.create().withUser(student.getUser()).withValorized(true).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withValorized(true).toModel();
 
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
         when(traceRepository.save(trace)).thenReturn(trace);
@@ -582,7 +575,8 @@ class TraceServiceImplTest {
       void thenItShouldThrowTraceNotFoundWhenTraceBelongsToAnotherUser() {
         BddLogger.when("updating a trace owned by another user");
 
-        Trace trace = TraceFixture.create().withUser(UserFixture.create().toModel()).toModel();
+        Trace trace =
+            TraceFixture.create().withStudent(StudentFixture.create().toModel()).toModel();
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
 
         TraceNotFoundException exception =
@@ -621,7 +615,7 @@ class TraceServiceImplTest {
         List<UUID> traceIds = List.of(traceId);
 
         when(trace.getId()).thenReturn(traceId);
-        when(trace.getUser()).thenReturn(student.getUser());
+        when(trace.getStudent()).thenReturn(student);
         when(trace.getAttachment()).thenReturn(Optional.of(file));
         when(file.getId()).thenReturn(fileId);
 
@@ -650,7 +644,7 @@ class TraceServiceImplTest {
         List<UUID> traceIds = List.of(traceId);
 
         when(trace.getId()).thenReturn(traceId);
-        when(trace.getUser()).thenReturn(student.getUser());
+        when(trace.getStudent()).thenReturn(student);
         when(trace.getAttachment()).thenReturn(Optional.of(file));
         when(file.getId()).thenReturn(fileId);
 
@@ -679,7 +673,7 @@ class TraceServiceImplTest {
         List<UUID> traceIds = List.of(traceId);
 
         when(trace.getId()).thenReturn(traceId);
-        when(trace.getUser()).thenReturn(student.getUser());
+        when(trace.getStudent()).thenReturn(student);
         when(trace.getAttachment()).thenReturn(Optional.of(file));
         when(file.getId()).thenReturn(fileId);
 
@@ -701,7 +695,7 @@ class TraceServiceImplTest {
       void thenItShouldThrowTraceNotFoundWhenOneTraceDoesNotExist() {
         BddLogger.when("deleting traces with one unknown trace");
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
         UUID missingTraceId = UUID.randomUUID();
 
         List<UUID> traceIds = List.of(trace.getId(), missingTraceId);
@@ -723,9 +717,9 @@ class TraceServiceImplTest {
       void thenItShouldThrowTraceNotFoundWhenOneTraceBelongsToAnotherUser() {
         BddLogger.when("deleting traces with one trace owned by another user");
 
-        Trace ownedTrace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace ownedTrace = TraceFixture.create().withStudent(student).toModel();
         Trace otherUserTrace =
-            TraceFixture.create().withUser(UserFixture.create().toModel()).toModel();
+            TraceFixture.create().withStudent(StudentFixture.create().toModel()).toModel();
 
         List<UUID> traceIds = List.of(ownedTrace.getId(), otherUserTrace.getId());
 
@@ -752,7 +746,7 @@ class TraceServiceImplTest {
 
         Trace trace =
             TraceFixture.create()
-                .withUser(student.getUser())
+                .withStudent(student)
                 .withTitle("Trace title")
                 .withLanguage(ELanguage.FRENCH)
                 .withAuthorType(ETraceAuthorType.PERSONAL)
@@ -776,7 +770,7 @@ class TraceServiceImplTest {
       void thenItShouldReturnAssociatedAndNotDeletableTraceDetailWhenAssociationsAreLocked() {
         BddLogger.when("getting trace detail for an associated locked trace");
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
 
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
         when(traceRepository.isAssociated(List.of(trace))).thenReturn(Map.of(trace, true));
@@ -792,7 +786,7 @@ class TraceServiceImplTest {
       void thenItShouldReturnUnassociatedAndDeletableTraceDetailWithoutCheckingAssociations() {
         BddLogger.when("getting trace detail for an unassociated trace");
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
 
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
         when(traceRepository.isAssociated(List.of(trace))).thenReturn(Map.of(trace, false));
@@ -810,7 +804,8 @@ class TraceServiceImplTest {
       void thenItShouldThrowTraceNotFoundWhenTraceBelongsToAnotherUser() {
         BddLogger.when("getting trace detail of another user");
 
-        Trace trace = TraceFixture.create().withUser(UserFixture.create().toModel()).toModel();
+        Trace trace =
+            TraceFixture.create().withStudent(StudentFixture.create().toModel()).toModel();
 
         when(traceRepository.findById(trace.getId())).thenReturn(Optional.of(trace));
 
@@ -834,7 +829,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         UUID activityId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         Association association = mock(Association.class);
         when(association.getAssociationType()).thenReturn(EAssociationType.DECLARED_ACTIVITY_TRACE);
@@ -864,7 +859,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         UUID activityId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         Association association = mock(Association.class);
         when(association.getAssociationType()).thenReturn(EAssociationType.DECLARED_ACTIVITY_TRACE);
@@ -910,7 +905,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         Trace trace =
             TraceFixture.create()
-                .withUser(UserFixture.create().toModel())
+                .withStudent(StudentFixture.create().toModel())
                 .withId(traceId)
                 .toModel();
 
@@ -933,7 +928,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         UUID skillId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         DeclaredSkillProgress skill = mock(DeclaredSkillProgress.class);
         when(skill.getId()).thenReturn(skillId);
@@ -962,7 +957,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         UUID skillId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         when(traceRepository.findById(traceId)).thenReturn(Optional.of(trace));
         when(declaredSkillProgressService.findAllDeclaredSkillProgressesByIds(List.of(skillId)))
@@ -982,7 +977,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         UUID skillId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         DeclaredSkillProgress skill = mock(DeclaredSkillProgress.class);
         when(skill.getId()).thenReturn(skillId);
@@ -1010,7 +1005,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         UUID experienceId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         DeclaredExperience experience = mock(DeclaredExperience.class);
         when(experience.getId()).thenReturn(experienceId);
@@ -1039,7 +1034,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         UUID experienceId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         when(traceRepository.findById(traceId)).thenReturn(Optional.of(trace));
         when(declaredExperienceService.findAllByIds(List.of(experienceId))).thenReturn(List.of());
@@ -1059,7 +1054,7 @@ class TraceServiceImplTest {
         UUID traceId = UUID.randomUUID();
         UUID experienceId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
         DeclaredExperience experience = Mockito.mock(DeclaredExperience.class);
 
         when(traceRepository.findById(traceId)).thenReturn(Optional.of(trace));
@@ -1089,7 +1084,7 @@ class TraceServiceImplTest {
         UUID associationId2 = UUID.randomUUID();
         List<UUID> idsToDelete = List.of(associationId1, associationId2);
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         Association association1 = mock(Association.class);
         when(association1.getId()).thenReturn(associationId1);
@@ -1116,7 +1111,7 @@ class TraceServiceImplTest {
         UUID linkedAssociationId = UUID.randomUUID();
         UUID unlinkedAssociationId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
 
         Association association = mock(Association.class);
         when(association.getId()).thenReturn(linkedAssociationId);
@@ -1145,7 +1140,7 @@ class TraceServiceImplTest {
         UUID associationId = UUID.randomUUID();
         UUID activityId = UUID.randomUUID();
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).withId(traceId).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).withId(traceId).toModel();
 
         Association association = mock(Association.class);
         when(association.getId()).thenReturn(associationId);
@@ -1179,8 +1174,8 @@ class TraceServiceImplTest {
       void thenItShouldReturnLockedDeclaredActivitiesGroupedByTrace() {
         BddLogger.when("getting locked declared activities for traces");
 
-        Trace firstTrace = TraceFixture.create().withUser(student.getUser()).toModel();
-        Trace secondTrace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace firstTrace = TraceFixture.create().withStudent(student).toModel();
+        Trace secondTrace = TraceFixture.create().withStudent(student).toModel();
 
         UUID firstDeclaredActivityId = UUID.randomUUID();
         UUID secondDeclaredActivityId = UUID.randomUUID();
@@ -1265,7 +1260,7 @@ class TraceServiceImplTest {
         BddLogger.when(
             "getting locked declared activities for traces without declared activity association");
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
         List<UUID> traceIds = List.of(trace.getId());
 
         when(traceRepository.findAllById(traceIds)).thenReturn(List.of(trace));
@@ -1294,7 +1289,7 @@ class TraceServiceImplTest {
       void thenItShouldThrowTraceNotFoundWhenOneTraceDoesNotExist() {
         BddLogger.when("getting locked declared activities with one unknown trace");
 
-        Trace trace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace trace = TraceFixture.create().withStudent(student).toModel();
         UUID missingTraceId = UUID.randomUUID();
         List<UUID> traceIds = List.of(trace.getId(), missingTraceId);
 
@@ -1312,9 +1307,9 @@ class TraceServiceImplTest {
       void thenItShouldThrowTraceNotFoundWhenOneTraceBelongsToAnotherUser() {
         BddLogger.when("getting locked declared activities with one trace owned by another user");
 
-        Trace ownedTrace = TraceFixture.create().withUser(student.getUser()).toModel();
+        Trace ownedTrace = TraceFixture.create().withStudent(student).toModel();
         Trace otherUserTrace =
-            TraceFixture.create().withUser(UserFixture.create().toModel()).toModel();
+            TraceFixture.create().withStudent(StudentFixture.create().toModel()).toModel();
 
         List<UUID> traceIds = List.of(ownedTrace.getId(), otherUserTrace.getId());
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/seeder/TraceSeederTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/seeder/TraceSeederTest.java
@@ -7,7 +7,7 @@ import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.shared.infrastructure.ContainerConfigurationTest;
 import fr.avenirsesr.portfolio.student.skill.infrastructure.adapter.seeder.DeclaredSkillSeeder;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.model.TraceEntity;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.UserEntity;
+import fr.avenirsesr.portfolio.user.infrastructure.adapter.model.StudentEntity;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.seeder.StudentSeeder;
 import fr.avenirsesr.portfolio.user.infrastructure.adapter.seeder.UserSeeder;
 import java.util.List;
@@ -26,42 +26,44 @@ class TraceSeederTest extends ContainerConfigurationTest {
   @Autowired private StudentSeeder studentSeeder;
   @Autowired private DeclaredSkillSeeder declaredSkillSeeder;
 
-  private static List<UserEntity> users;
+  private static List<StudentEntity> students;
 
   @BeforeAll
   void setUp() {
-    users = userSeeder.seed();
-    studentSeeder.seed(users);
+    var users = userSeeder.seed();
+    students = studentSeeder.seed(users);
     declaredSkillSeeder.seed();
   }
 
   @Test
   void seed_shouldThrowException_whenUsersEmpty() {
     BddLogger.given("a trace seeder");
-    List<UserEntity> emptyUsers = List.of();
+    List<StudentEntity> emptyStudents = List.of();
 
-    BddLogger.when("seeding traces and there is no users");
+    BddLogger.when("seeding traces and there is no students");
     BddLogger.then("it should throw IllegalArgumentException");
     Exception exception =
-        assertThrows(IllegalArgumentException.class, () -> traceSeeder.seed(emptyUsers));
-    assertTrue(exception.getMessage().contains("users cannot be empty"));
+        assertThrows(IllegalArgumentException.class, () -> traceSeeder.seed(emptyStudents));
+    assertTrue(exception.getMessage().contains("students cannot be empty"));
   }
 
   @Test
   void seed_shouldReturnTraces_withCorrectSizeAndUser() {
     BddLogger.given("a trace seeder");
-    BddLogger.when("seeding traces with correct fileSize and user");
-    List<TraceEntity> traces = traceSeeder.seed(users);
+    BddLogger.when("seeding traces with correct file size and user");
+    List<TraceEntity> traces = traceSeeder.seed(students);
 
     BddLogger.then("it should return traces");
     assertNotNull(traces);
     assertFalse(traces.isEmpty());
 
-    // Vérifie que chaque trace est associée à un utilisateur
     for (TraceEntity trace : traces) {
-      assertNotNull(trace.getUser());
+      assertNotNull(trace.getStudent());
       assertTrue(
-          users.stream().map(AvenirsBaseEntity::getId).toList().contains(trace.getUser().getId()));
+          students.stream()
+              .map(AvenirsBaseEntity::getId)
+              .toList()
+              .contains(trace.getStudent().getId()));
     }
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/trace/infrastructure/adapter/specification/TraceSpecificationIT.java
@@ -61,9 +61,9 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
         builder.getSpecification(ETraceFilterKey.FILE_TYPE, List.of());
 
     List<TraceEntity> resultNull =
-        traceJpaRepository.findAll(ofTestUser(user.getId()).and(specNull));
+        traceJpaRepository.findAll(ofTestStudent(student.getId()).and(specNull));
     List<TraceEntity> resultEmpty =
-        traceJpaRepository.findAll(ofTestUser(user.getId()).and(specEmpty));
+        traceJpaRepository.findAll(ofTestStudent(student.getId()).and(specEmpty));
 
     assertThat(resultNull).extracting(TraceEntity::getId).contains(t1.getId(), t2.getId());
     assertThat(resultEmpty).extracting(TraceEntity::getId).contains(t1.getId(), t2.getId());
@@ -87,7 +87,8 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
 
     List<TraceEntity> result =
         traceJpaRepository.findAll(
-            ofTestUser(user.getId()).and(TraceSpecification.search("java", ELanguage.FRENCH)));
+            ofTestStudent(student.getId())
+                .and(TraceSpecification.search("java", ELanguage.FRENCH)));
 
     assertThat(result).extracting(TraceEntity::getId).contains(byTitle.getId());
     assertThat(result).extracting(TraceEntity::getId).contains(byAiUse.getId());
@@ -105,10 +106,10 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
 
     List<TraceEntity> resultNull =
         traceJpaRepository.findAll(
-            ofTestUser(user.getId()).and(TraceSpecification.search(null, ELanguage.FRENCH)));
+            ofTestStudent(student.getId()).and(TraceSpecification.search(null, ELanguage.FRENCH)));
     List<TraceEntity> resultBlank =
         traceJpaRepository.findAll(
-            ofTestUser(user.getId()).and(TraceSpecification.search("   ", ELanguage.FRENCH)));
+            ofTestStudent(student.getId()).and(TraceSpecification.search("   ", ELanguage.FRENCH)));
 
     assertThat(resultNull).extracting(TraceEntity::getId).contains(t1.getId(), t2.getId());
     assertThat(resultBlank).extracting(TraceEntity::getId).contains(t1.getId(), t2.getId());
@@ -136,10 +137,10 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
 
     List<TraceEntity> valorizedResult =
         traceJpaRepository.findAll(
-            ofTestUser(user.getId()).and(TraceSpecification.valorized(true)));
+            ofTestStudent(student.getId()).and(TraceSpecification.valorized(true)));
     List<TraceEntity> notValorizedResult =
         traceJpaRepository.findAll(
-            ofTestUser(user.getId()).and(TraceSpecification.valorized(false)));
+            ofTestStudent(student.getId()).and(TraceSpecification.valorized(false)));
 
     assertThat(valorizedResult).extracting(TraceEntity::getId).contains(valorized.getId());
     assertThat(valorizedResult).extracting(TraceEntity::getId).doesNotContain(notValorized.getId());
@@ -188,8 +189,8 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
     assertThat(spec).isNull();
   }
 
-  private Specification<TraceEntity> ofTestUser(UUID userId) {
-    return (root, query, cb) -> cb.equal(root.get("user").get("id"), userId);
+  private Specification<TraceEntity> ofTestStudent(UUID studentId) {
+    return (root, query, cb) -> cb.equal(root.get("student").get("id"), studentId);
   }
 
   private UserEntity persistUser() {
@@ -228,7 +229,7 @@ class TraceSpecificationIT extends ContainerConfigurationTest {
     TraceEntity trace =
         TraceEntity.of(
             UUID.randomUUID(),
-            user,
+            student,
             title,
             ELanguage.FRENCH,
             ETraceAuthorType.PERSONAL,

--- a/src/test/java/fr/avenirsesr/portfolio/student/trace/infrastructure/fixture/TraceFixture.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/trace/infrastructure/fixture/TraceFixture.java
@@ -1,21 +1,21 @@
 package fr.avenirsesr.portfolio.student.trace.infrastructure.fixture;
 
-import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.language.domain.model.enums.ELanguage;
 import fr.avenirsesr.portfolio.file.domain.model.File;
 import fr.avenirsesr.portfolio.file.domain.model.enums.EFileType;
 import fr.avenirsesr.portfolio.student.trace.domain.model.Trace;
 import fr.avenirsesr.portfolio.student.trace.domain.model.enums.ETraceAuthorType;
 import fr.avenirsesr.portfolio.student.trace.infrastructure.adapter.seeder.FakeTrace;
-import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.UserMapper;
-import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
+import fr.avenirsesr.portfolio.user.domain.model.Student;
+import fr.avenirsesr.portfolio.user.infrastructure.adapter.mapper.StudentMapper;
+import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import java.time.Instant;
 import java.util.UUID;
 
 public class TraceFixture {
 
   private UUID id;
-  private User user;
+  private Student student;
   private String title;
   private Instant createdAt;
   private Instant updatedAt;
@@ -28,17 +28,24 @@ public class TraceFixture {
   private boolean valorized;
 
   private TraceFixture() {
-    var fakeUser = UserFixture.create().toModel();
-    var base = FakeTrace.of(UserMapper.INSTANCE.fromDomain(fakeUser)).toEntity();
+    var fakeStudent = StudentFixture.create().toModel();
+    var base = FakeTrace.of(StudentMapper.INSTANCE.fromDomain(fakeStudent)).toEntity();
     this.id = base.getId();
-    this.user = fakeUser;
+    this.student = fakeStudent;
     this.title = base.getTitle();
     this.createdAt = base.getCreatedAt();
     this.updatedAt = base.getUpdatedAt();
     this.authorType = base.getAuthorType();
     this.valorized = base.isValorized();
     this.attachment =
-        File.create(UUID.randomUUID(), EFileType.PDF, "my fake pdf", 1000L, "fake-url", user, true);
+        File.create(
+            UUID.randomUUID(),
+            EFileType.PDF,
+            "my fake pdf",
+            1000L,
+            "fake-url",
+            student.getUser(),
+            true);
   }
 
   public static TraceFixture create() {
@@ -50,8 +57,8 @@ public class TraceFixture {
     return this;
   }
 
-  public TraceFixture withUser(User user) {
-    this.user = user;
+  public TraceFixture withStudent(Student student) {
+    this.student = student;
     return this;
   }
 
@@ -108,7 +115,7 @@ public class TraceFixture {
   public Trace toModel() {
     return Trace.toDomain(
         id,
-        user,
+        student,
         title,
         authorType,
         aiUseJustification,


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Traces were linked directly to `User`. They now reference `Student` throughout the stack (domain model, JPA entity, repository, specification, mapper, service), matching the pattern already used by `DeclaredActivity`/`DeclaredExperience`. Includes a Liquibase migration renaming `trace.user_id` to `trace.student_id` (repointing the FK to `student`, no row backfill needed since `student.id` always equals the underlying `user.id`), plus a data migration for the `userId` key stored inside `feedback.associations` trace snapshots (renamed to `studentId`) so existing feedback JSON stays readable.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2365

---

### Documentation
> No external documentation updated. The new Liquibase changelog (`changelog_2026-08-06__relink-trace-to-student.xml`) is self-documented with an inline comment explaining why no row backfill is required for the `trace` table and why the `feedback.associations` JSONB snapshot needs a key rename.

---

### Target Branch
> `develop`

---

### Additional Notes
> - Also updated `TraceSeeder`/`TraceCreationData`/`traces.json` (seed field `userId` → `studentId`) and the `SeederOrchestrator` call site.
> - `FeedbackMapper`/`FeedbackDatabaseRepository`/`AssociationsJson` were touched because trace ownership snapshots stored in feedback records referenced a user id; they now resolve/store a student id instead.

---

### Known Limitations or Side Effects
> None identified. The migration is a metadata-only rename for the `trace` table (values are preserved as-is) and a targeted JSONB key rename for `feedback.associations`.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process