### PR TITLE
feat(feedback): add attachments uploaded by the activity author

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/application/adapter/controller/FeedbackController.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/application/adapter/controller/FeedbackController.java
@@ -1,9 +1,13 @@
 package fr.avenirsesr.portfolio.student.activity.application.adapter.controller;
 
+import static fr.avenirsesr.portfolio.shared.application.adapter.Utils.readBytes;
+
 import fr.avenirsesr.portfolio.common.data.application.adapter.dto.PageInfoDTO;
 import fr.avenirsesr.portfolio.common.data.application.adapter.response.PagedResponse;
 import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
+import fr.avenirsesr.portfolio.file.application.adapter.dto.FileDTO;
+import fr.avenirsesr.portfolio.file.application.adapter.mapper.FileDtoMapper;
 import fr.avenirsesr.portfolio.student.activity.application.adapter.dto.FeedbackDashboardDTO;
 import fr.avenirsesr.portfolio.student.activity.application.adapter.dto.FeedbackDetailsDTO;
 import fr.avenirsesr.portfolio.student.activity.application.adapter.dto.FeedbackOverviewDTO;
@@ -24,9 +28,12 @@ import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,6 +42,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @Slf4j
@@ -46,6 +54,7 @@ public class FeedbackController {
   private final FeedbackStaffListItemDTOMapper feedbackStaffListItemDTOMapper;
   private final StudentFeedbackItemListDTOMapper studentFeedbackItemListDTOMapper;
   private final FeedbackOverviewDTOMapper feedbackOverviewDTOMapper;
+  private final FileDtoMapper fileDtoMapper;
 
   @PreAuthorize("hasAuthority('feedback:request:read:assigned')")
   @GetMapping
@@ -166,5 +175,62 @@ public class FeedbackController {
         "Received request to submit feedback [{}] by user [{}]", feedbackId, principal.getName());
     feedbackService.submitFeedback(feedbackId);
     return ResponseEntity.noContent().build();
+  }
+
+  @PreAuthorize("hasAuthority('feedback:request:respond:assigned')")
+  @PostMapping(value = "/{feedbackId}/attachments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<FileDTO> uploadAttachment(
+      Principal principal,
+      @Valid @PathVariable UUID feedbackId,
+      @RequestParam("file") MultipartFile file) {
+    log.debug(
+        "Received request to upload an attachment on feedback [{}] by user [{}]",
+        feedbackId,
+        principal.getName());
+    var uploaded =
+        feedbackService.uploadAttachment(
+            feedbackId,
+            file.getOriginalFilename(),
+            file.getContentType(),
+            file.getSize(),
+            readBytes(file));
+    return ResponseEntity.status(HttpStatus.CREATED).body(fileDtoMapper.fromDomain(uploaded));
+  }
+
+  @PreAuthorize("hasAuthority('feedback:request:respond:assigned')")
+  @DeleteMapping("/{feedbackId}/attachments/{attachmentId}")
+  public ResponseEntity<Void> deleteAttachment(
+      Principal principal,
+      @Valid @PathVariable UUID feedbackId,
+      @Valid @PathVariable UUID attachmentId) {
+    log.debug(
+        "Received request to delete attachment [{}] of feedback [{}] by user [{}]",
+        attachmentId,
+        feedbackId,
+        principal.getName());
+    feedbackService.deleteAttachment(feedbackId, attachmentId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PreAuthorize("hasAnyAuthority('feedback:received:read:own','feedback:request:read:assigned')")
+  @GetMapping(
+      value = "/{feedbackId}/attachments/{attachmentId}/download",
+      produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+  public ResponseEntity<byte[]> downloadAttachment(
+      Principal principal,
+      @Valid @PathVariable UUID feedbackId,
+      @Valid @PathVariable UUID attachmentId) {
+    log.debug(
+        "Received request to download attachment [{}] of feedback [{}] by user [{}]",
+        attachmentId,
+        feedbackId,
+        principal.getName());
+    var downloadedFile = feedbackService.downloadAttachment(feedbackId, attachmentId);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=\"" + downloadedFile.fileName() + "\"")
+        .body(downloadedFile.content());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/application/adapter/dto/FeedbackDetailsDTO.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/application/adapter/dto/FeedbackDetailsDTO.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.activity.application.adapter.dto;
 
+import fr.avenirsesr.portfolio.file.application.adapter.dto.FileDTO;
 import fr.avenirsesr.portfolio.staff.activity.application.adapter.dto.ActivityContentDTO;
 import fr.avenirsesr.portfolio.student.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.skill.application.adapter.dto.DeclaredSkillProgressDTO;
@@ -30,5 +31,6 @@ public record FeedbackDetailsDTO(
     @Schema(ref = "#/components/schemas/EFeedbackStatus") EFeedbackStatus status,
     List<TraceDetailDTO> associatedTraces,
     List<DeclaredSkillProgressDTO> associatedDeclaredSkills,
+    List<FileDTO> attachments,
     Instant createdAt,
     Instant updatedAt) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/application/adapter/mapper/FeedbackDetailsDTOMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/application/adapter/mapper/FeedbackDetailsDTOMapper.java
@@ -1,6 +1,7 @@
 package fr.avenirsesr.portfolio.student.activity.application.adapter.mapper;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
+import fr.avenirsesr.portfolio.file.application.adapter.mapper.FileDtoMapper;
 import fr.avenirsesr.portfolio.shared.application.adapter.mapper.OptionalMapper;
 import fr.avenirsesr.portfolio.staff.activity.application.adapter.mapper.ActivityContentDtoMapper;
 import fr.avenirsesr.portfolio.student.activity.application.adapter.dto.FeedbackDetailsDTO;
@@ -18,7 +19,8 @@ import org.mapstruct.Mapping;
       OptionalMapper.class,
       TraceDetailMapper.class,
       DeclaredSkillProgressMapper.class,
-      ActivityContentDtoMapper.class
+      ActivityContentDtoMapper.class,
+      FileDtoMapper.class
     })
 public interface FeedbackDetailsDTOMapper {
 

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/data/FeedbackData.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/data/FeedbackData.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.activity.domain.data;
 
+import fr.avenirsesr.portfolio.file.domain.model.File;
 import fr.avenirsesr.portfolio.student.activity.domain.model.DeclaredActivity;
 import fr.avenirsesr.portfolio.student.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.skill.domain.model.DeclaredSkillProgress;
@@ -9,9 +10,10 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Represents the details of a feedback. The {@code feedback} field may be {@code null} when the
- * feedback has not yet been submitted (status other than {@link EFeedbackStatus#SUBMITTED}), in
- * order to hide the staff comment from the student until the review is finalised.
+ * Represents the details of a feedback. The {@code feedback} and {@code attachments} fields may be
+ * respectively {@code null} and empty when the feedback has not yet been submitted (status other
+ * than {@link EFeedbackStatus#SUBMITTED}), in order to hide the staff answer from the student until
+ * the review is finalised.
  */
 public record FeedbackData(
     UUID id,
@@ -23,4 +25,5 @@ public record FeedbackData(
     EFeedbackStatus status,
     int iteration,
     List<Trace> associatedTraces,
-    List<DeclaredSkillProgress> associatedDeclaredSkills) {}
+    List<DeclaredSkillProgress> associatedDeclaredSkills,
+    List<File> attachments) {}

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/model/Feedback.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/model/Feedback.java
@@ -1,10 +1,12 @@
 package fr.avenirsesr.portfolio.student.activity.domain.model;
 
 import fr.avenirsesr.portfolio.common.data.domain.model.AvenirsBaseModel;
+import fr.avenirsesr.portfolio.file.domain.model.File;
 import fr.avenirsesr.portfolio.student.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.skill.domain.model.DeclaredSkillProgress;
 import fr.avenirsesr.portfolio.student.trace.domain.model.Trace;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,6 +29,7 @@ public class Feedback extends AvenirsBaseModel {
   private int iteration;
   private List<Trace> associatedTraces;
   private List<DeclaredSkillProgress> associatedDeclaredSkills;
+  private List<File> attachments;
 
   private Feedback(
       UUID id,
@@ -38,7 +41,8 @@ public class Feedback extends AvenirsBaseModel {
       EFeedbackStatus status,
       int iteration,
       List<Trace> associatedTraces,
-      List<DeclaredSkillProgress> associatedDeclaredSkills) {
+      List<DeclaredSkillProgress> associatedDeclaredSkills,
+      List<File> attachments) {
     super(id, createdAt, updatedAt);
     this.reflexion = reflexion;
     this.feedback = feedback;
@@ -46,6 +50,7 @@ public class Feedback extends AvenirsBaseModel {
     this.iteration = iteration;
     this.associatedTraces = associatedTraces;
     this.associatedDeclaredSkills = associatedDeclaredSkills;
+    this.attachments = new ArrayList<>(attachments == null ? List.of() : attachments);
     this.declaredActivity = declaredActivity;
   }
 
@@ -65,7 +70,8 @@ public class Feedback extends AvenirsBaseModel {
         EFeedbackStatus.NEW,
         iteration,
         associatedTraces,
-        associatedDeclaredSkills);
+        associatedDeclaredSkills,
+        List.of());
   }
 
   public static Feedback toDomain(
@@ -78,7 +84,8 @@ public class Feedback extends AvenirsBaseModel {
       EFeedbackStatus status,
       int iteration,
       List<Trace> associatedTraces,
-      List<DeclaredSkillProgress> associatedDeclaredSkills) {
+      List<DeclaredSkillProgress> associatedDeclaredSkills,
+      List<File> attachments) {
     return new Feedback(
         id,
         createdAt,
@@ -89,7 +96,22 @@ public class Feedback extends AvenirsBaseModel {
         status,
         iteration,
         associatedTraces,
-        associatedDeclaredSkills);
+        associatedDeclaredSkills,
+        attachments);
+  }
+
+  public void addAttachment(File attachment) {
+    this.attachments.add(attachment);
+  }
+
+  public void removeAttachment(UUID attachmentId) {
+    this.attachments.removeIf(attachment -> attachment.getId().equals(attachmentId));
+  }
+
+  public Optional<File> findAttachment(UUID attachmentId) {
+    return this.attachments.stream()
+        .filter(attachment -> attachment.getId().equals(attachmentId))
+        .findFirst();
   }
 
   public Optional<String> getReflexion() {

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/port/input/FeedbackService.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/port/input/FeedbackService.java
@@ -4,6 +4,8 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageCriteria;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
+import fr.avenirsesr.portfolio.file.domain.model.File;
+import fr.avenirsesr.portfolio.file.domain.model.FileDownload;
 import fr.avenirsesr.portfolio.student.activity.domain.data.FeedbackDashboardData;
 import fr.avenirsesr.portfolio.student.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.activity.domain.model.Feedback;
@@ -29,6 +31,13 @@ public interface FeedbackService {
   List<Feedback> getFeedbackHistory(UUID declaredActivityId);
 
   void submitFeedback(UUID feedbackId);
+
+  File uploadAttachment(
+      UUID feedbackId, String fileName, String mimeType, long size, byte[] content);
+
+  void deleteAttachment(UUID feedbackId, UUID attachmentId);
+
+  FileDownload downloadAttachment(UUID feedbackId, UUID attachmentId);
 
   Set<UUID> findAttachmentIdsUsedByTraceSnapshots(
       List<UUID> declaredActivityIds, List<UUID> traceIds);

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/service/FeedbackServiceImpl.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/domain/service/FeedbackServiceImpl.java
@@ -10,6 +10,10 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.User;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
+import fr.avenirsesr.portfolio.file.domain.exception.FileNotFoundException;
+import fr.avenirsesr.portfolio.file.domain.model.File;
+import fr.avenirsesr.portfolio.file.domain.model.FileDownload;
+import fr.avenirsesr.portfolio.file.domain.port.input.FileResourceService;
 import fr.avenirsesr.portfolio.notification.domain.model.notification.AskForFeedbackNotification;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
@@ -51,6 +55,7 @@ public class FeedbackServiceImpl implements FeedbackService {
   private final LoggedInUserService loggedInUserService;
   private final NotificationService notificationService;
   private final ActivityService activityService;
+  private final FileResourceService fileResourceService;
 
   @Override
   public Feedback createFeedback(UUID declaredActivityId) {
@@ -149,7 +154,8 @@ public class FeedbackServiceImpl implements FeedbackService {
         feedback.getStatus(),
         feedback.getIteration(),
         feedback.getAssociatedTraces(),
-        feedback.getAssociatedDeclaredSkills());
+        feedback.getAssociatedDeclaredSkills(),
+        feedback.getAttachments());
   }
 
   @Override
@@ -158,10 +164,9 @@ public class FeedbackServiceImpl implements FeedbackService {
       throw new UserNotAuthorizedException();
     }
 
-    String feedbackText =
-        feedback.getStatus() == EFeedbackStatus.SUBMITTED
-            ? feedback.getFeedback().orElse(null)
-            : null;
+    boolean isSubmitted = feedback.getStatus() == EFeedbackStatus.SUBMITTED;
+    String feedbackText = isSubmitted ? feedback.getFeedback().orElse(null) : null;
+    List<File> attachments = isSubmitted ? feedback.getAttachments() : List.of();
     return new FeedbackData(
         feedback.getId(),
         feedback.getCreatedAt(),
@@ -172,7 +177,8 @@ public class FeedbackServiceImpl implements FeedbackService {
         feedback.getStatus(),
         feedback.getIteration(),
         feedback.getAssociatedTraces(),
-        feedback.getAssociatedDeclaredSkills());
+        feedback.getAssociatedDeclaredSkills(),
+        attachments);
   }
 
   @Override
@@ -225,6 +231,58 @@ public class FeedbackServiceImpl implements FeedbackService {
 
   @Override
   public void submitFeedback(UUID feedbackId) {
+    Feedback feedback = fetchFeedbackAndCheckLoggedInStaffIsAuthor(feedbackId);
+
+    requireNotNull("feedback", feedback.getFeedback().orElse(null));
+
+    feedback.setStatus(EFeedbackStatus.SUBMITTED);
+    feedbackRepository.save(feedback);
+  }
+
+  @Override
+  public File uploadAttachment(
+      UUID feedbackId, String fileName, String mimeType, long size, byte[] content) {
+    Feedback feedback = fetchFeedbackAndCheckLoggedInStaffIsAuthor(feedbackId);
+
+    File file = fileResourceService.upload(fileName, mimeType, size, content, true);
+    feedback.addAttachment(file);
+    feedbackRepository.save(feedback);
+
+    return file;
+  }
+
+  @Override
+  public void deleteAttachment(UUID feedbackId, UUID attachmentId) {
+    Feedback feedback = fetchFeedbackAndCheckLoggedInStaffIsAuthor(feedbackId);
+    feedback.findAttachment(attachmentId).orElseThrow(FileNotFoundException::new);
+
+    feedback.removeAttachment(attachmentId);
+    feedbackRepository.save(feedback);
+    fileResourceService.delete(attachmentId);
+  }
+
+  @Override
+  public FileDownload downloadAttachment(UUID feedbackId, UUID attachmentId) {
+    Feedback feedback =
+        feedbackRepository.findById(feedbackId).orElseThrow(FeedbackNotFoundException::new);
+    User loggedInUser = loggedInUserService.getLoggedInUser();
+
+    boolean isAuthor =
+        loggedInUser.equals(feedback.getDeclaredActivity().getActivity().getAuthor().getUser());
+    boolean isOwningStudent =
+        loggedInUser.equals(feedback.getDeclaredActivity().getStudent().getUser())
+            && feedback.getStatus() == EFeedbackStatus.SUBMITTED;
+
+    if (!isAuthor && !isOwningStudent) {
+      throw new UserNotAuthorizedException();
+    }
+
+    feedback.findAttachment(attachmentId).orElseThrow(FileNotFoundException::new);
+
+    return fileResourceService.download(attachmentId);
+  }
+
+  private Feedback fetchFeedbackAndCheckLoggedInStaffIsAuthor(UUID feedbackId) {
     Feedback feedback =
         feedbackRepository.findById(feedbackId).orElseThrow(FeedbackNotFoundException::new);
 
@@ -235,10 +293,7 @@ public class FeedbackServiceImpl implements FeedbackService {
       throw new UserNotAuthorizedException();
     }
 
-    requireNotNull("feedback", feedback.getFeedback().orElse(null));
-
-    feedback.setStatus(EFeedbackStatus.SUBMITTED);
-    feedbackRepository.save(feedback);
+    return feedback;
   }
 
   @Override

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/mapper/FeedbackMapper.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/mapper/FeedbackMapper.java
@@ -3,6 +3,7 @@ package fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.mapper;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.EntityGrapher;
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.mapper.Mapper;
 import fr.avenirsesr.portfolio.file.domain.model.File;
+import fr.avenirsesr.portfolio.file.infrastructure.adapter.mapper.FileMapper;
 import fr.avenirsesr.portfolio.student.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.model.AssociationsJson;
 import fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.model.FeedbackEntity;
@@ -27,7 +28,8 @@ public class FeedbackMapper implements Mapper<FeedbackEntity, Feedback> {
             feedback.getFeedback().orElse(null),
             feedback.getStatus(),
             feedback.getIteration(),
-            buildAssociations(feedback));
+            buildAssociations(feedback),
+            feedback.getAttachments().stream().map(FileMapper.INSTANCE::fromDomain).toList());
     entity.setId(feedback.getId());
     return entity;
   }
@@ -132,6 +134,7 @@ public class FeedbackMapper implements Mapper<FeedbackEntity, Feedback> {
         entity.getStatus(),
         entity.getIteration(),
         traces,
-        progresses);
+        progresses,
+        entity.getAttachments().stream().map(FileMapper.INSTANCE::toDomain).toList());
   }
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/model/FeedbackEntity.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/model/FeedbackEntity.java
@@ -3,9 +3,12 @@ package fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.model;
 import static fr.avenirsesr.portfolio.common.validation.domain.constraints.FieldMaxLengths.RICH_TEXT_LENGTH;
 
 import fr.avenirsesr.portfolio.common.data.infrastructure.adapter.model.AvenirsBaseEntity;
+import fr.avenirsesr.portfolio.file.infrastructure.adapter.model.FileEntity;
 import fr.avenirsesr.portfolio.student.activity.domain.model.enums.EFeedbackStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,4 +50,12 @@ public class FeedbackEntity extends AvenirsBaseEntity {
   @JdbcTypeCode(SqlTypes.JSON)
   @Column(nullable = false)
   private AssociationsJson associations;
+
+  @ManyToMany
+  @JoinTable(
+      name = "feedback_attachments",
+      joinColumns = @JoinColumn(name = "feedback_id"),
+      inverseJoinColumns = @JoinColumn(name = "file_id"))
+  @OrderBy("createdAt")
+  private List<FileEntity> attachments = new ArrayList<>();
 }

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/seeder/data/FakeFeedback.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/seeder/data/FakeFeedback.java
@@ -4,6 +4,7 @@ import fr.avenirsesr.portfolio.student.activity.domain.model.enums.EFeedbackStat
 import fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.model.AssociationsJson;
 import fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.model.DeclaredActivityEntity;
 import fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.model.FeedbackEntity;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import net.datafaker.Faker;
@@ -24,7 +25,8 @@ public class FakeFeedback {
             null,
             EFeedbackStatus.NEW,
             1,
-            new AssociationsJson(List.of(), List.of()));
+            new AssociationsJson(List.of(), List.of()),
+            new ArrayList<>());
     entity.setId(UUID.fromString(faker.internet().uuid()));
     return new FakeFeedback(entity);
   }

--- a/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/service/FeedbackServiceConfig.java
+++ b/src/main/java/fr/avenirsesr/portfolio/student/activity/infrastructure/adapter/service/FeedbackServiceConfig.java
@@ -1,5 +1,6 @@
 package fr.avenirsesr.portfolio.student.activity.infrastructure.adapter.service;
 
+import fr.avenirsesr.portfolio.file.domain.port.input.FileResourceService;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.staff.activity.domain.port.input.ActivityService;
@@ -28,6 +29,7 @@ public class FeedbackServiceConfig {
   private final LoggedInUserService loggedInUserService;
   private final NotificationService notificationService;
   private final ActivityService activityService;
+  private final FileResourceService fileResourceService;
 
   @Bean
   public FeedbackService feedbackService(
@@ -41,6 +43,7 @@ public class FeedbackServiceConfig {
         declaredSkillProgressService,
         loggedInUserService,
         notificationService,
-        activityService);
+        activityService,
+        fileResourceService);
   }
 }

--- a/src/main/resources/db/changelog/generated/changelog_2026-08-10__add-attachments-to-feedback.xml
+++ b/src/main/resources/db/changelog/generated/changelog_2026-08-10__add-attachments-to-feedback.xml
@@ -1,0 +1,51 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="iamgreendev" id="feedback-attachments-create-table">
+        <createTable tableName="feedback_attachments">
+            <column name="feedback_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="file_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <rollback>
+            <dropTable tableName="feedback_attachments"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="iamgreendev" id="feedback-attachments-add-fks">
+        <addForeignKeyConstraint
+                baseTableName="feedback_attachments"
+                baseColumnNames="feedback_id"
+                constraintName="FK_feedback_attachments_feedback"
+                referencedTableName="feedback"
+                referencedColumnNames="id"/>
+        <addForeignKeyConstraint
+                baseTableName="feedback_attachments"
+                baseColumnNames="file_id"
+                constraintName="FK_feedback_attachments_file"
+                referencedTableName="file"
+                referencedColumnNames="id"/>
+
+        <rollback>
+            <dropForeignKeyConstraint
+                    baseTableName="feedback_attachments"
+                    constraintName="FK_feedback_attachments_feedback"/>
+            <dropForeignKeyConstraint
+                    baseTableName="feedback_attachments"
+                    constraintName="FK_feedback_attachments_file"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/controller/FeedbackControllerIT.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/controller/FeedbackControllerIT.java
@@ -7,19 +7,27 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
 import fr.avenirsesr.portfolio.shared.infrastructure.ContainerConfigurationTest;
 import fr.avenirsesr.portfolio.shared.infrastructure.adapter.seeder.SeederRunner;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.BodyInserters;
 
 public class FeedbackControllerIT extends ContainerConfigurationTest {
 
   private static final String BASE_PATH = "/me/activity-progress/feedbacks";
   private static final String ACTIVITY_BASE_PATH = "/me/activity-progress";
   private static final String ACTIVITY_ID = "9a12e6b4-8c3f-4d22-bf55-6d4c1f2a7e33";
+  private static final String ATTACHMENT_FILE_NAME = "retour.pdf";
+  private static final String ATTACHMENT_CONTENT = "Contenu du retour du staff";
 
   @Autowired private WebTestClient webTestClient;
   @Autowired private ObjectMapper objectMapper;
@@ -978,5 +986,393 @@ public class FeedbackControllerIT extends ContainerConfigurationTest {
         .exchange()
         .expectStatus()
         .isForbidden();
+  }
+
+  // ── POST /{feedbackId}/attachments ──────────────────────────────────
+
+  private BodyInserters.MultipartInserter attachmentBody() {
+    var builder = new MultipartBodyBuilder();
+    builder
+        .part(
+            "file",
+            new ByteArrayResource(ATTACHMENT_CONTENT.getBytes(StandardCharsets.UTF_8)) {
+              @Override
+              public String getFilename() {
+                return ATTACHMENT_FILE_NAME;
+              }
+            })
+        .contentType(MediaType.APPLICATION_PDF);
+    return BodyInserters.fromMultipartData(builder.build());
+  }
+
+  private String uploadAttachmentAndGetId(String feedbackId) throws Exception {
+    String body =
+        webTestClient
+            .post()
+            .uri(attachmentsPath(feedbackId))
+            .header("X-Signed-Context", studentPayload)
+            .header("X-Context-Signature", studentSignature)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .body(attachmentBody())
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+    return objectMapper.readTree(body).get("id").asText();
+  }
+
+  private String attachmentsPath(String feedbackId) {
+    return BASE_PATH + "/" + feedbackId + "/attachments";
+  }
+
+  @Test
+  @Transactional
+  void shouldUploadAnAttachmentWhenTheStaffIsTheAuthorOfTheActivity() throws Exception {
+    BddLogger.given("a feedback assigned to the staff author of the activity");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+
+    BddLogger.when("the staff author uploads a file on the feedback");
+    BddLogger.then("201 CREATED is returned with the uploaded file description");
+
+    webTestClient
+        .post()
+        .uri(attachmentsPath(feedbackId))
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .body(attachmentBody())
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .jsonPath("$.id")
+        .isNotEmpty()
+        .jsonPath("$.fileName")
+        .isEqualTo(ATTACHMENT_FILE_NAME)
+        .jsonPath("$.fileType")
+        .isEqualTo("PDF")
+        .jsonPath("$.fileSize")
+        .isEqualTo(ATTACHMENT_CONTENT.getBytes(StandardCharsets.UTF_8).length)
+        .jsonPath("$.uploadedAt")
+        .isNotEmpty();
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn403WhenUploadingAnAttachmentAsAStaffWhoIsNotTheAuthor() throws Exception {
+    BddLogger.given("a feedback on an activity authored by another staff");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+
+    BddLogger.when("a staff who is not the author uploads a file on the feedback");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .post()
+        .uri(attachmentsPath(feedbackId))
+        .header("X-Signed-Context", staffPayload)
+        .header("X-Context-Signature", staffSignature)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .body(attachmentBody())
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  void shouldReturn404WhenUploadingAnAttachmentOnANonExistentFeedback() {
+    BddLogger.given("a non-existent feedback ID");
+    BddLogger.when("the staff uploads a file on it");
+    BddLogger.then("404 Not Found is returned");
+
+    webTestClient
+        .post()
+        .uri(attachmentsPath(notFoundId))
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .body(attachmentBody())
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .jsonPath("$.code")
+        .isEqualTo("FEEDBACK_NOT_FOUND");
+  }
+
+  @Test
+  void shouldReturn401WhenNotAuthenticatedOnUploadAttachment() {
+    BddLogger.given("the POST /me/activity-progress/feedbacks/{feedbackId}/attachments endpoint");
+    BddLogger.when("uploading a file without authentication headers");
+    BddLogger.then("401 Unauthorized is returned");
+
+    webTestClient
+        .post()
+        .uri(attachmentsPath(notFoundId))
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .body(attachmentBody())
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+  }
+
+  @Test
+  void shouldReturn403WhenUploadingAnAttachmentWithoutPermission() {
+    BddLogger.given(
+        "an authenticated user without the feedback:request:respond:assigned permission");
+    BddLogger.when("uploading a file on a feedback");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .post()
+        .uri(attachmentsPath(notFoundId))
+        .header("X-Signed-Context", noPermissionPayload)
+        .header("X-Context-Signature", noPermissionSignature)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .body(attachmentBody())
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  @Transactional
+  void shouldExposeTheUploadedAttachmentToTheStaffAuthorInTheFeedbackDetails() throws Exception {
+    BddLogger.given("a feedback with an attachment uploaded by the staff author");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    String attachmentId = uploadAttachmentAndGetId(feedbackId);
+
+    BddLogger.when("the staff author fetches the feedback details");
+    BddLogger.then("the attachment is listed in the details");
+
+    webTestClient
+        .get()
+        .uri(feedbackPath("STAFF", feedbackId))
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.attachments")
+        .isArray()
+        .jsonPath("$.attachments[?(@.id == '" + attachmentId + "')]")
+        .exists();
+
+    // Fetching the details as staff moved the feedback to IN_PROCESS: submit it so that the
+    // next test can ask for feedback again on the same declared activity.
+    updateFeedbackWithText(feedbackId, "Retour avec pièce jointe.");
+    submitFeedback(feedbackId);
+  }
+
+  @Test
+  @Transactional
+  void shouldHideTheAttachmentsFromTheStudentUntilTheFeedbackIsSubmitted() throws Exception {
+    BddLogger.given("a feedback with an attachment that has not been submitted yet");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    String attachmentId = uploadAttachmentAndGetId(feedbackId);
+
+    BddLogger.when("the student fetches the feedback details before submission");
+    BddLogger.then("no attachment is exposed");
+
+    webTestClient
+        .get()
+        .uri(feedbackPath("STUDENT", feedbackId))
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.attachments")
+        .isEmpty();
+
+    BddLogger.when("the staff author submits the feedback");
+    updateFeedbackWithText(feedbackId, "Retour avec pièce jointe.");
+    submitFeedback(feedbackId);
+
+    BddLogger.then("the attachment becomes visible to the student");
+
+    webTestClient
+        .get()
+        .uri(feedbackPath("STUDENT", feedbackId))
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.attachments[?(@.id == '" + attachmentId + "')]")
+        .exists();
+  }
+
+  // ── GET /{feedbackId}/attachments/{attachmentId}/download ───────────
+
+  @Test
+  @Transactional
+  void shouldDownloadTheAttachmentWhenTheStaffIsTheAuthorOfTheActivity() throws Exception {
+    BddLogger.given("a feedback with an attachment uploaded by the staff author");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    String attachmentId = uploadAttachmentAndGetId(feedbackId);
+
+    BddLogger.when("the staff author downloads the attachment");
+    BddLogger.then("200 OK is returned with the file content as an attachment");
+
+    webTestClient
+        .get()
+        .uri(attachmentsPath(feedbackId) + "/" + attachmentId + "/download")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .valueEquals(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"retour.pdf\"")
+        .expectBody(byte[].class)
+        .isEqualTo(ATTACHMENT_CONTENT.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn403WhenDownloadingTheAttachmentAsAnUnrelatedUser() throws Exception {
+    BddLogger.given("a feedback with an attachment belonging to another student");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    String attachmentId = uploadAttachmentAndGetId(feedbackId);
+
+    BddLogger.when("another student downloads the attachment");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .get()
+        .uri(attachmentsPath(feedbackId) + "/" + attachmentId + "/download")
+        .header("X-Signed-Context", otherStudentPayload)
+        .header("X-Context-Signature", otherStudentSignature)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn404WhenDownloadingAFileThatIsNotAnAttachmentOfTheFeedback() throws Exception {
+    BddLogger.given("a feedback and a file ID that is not one of its attachments");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+
+    BddLogger.when("the staff author downloads that file");
+    BddLogger.then("404 Not Found is returned with FILE_NOT_FOUND code");
+
+    webTestClient
+        .get()
+        .uri(attachmentsPath(feedbackId) + "/" + UUID.randomUUID() + "/download")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .jsonPath("$.code")
+        .isEqualTo("FILE_NOT_FOUND");
+  }
+
+  @Test
+  void shouldReturn401WhenNotAuthenticatedOnDownloadAttachment() {
+    BddLogger.given("the attachment download endpoint");
+    BddLogger.when("downloading without authentication headers");
+    BddLogger.then("401 Unauthorized is returned");
+
+    webTestClient
+        .get()
+        .uri(attachmentsPath(notFoundId) + "/" + notFoundId + "/download")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
+  }
+
+  // ── DELETE /{feedbackId}/attachments/{attachmentId} ─────────────────
+
+  @Test
+  @Transactional
+  void shouldDeleteTheAttachmentWhenTheStaffIsTheAuthorOfTheActivity() throws Exception {
+    BddLogger.given("a feedback with an attachment uploaded by the staff author");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    String attachmentId = uploadAttachmentAndGetId(feedbackId);
+
+    BddLogger.when("the staff author deletes the attachment");
+    BddLogger.then("204 No Content is returned and the attachment is no longer downloadable");
+
+    webTestClient
+        .delete()
+        .uri(attachmentsPath(feedbackId) + "/" + attachmentId)
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    webTestClient
+        .get()
+        .uri(attachmentsPath(feedbackId) + "/" + attachmentId + "/download")
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn404WhenDeletingAFileThatIsNotAnAttachmentOfTheFeedback() throws Exception {
+    BddLogger.given("a feedback and a file ID that is not one of its attachments");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+
+    BddLogger.when("the staff author deletes that file");
+    BddLogger.then("404 Not Found is returned with FILE_NOT_FOUND code");
+
+    webTestClient
+        .delete()
+        .uri(attachmentsPath(feedbackId) + "/" + UUID.randomUUID())
+        .header("X-Signed-Context", studentPayload)
+        .header("X-Context-Signature", studentSignature)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .jsonPath("$.code")
+        .isEqualTo("FILE_NOT_FOUND");
+  }
+
+  @Test
+  @Transactional
+  void shouldReturn403WhenDeletingAnAttachmentAsAStaffWhoIsNotTheAuthor() throws Exception {
+    BddLogger.given("a feedback with an attachment on an activity authored by another staff");
+    String feedbackId = askForFeedbackAndGetId(declaredActivityId);
+    String attachmentId = uploadAttachmentAndGetId(feedbackId);
+
+    BddLogger.when("a staff who is not the author deletes the attachment");
+    BddLogger.then("403 Forbidden is returned");
+
+    webTestClient
+        .delete()
+        .uri(attachmentsPath(feedbackId) + "/" + attachmentId)
+        .header("X-Signed-Context", staffPayload)
+        .header("X-Context-Signature", staffSignature)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  void shouldReturn401WhenNotAuthenticatedOnDeleteAttachment() {
+    BddLogger.given("the attachment deletion endpoint");
+    BddLogger.when("deleting without authentication headers");
+    BddLogger.then("401 Unauthorized is returned");
+
+    webTestClient
+        .delete()
+        .uri(attachmentsPath(notFoundId) + "/" + notFoundId)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized();
   }
 }

--- a/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/controller/FeedbackControllerTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/controller/FeedbackControllerTest.java
@@ -11,6 +11,11 @@ import fr.avenirsesr.portfolio.common.data.domain.model.PageInfo;
 import fr.avenirsesr.portfolio.common.data.domain.model.PagedResult;
 import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
+import fr.avenirsesr.portfolio.file.application.adapter.dto.FileDTO;
+import fr.avenirsesr.portfolio.file.application.adapter.mapper.FileDtoMapper;
+import fr.avenirsesr.portfolio.file.domain.model.File;
+import fr.avenirsesr.portfolio.file.domain.model.FileDownload;
+import fr.avenirsesr.portfolio.file.domain.model.enums.EFileType;
 import fr.avenirsesr.portfolio.staff.activity.application.adapter.dto.ActivityContentDTO;
 import fr.avenirsesr.portfolio.student.activity.application.adapter.dto.FeedbackDashboardDTO;
 import fr.avenirsesr.portfolio.student.activity.application.adapter.dto.FeedbackDetailsDTO;
@@ -27,6 +32,7 @@ import fr.avenirsesr.portfolio.student.activity.domain.data.FeedbackData;
 import fr.avenirsesr.portfolio.student.activity.domain.model.Feedback;
 import fr.avenirsesr.portfolio.student.activity.domain.model.enums.EFeedbackStatus;
 import fr.avenirsesr.portfolio.student.activity.domain.port.input.FeedbackService;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.time.Instant;
 import java.util.List;
@@ -38,8 +44,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class FeedbackControllerTest {
@@ -49,6 +58,7 @@ class FeedbackControllerTest {
   @Mock private FeedbackStaffListItemDTOMapper feedbackStaffListItemDTOMapper;
   @Mock private StudentFeedbackItemListDTOMapper studentFeedbackItemListDTOMapper;
   @Mock private FeedbackOverviewDTOMapper feedbackOverviewDTOMapper;
+  @Mock private FileDtoMapper fileDtoMapper;
 
   @InjectMocks private FeedbackController controller;
 
@@ -77,6 +87,7 @@ class FeedbackControllerTest {
               "Ma réflexion",
               null,
               EFeedbackStatus.NEW,
+              List.of(),
               List.of(),
               List.of(),
               Instant.now(),
@@ -138,6 +149,7 @@ class FeedbackControllerTest {
               null,
               null,
               EFeedbackStatus.NEW,
+              List.of(),
               List.of(),
               List.of(),
               Instant.now(),
@@ -572,6 +584,152 @@ class FeedbackControllerTest {
 
       BddLogger.then("The service is called exactly once with the correct declaredActivityId");
       verify(feedbackService, times(1)).getFeedbackHistory(declaredActivityId);
+      verifyNoMoreInteractions(feedbackService);
+    }
+  }
+
+  @Nested
+  class UploadAttachment {
+
+    private MockMultipartFile multipartFile() {
+      return new MockMultipartFile(
+          "file", "retour.pdf", "application/pdf", "content".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void should_return_201_with_the_mapped_file_dto() {
+      BddLogger.given("A feedback ID and a file uploaded by the staff author");
+
+      UUID feedbackId = UUID.randomUUID();
+      MockMultipartFile file = multipartFile();
+      File uploaded = mock(File.class);
+      FileDTO expectedDto =
+          new FileDTO(
+              UUID.randomUUID(), "retour.pdf", EFileType.PDF, file.getSize(), "url", Instant.now());
+
+      when(feedbackService.uploadAttachment(
+              eq(feedbackId),
+              eq("retour.pdf"),
+              eq("application/pdf"),
+              eq(file.getSize()),
+              any(byte[].class)))
+          .thenReturn(uploaded);
+      when(fileDtoMapper.fromDomain(uploaded)).thenReturn(expectedDto);
+
+      BddLogger.when("uploadAttachment is called");
+      ResponseEntity<FileDTO> response = controller.uploadAttachment(principal, feedbackId, file);
+
+      BddLogger.then("201 CREATED is returned with the mapped FileDTO");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+      assertThat(response.getBody()).isEqualTo(expectedDto);
+
+      verify(fileDtoMapper).fromDomain(uploaded);
+    }
+
+    @Test
+    void should_delegate_to_service_with_the_file_metadata() {
+      BddLogger.given("A feedback ID and an uploaded file");
+
+      UUID feedbackId = UUID.randomUUID();
+      MockMultipartFile file = multipartFile();
+
+      BddLogger.when("uploadAttachment is called");
+      controller.uploadAttachment(principal, feedbackId, file);
+
+      BddLogger.then("The service is called once with the file name, mime type, size and content");
+      verify(feedbackService, times(1))
+          .uploadAttachment(
+              feedbackId,
+              "retour.pdf",
+              "application/pdf",
+              file.getSize(),
+              "content".getBytes(StandardCharsets.UTF_8));
+      verifyNoMoreInteractions(feedbackService);
+    }
+  }
+
+  @Nested
+  class DeleteAttachment {
+
+    @Test
+    void should_return_204_no_content() {
+      BddLogger.given("A feedback ID and one of its attachment IDs");
+
+      UUID feedbackId = UUID.randomUUID();
+      UUID attachmentId = UUID.randomUUID();
+      doNothing().when(feedbackService).deleteAttachment(feedbackId, attachmentId);
+
+      BddLogger.when("deleteAttachment is called");
+      ResponseEntity<Void> response =
+          controller.deleteAttachment(principal, feedbackId, attachmentId);
+
+      BddLogger.then("204 No Content is returned with no body");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+      assertThat(response.getBody()).isNull();
+
+      verify(feedbackService).deleteAttachment(feedbackId, attachmentId);
+    }
+
+    @Test
+    void should_delegate_to_service_with_correct_feedback_and_attachment_ids() {
+      BddLogger.given("A feedback ID and an attachment ID");
+
+      UUID feedbackId = UUID.randomUUID();
+      UUID attachmentId = UUID.randomUUID();
+
+      BddLogger.when("deleteAttachment is called");
+      controller.deleteAttachment(principal, feedbackId, attachmentId);
+
+      BddLogger.then("The service is called exactly once with both IDs");
+      verify(feedbackService, times(1)).deleteAttachment(feedbackId, attachmentId);
+      verifyNoMoreInteractions(feedbackService);
+    }
+  }
+
+  @Nested
+  class DownloadAttachment {
+
+    @Test
+    void should_return_200_with_the_file_content_and_content_disposition_header() {
+      BddLogger.given("A feedback ID and one of its attachment IDs");
+
+      UUID feedbackId = UUID.randomUUID();
+      UUID attachmentId = UUID.randomUUID();
+      byte[] content = "content".getBytes(StandardCharsets.UTF_8);
+
+      when(feedbackService.downloadAttachment(feedbackId, attachmentId))
+          .thenReturn(new FileDownload("retour.pdf", content));
+
+      BddLogger.when("downloadAttachment is called");
+      ResponseEntity<byte[]> response =
+          controller.downloadAttachment(principal, feedbackId, attachmentId);
+
+      BddLogger.then("200 OK is returned with the file content as an octet stream");
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).isEqualTo(content);
+      assertThat(response.getHeaders().getContentType())
+          .isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+      assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION))
+          .isEqualTo("attachment; filename=\"retour.pdf\"");
+
+      verify(feedbackService).downloadAttachment(feedbackId, attachmentId);
+    }
+
+    @Test
+    void should_delegate_to_service_with_correct_feedback_and_attachment_ids() {
+      BddLogger.given("A feedback ID and an attachment ID");
+
+      UUID feedbackId = UUID.randomUUID();
+      UUID attachmentId = UUID.randomUUID();
+
+      when(feedbackService.downloadAttachment(feedbackId, attachmentId))
+          .thenReturn(new FileDownload("retour.pdf", new byte[0]));
+
+      BddLogger.when("downloadAttachment is called");
+      controller.downloadAttachment(principal, feedbackId, attachmentId);
+
+      BddLogger.then("The service is called exactly once with both IDs");
+      verify(feedbackService, times(1)).downloadAttachment(feedbackId, attachmentId);
       verifyNoMoreInteractions(feedbackService);
     }
   }

--- a/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/mapper/DeclaredActivityPresentationDTOMapperTest.java
@@ -101,6 +101,7 @@ class DeclaredActivityPresentationDTOMapperTest {
             EFeedbackStatus.NEW,
             1,
             List.of(),
+            List.of(),
             List.of());
 
     FeedbackData feedbackData2 =
@@ -113,6 +114,7 @@ class DeclaredActivityPresentationDTOMapperTest {
             "Mon retour",
             EFeedbackStatus.SUBMITTED,
             2,
+            List.of(),
             List.of(),
             List.of());
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/mapper/FeedbackOverviewDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/mapper/FeedbackOverviewDTOMapperTest.java
@@ -42,6 +42,7 @@ class FeedbackOverviewDTOMapperTest {
             EFeedbackStatus.NEW,
             1,
             List.of(),
+            List.of(),
             List.of());
 
     BddLogger.when("mapping to FeedbackOverviewDTO");
@@ -87,6 +88,7 @@ class FeedbackOverviewDTOMapperTest {
             EFeedbackStatus.SUBMITTED,
             1,
             List.of(),
+            List.of(),
             List.of());
 
     BddLogger.when("mapping to FeedbackOverviewDTO");
@@ -121,6 +123,7 @@ class FeedbackOverviewDTOMapperTest {
             null,
             EFeedbackStatus.NEW,
             1,
+            List.of(),
             List.of(),
             List.of());
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/mapper/StudentFeedbackItemListDTOMapperTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/activity/application/adapter/mapper/StudentFeedbackItemListDTOMapperTest.java
@@ -37,6 +37,7 @@ class StudentFeedbackItemListDTOMapperTest {
         EFeedbackStatus.NEW,
         1,
         List.of(),
+        List.of(),
         List.of());
   }
 

--- a/src/test/java/fr/avenirsesr/portfolio/student/activity/domain/service/FeedbackServiceImplTest.java
+++ b/src/test/java/fr/avenirsesr/portfolio/student/activity/domain/service/FeedbackServiceImplTest.java
@@ -12,6 +12,11 @@ import fr.avenirsesr.portfolio.common.data.domain.model.enums.EUserCategory;
 import fr.avenirsesr.portfolio.common.error.domain.exception.FieldValidationException;
 import fr.avenirsesr.portfolio.common.security.domain.exception.UserNotAuthorizedException;
 import fr.avenirsesr.portfolio.common.testutils.BddLogger;
+import fr.avenirsesr.portfolio.file.domain.exception.FileNotFoundException;
+import fr.avenirsesr.portfolio.file.domain.model.File;
+import fr.avenirsesr.portfolio.file.domain.model.FileDownload;
+import fr.avenirsesr.portfolio.file.domain.model.enums.EFileType;
+import fr.avenirsesr.portfolio.file.domain.port.input.FileResourceService;
 import fr.avenirsesr.portfolio.notification.domain.port.input.NotificationService;
 import fr.avenirsesr.portfolio.shared.domain.port.input.LoggedInUserService;
 import fr.avenirsesr.portfolio.staff.activity.domain.model.Activity;
@@ -41,6 +46,7 @@ import fr.avenirsesr.portfolio.user.domain.model.Student;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StaffFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.StudentFixture;
 import fr.avenirsesr.portfolio.user.infrastructure.fixture.UserFixture;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +59,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -69,10 +76,15 @@ class FeedbackServiceImplTest {
   @Mock private DeclaredSkillProgressService declaredSkillProgressService;
   @Mock private LoggedInUserService loggedInUserService;
   @Mock private NotificationService notificationService;
+  @Mock private FileResourceService fileResourceService;
 
   @InjectMocks private FeedbackServiceImpl service;
 
   @Captor private ArgumentCaptor<Feedback> feedbackCaptor;
+
+  private static final String FILE_NAME = "retour.pdf";
+  private static final String MIME_TYPE = "application/pdf";
+  private static final byte[] CONTENT = "content".getBytes(StandardCharsets.UTF_8);
 
   private Student student;
 
@@ -253,6 +265,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.IN_PROCESS,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
@@ -292,6 +305,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.SUBMITTED,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       Feedback inProcessFeedback =
@@ -304,6 +318,7 @@ class FeedbackServiceImplTest {
               null,
               EFeedbackStatus.IN_PROCESS,
               2,
+              List.of(),
               List.of(),
               List.of());
 
@@ -348,6 +363,7 @@ class FeedbackServiceImplTest {
               null,
               EFeedbackStatus.NEW,
               1,
+              List.of(),
               List.of(),
               List.of());
 
@@ -412,6 +428,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.SUBMITTED,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(declaredActivityService.fetchActivityAndCheckLoggedInStudentAuthorization(
@@ -459,6 +476,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.SUBMITTED,
               1,
               List.of(),
+              List.of(),
               List.of());
       Feedback feedback2 =
           Feedback.toDomain(
@@ -470,6 +488,7 @@ class FeedbackServiceImplTest {
               "Retour 2",
               EFeedbackStatus.SUBMITTED,
               1,
+              List.of(),
               List.of(),
               List.of());
 
@@ -510,6 +529,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.SUBMITTED,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
@@ -541,6 +561,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.NEW,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
@@ -552,6 +573,63 @@ class FeedbackServiceImplTest {
       BddLogger.then("FeedbackData is returned with feedback set to null (not yet submitted)");
       assertThat(result.feedback()).isNull();
       assertThat(result.status()).isEqualTo(EFeedbackStatus.NEW);
+    }
+
+    @Test
+    void should_hide_the_attachments_from_the_student_when_feedback_is_not_SUBMITTED() {
+      BddLogger.given("A student requesting their own IN_PROCESS feedback holding an attachment");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of(attachment()));
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
+
+      BddLogger.when("getFeedbackDetails is called with STUDENT category");
+      FeedbackData result = service.getFeedbackDetails(feedbackId, EUserCategory.STUDENT);
+
+      BddLogger.then("FeedbackData is returned without any attachment");
+      assertThat(result.attachments()).isEmpty();
+    }
+
+    @Test
+    void should_expose_the_attachments_to_the_student_when_feedback_is_SUBMITTED() {
+      BddLogger.given("A student requesting their own SUBMITTED feedback holding an attachment");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      File existingAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.SUBMITTED, List.of(existingAttachment));
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
+
+      BddLogger.when("getFeedbackDetails is called with STUDENT category");
+      FeedbackData result = service.getFeedbackDetails(feedbackId, EUserCategory.STUDENT);
+
+      BddLogger.then("FeedbackData is returned with the attachment");
+      assertThat(result.attachments()).containsExactly(existingAttachment);
+    }
+
+    @Test
+    void should_expose_the_attachments_to_the_staff_author_whatever_the_status() {
+      BddLogger.given("A staff author requesting an IN_PROCESS feedback holding an attachment");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      File existingAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of(existingAttachment));
+      User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+
+      BddLogger.when("getFeedbackDetails is called with STAFF category");
+      FeedbackData result = service.getFeedbackDetails(feedbackId, EUserCategory.STAFF);
+
+      BddLogger.then("FeedbackData is returned with the attachment");
+      assertThat(result.attachments()).containsExactly(existingAttachment);
     }
 
     @Test
@@ -571,6 +649,7 @@ class FeedbackServiceImplTest {
               null,
               EFeedbackStatus.NEW,
               1,
+              List.of(),
               List.of(),
               List.of());
 
@@ -602,6 +681,7 @@ class FeedbackServiceImplTest {
               feedbackText,
               EFeedbackStatus.IN_PROCESS,
               1,
+              List.of(),
               List.of(),
               List.of());
 
@@ -635,6 +715,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.NEW,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
@@ -666,6 +747,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.IN_PROCESS,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
@@ -695,6 +777,7 @@ class FeedbackServiceImplTest {
               null,
               EFeedbackStatus.IN_PROCESS,
               1,
+              List.of(),
               List.of(),
               List.of());
 
@@ -743,6 +826,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.IN_PROCESS,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       BddLogger.when("getStudentFeedbackDetails is called with the student's own user");
@@ -771,6 +855,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.SUBMITTED,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       BddLogger.when("getStudentFeedbackDetails is called with the student's own user");
@@ -796,6 +881,7 @@ class FeedbackServiceImplTest {
               null,
               EFeedbackStatus.NEW,
               1,
+              List.of(),
               List.of(),
               List.of());
       User differentUser = UserFixture.create().toModel();
@@ -829,6 +915,7 @@ class FeedbackServiceImplTest {
               null,
               EFeedbackStatus.IN_PROCESS,
               1,
+              List.of(),
               List.of(),
               List.of());
       String feedbackText = "Excellent travail, bravo !";
@@ -882,6 +969,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.IN_PROCESS,
               1,
               List.of(),
+              List.of(),
               List.of());
       User differentUser = UserFixture.create().toModel();
 
@@ -915,6 +1003,7 @@ class FeedbackServiceImplTest {
               null,
               EFeedbackStatus.IN_PROCESS,
               1,
+              List.of(),
               List.of(),
               List.of());
       String tooLongFeedback = "a".repeat(RICH_DESCRIPTION_LENGTH + 1);
@@ -956,6 +1045,7 @@ class FeedbackServiceImplTest {
               "Bon travail !",
               EFeedbackStatus.IN_PROCESS,
               1,
+              List.of(),
               List.of(),
               List.of());
 
@@ -1008,6 +1098,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.IN_PROCESS,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
@@ -1042,6 +1133,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.IN_PROCESS,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
@@ -1075,6 +1167,7 @@ class FeedbackServiceImplTest {
               null,
               EFeedbackStatus.NEW,
               1,
+              List.of(),
               List.of(),
               List.of());
 
@@ -1308,6 +1401,7 @@ class FeedbackServiceImplTest {
               EFeedbackStatus.SUBMITTED,
               1,
               List.of(),
+              List.of(),
               List.of());
 
       when(loggedInUserService.getLoggedInStaff()).thenReturn(staff);
@@ -1498,5 +1592,377 @@ class FeedbackServiceImplTest {
       verify(feedbackRepository)
           .findAttachmentIdsUsedByTraceSnapshots(declaredActivityIds, traceIds);
     }
+  }
+
+  @Nested
+  class UploadAttachment {
+
+    @Test
+    void should_upload_the_file_and_attach_it_to_the_feedback_when_staff_is_the_author() {
+      BddLogger.given("A logged-in staff who is the author of the activity and a valid feedback");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff author = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      Feedback feedback = feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of());
+      File uploaded = attachment();
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(author);
+      when(fileResourceService.upload(FILE_NAME, MIME_TYPE, CONTENT.length, CONTENT, true))
+          .thenReturn(uploaded);
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+
+      BddLogger.when("uploadAttachment is called");
+      File result =
+          service.uploadAttachment(feedbackId, FILE_NAME, MIME_TYPE, CONTENT.length, CONTENT);
+
+      BddLogger.then("The file is uploaded as restricted and saved as an attachment");
+      assertThat(result).isEqualTo(uploaded);
+      verify(fileResourceService).upload(FILE_NAME, MIME_TYPE, CONTENT.length, CONTENT, true);
+      verify(feedbackRepository).save(feedbackCaptor.capture());
+      assertThat(feedbackCaptor.getValue().getAttachments()).containsExactly(uploaded);
+    }
+
+    @Test
+    void should_keep_the_previously_uploaded_attachments() {
+      BddLogger.given("A feedback that already has an attachment");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff author = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      File existingAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of(existingAttachment));
+      File uploaded = attachment();
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(author);
+      when(fileResourceService.upload(FILE_NAME, MIME_TYPE, CONTENT.length, CONTENT, true))
+          .thenReturn(uploaded);
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+
+      BddLogger.when("uploadAttachment is called");
+      service.uploadAttachment(feedbackId, FILE_NAME, MIME_TYPE, CONTENT.length, CONTENT);
+
+      BddLogger.then("The feedback holds both the existing and the new attachment");
+      verify(feedbackRepository).save(feedbackCaptor.capture());
+      assertThat(feedbackCaptor.getValue().getAttachments())
+          .containsExactly(existingAttachment, uploaded);
+    }
+
+    @Test
+    void should_throw_FeedbackNotFoundException_when_feedback_does_not_exist() {
+      BddLogger.given("A non-existent feedback ID");
+      UUID feedbackId = UUID.randomUUID();
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.empty());
+
+      BddLogger.when("uploadAttachment is called");
+
+      BddLogger.then("A FeedbackNotFoundException is thrown and nothing is uploaded");
+      assertThatThrownBy(
+              () ->
+                  service.uploadAttachment(
+                      feedbackId, FILE_NAME, MIME_TYPE, CONTENT.length, CONTENT))
+          .isInstanceOf(FeedbackNotFoundException.class);
+
+      verifyNoInteractions(fileResourceService);
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_staff_is_not_the_author() {
+      BddLogger.given("A logged-in staff who is NOT the author of the activity");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff otherStaff = StaffFixture.create().toModel();
+      Feedback feedback = feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(otherStaff);
+
+      BddLogger.when("uploadAttachment is called");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown and nothing is uploaded");
+      assertThatThrownBy(
+              () ->
+                  service.uploadAttachment(
+                      feedbackId, FILE_NAME, MIME_TYPE, CONTENT.length, CONTENT))
+          .isInstanceOf(UserNotAuthorizedException.class);
+
+      verifyNoInteractions(fileResourceService);
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_UserIsNotStaffException_when_logged_in_user_is_not_staff() {
+      BddLogger.given("A logged-in user who is not registered as staff");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Feedback feedback = feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of());
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenThrow(new UserIsNotStaffException());
+
+      BddLogger.when("uploadAttachment is called");
+
+      BddLogger.then("A UserIsNotStaffException is thrown and nothing is uploaded");
+      assertThatThrownBy(
+              () ->
+                  service.uploadAttachment(
+                      feedbackId, FILE_NAME, MIME_TYPE, CONTENT.length, CONTENT))
+          .isInstanceOf(UserIsNotStaffException.class);
+
+      verifyNoInteractions(fileResourceService);
+      verify(feedbackRepository, never()).save(any());
+    }
+  }
+
+  @Nested
+  class DeleteAttachment {
+
+    @Test
+    void should_unlink_the_attachment_before_deleting_the_file_when_staff_is_the_author() {
+      BddLogger.given("A logged-in staff author and a feedback holding two attachments");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff author = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      File attachmentToDelete = attachment();
+      File otherAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(
+              feedbackId,
+              activity,
+              EFeedbackStatus.IN_PROCESS,
+              List.of(attachmentToDelete, otherAttachment));
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(author);
+      when(feedbackRepository.save(any(Feedback.class))).thenAnswer(i -> i.getArguments()[0]);
+
+      BddLogger.when("deleteAttachment is called");
+      service.deleteAttachment(feedbackId, attachmentToDelete.getId());
+
+      BddLogger.then("The feedback is saved without the attachment, then the file is deleted");
+      InOrder inOrder = inOrder(feedbackRepository, fileResourceService);
+      inOrder.verify(feedbackRepository).save(feedbackCaptor.capture());
+      inOrder.verify(fileResourceService).delete(attachmentToDelete.getId());
+      assertThat(feedbackCaptor.getValue().getAttachments()).containsExactly(otherAttachment);
+    }
+
+    @Test
+    void should_throw_FileNotFoundException_when_the_attachment_is_not_linked_to_the_feedback() {
+      BddLogger.given("A logged-in staff author and a file that is not an attachment");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff author = StaffFixture.create().withId(activity.getAuthor().getId()).toModel();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of(attachment()));
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(author);
+
+      BddLogger.when("deleteAttachment is called with an unknown attachment ID");
+
+      BddLogger.then("A FileNotFoundException is thrown and nothing is deleted");
+      assertThatThrownBy(() -> service.deleteAttachment(feedbackId, UUID.randomUUID()))
+          .isInstanceOf(FileNotFoundException.class);
+
+      verifyNoInteractions(fileResourceService);
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_staff_is_not_the_author() {
+      BddLogger.given("A logged-in staff who is NOT the author of the activity");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      Staff otherStaff = StaffFixture.create().toModel();
+      File existingAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of(existingAttachment));
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInStaff()).thenReturn(otherStaff);
+
+      BddLogger.when("deleteAttachment is called");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown and nothing is deleted");
+      assertThatThrownBy(() -> service.deleteAttachment(feedbackId, existingAttachment.getId()))
+          .isInstanceOf(UserNotAuthorizedException.class);
+
+      verifyNoInteractions(fileResourceService);
+      verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_FeedbackNotFoundException_when_feedback_does_not_exist() {
+      BddLogger.given("A non-existent feedback ID");
+      UUID feedbackId = UUID.randomUUID();
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.empty());
+
+      BddLogger.when("deleteAttachment is called");
+
+      BddLogger.then("A FeedbackNotFoundException is thrown and nothing is deleted");
+      assertThatThrownBy(() -> service.deleteAttachment(feedbackId, UUID.randomUUID()))
+          .isInstanceOf(FeedbackNotFoundException.class);
+
+      verifyNoInteractions(fileResourceService);
+      verify(feedbackRepository, never()).save(any());
+    }
+  }
+
+  @Nested
+  class DownloadAttachment {
+
+    @Test
+    void should_return_the_file_download_when_the_user_is_the_staff_author() {
+      BddLogger.given("A logged-in staff author and a feedback holding an attachment");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
+      File existingAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of(existingAttachment));
+      FileDownload expected = new FileDownload(FILE_NAME, CONTENT);
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+      when(fileResourceService.download(existingAttachment.getId())).thenReturn(expected);
+
+      BddLogger.when("downloadAttachment is called");
+      FileDownload result = service.downloadAttachment(feedbackId, existingAttachment.getId());
+
+      BddLogger.then("The file download is returned even though the feedback is not submitted");
+      assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void should_return_the_file_download_when_the_owning_student_and_feedback_is_SUBMITTED() {
+      BddLogger.given("A logged-in student owning a SUBMITTED feedback holding an attachment");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      File existingAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.SUBMITTED, List.of(existingAttachment));
+      FileDownload expected = new FileDownload(FILE_NAME, CONTENT);
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
+      when(fileResourceService.download(existingAttachment.getId())).thenReturn(expected);
+
+      BddLogger.when("downloadAttachment is called");
+      FileDownload result = service.downloadAttachment(feedbackId, existingAttachment.getId());
+
+      BddLogger.then("The file download is returned");
+      assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void
+        should_throw_UserNotAuthorizedException_when_the_owning_student_and_feedback_is_not_SUBMITTED() {
+      BddLogger.given("A logged-in student owning a feedback that is not submitted yet");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      File existingAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of(existingAttachment));
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(student.getUser());
+
+      BddLogger.when("downloadAttachment is called");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown and nothing is downloaded");
+      assertThatThrownBy(() -> service.downloadAttachment(feedbackId, existingAttachment.getId()))
+          .isInstanceOf(UserNotAuthorizedException.class);
+
+      verifyNoInteractions(fileResourceService);
+    }
+
+    @Test
+    void should_throw_UserNotAuthorizedException_when_user_is_neither_author_nor_owning_student() {
+      BddLogger.given("A logged-in user unrelated to the feedback");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      File existingAttachment = attachment();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.SUBMITTED, List.of(existingAttachment));
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(UserFixture.create().toModel());
+
+      BddLogger.when("downloadAttachment is called");
+
+      BddLogger.then("A UserNotAuthorizedException is thrown and nothing is downloaded");
+      assertThatThrownBy(() -> service.downloadAttachment(feedbackId, existingAttachment.getId()))
+          .isInstanceOf(UserNotAuthorizedException.class);
+
+      verifyNoInteractions(fileResourceService);
+    }
+
+    @Test
+    void should_throw_FileNotFoundException_when_the_attachment_is_not_linked_to_the_feedback() {
+      BddLogger.given("A logged-in staff author and a file that is not an attachment");
+      UUID feedbackId = UUID.randomUUID();
+      Activity activity = ActivityFixture.create().toModel();
+      User authorUser = UserFixture.create().withId(activity.getAuthor().getId()).toModel();
+      Feedback feedback =
+          feedbackOf(feedbackId, activity, EFeedbackStatus.IN_PROCESS, List.of(attachment()));
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.of(feedback));
+      when(loggedInUserService.getLoggedInUser()).thenReturn(authorUser);
+
+      BddLogger.when("downloadAttachment is called with an unknown attachment ID");
+
+      BddLogger.then("A FileNotFoundException is thrown and nothing is downloaded");
+      assertThatThrownBy(() -> service.downloadAttachment(feedbackId, UUID.randomUUID()))
+          .isInstanceOf(FileNotFoundException.class);
+
+      verifyNoInteractions(fileResourceService);
+    }
+
+    @Test
+    void should_throw_FeedbackNotFoundException_when_feedback_does_not_exist() {
+      BddLogger.given("A non-existent feedback ID");
+      UUID feedbackId = UUID.randomUUID();
+
+      when(feedbackRepository.findById(feedbackId)).thenReturn(Optional.empty());
+
+      BddLogger.when("downloadAttachment is called");
+
+      BddLogger.then("A FeedbackNotFoundException is thrown and nothing is downloaded");
+      assertThatThrownBy(() -> service.downloadAttachment(feedbackId, UUID.randomUUID()))
+          .isInstanceOf(FeedbackNotFoundException.class);
+
+      verifyNoInteractions(fileResourceService);
+    }
+  }
+
+  private Feedback feedbackOf(
+      UUID feedbackId, Activity activity, EFeedbackStatus status, List<File> attachments) {
+    return Feedback.toDomain(
+        feedbackId,
+        Instant.now(),
+        Instant.now(),
+        DeclaredActivity.create(UUID.randomUUID(), student, activity, null, null, null, null, null),
+        "Ma réflexion",
+        "Mon retour",
+        status,
+        1,
+        List.of(),
+        List.of(),
+        attachments);
+  }
+
+  private File attachment() {
+    return File.create(
+        UUID.randomUUID(),
+        EFileType.PDF,
+        FILE_NAME,
+        CONTENT.length,
+        "uri/" + FILE_NAME,
+        UserFixture.create().toModel(),
+        true);
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Ajoute une liste de pièces jointes (`attachments`) sur le feedback, avec les endpoints permettant de les gérer.
>
> - `Feedback` (domaine) porte désormais une `List<File> attachments`, persistée via une table de jointure `feedback_attachments` (`@ManyToMany` vers `FileEntity`), sur le même modèle que `activity_files` / `activity_draft_files`.
> - Nouveaux endpoints sur `/me/activity-progress/feedbacks` :
>   - `POST /{feedbackId}/attachments` (multipart `file`) → `201` + `FileDTO` — droit `feedback:request:respond:assigned`
>   - `DELETE /{feedbackId}/attachments/{attachmentId}` → `204` — droit `feedback:request:respond:assigned`
>   - `GET /{feedbackId}/attachments/{attachmentId}/download` → `200` octet-stream — droit `feedback:received:read:own` ou `feedback:request:read:assigned`
> - Côté service : `uploadAttachment`, `deleteAttachment` et `downloadAttachment` sur `FeedbackService` / `FeedbackServiceImpl`.
> - **Seul le staff auteur de l'activité** peut uploader ou supprimer une pièce jointe (contrôle factorisé dans `fetchFeedbackAndCheckLoggedInStaffIsAuthor`, également réutilisé par `submitFeedback`).
> - `FeedbackDetailsDTO` expose `attachments: FileDTO[]`.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2274

---

### Documentation
> Nouveau changelog Liquibase `changelog_2026-08-10__add-attachments-to-feedback.xml` : création de la table `feedback_attachments` (`feedback_id`, `file_id`) et des deux contraintes de clé étrangère vers `feedback` et `file`, avec rollback. Aucune nouvelle propriété de configuration, aucun nouveau droit à déclarer (les droits existants `feedback:request:respond:assigned`, `feedback:received:read:own` et `feedback:request:read:assigned` sont réutilisés).

---

### Target Branch
> `develop`

---

### Additional Notes
> - Les fichiers sont uploadés en `isRestricted = true` via `FileResourceService`, comme les attachments de trace et les fichiers d'activité : ils ne sont donc pas accessibles via `/storage/{fileId}`, d'où l'endpoint de téléchargement dédié qui rejoue le contrôle d'accès métier.
> - Visibilité côté étudiant : les pièces jointes ne sont exposées (détail du feedback et téléchargement) qu'une fois le feedback `SUBMITTED`, exactement comme le texte du feedback qui est déjà masqué avant soumission.
> - Suppression : la pièce jointe est détachée du feedback et sauvegardée **avant** la suppression du fichier, pour ne jamais supprimer une ligne `file` encore référencée par la table de jointure.
> - `Feedback.toDomain` prend un paramètre supplémentaire — les appels existants (mappers et tests) ont été mis à jour.

---

### Known Limitations or Side Effects
> - Aucune restriction de type MIME spécifique n'est appliquée au-delà des types déjà supportés par `EFileType` (choix aligné sur les attachments de trace ; les fichiers de brouillon d'activité, eux, sont restreints à une liste blanche).
> - Aucun plafond sur le nombre de pièces jointes par feedback ; seule la limite de taille par type de fichier de `EFileType` s'applique.
> - Les pièces jointes ne sont pas reprises dans `FeedbackOverviewDTO` ni dans `StudentFeedbackItemListDTO` : elles ne sont disponibles que sur le détail du feedback.

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [x] a11y tested (if the PR includes frontend changes) — N/A, backend uniquement
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [x] i18n handled (texts are translated) — N/A, aucun texte utilisateur ajouté
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [x] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process
